### PR TITLE
Add grid pace function

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ netcdf4
 numpy
 rioxarray
 s3fs
+scipy
 xarray


### PR DESCRIPTION
This PR adds the `grid_pace` function for interpolating non-rectangular PACE data into a gridded dataset.

```python
import hypercoast
filepath = 'data/PACE_OCI.20240423T184658.L2.OC_AOP.V1_0_0.NRT.nc'
dataset = hypercoast.read_pace(filepath)

m = hypercoast.Map()
m.add_basemap("Hybrid")
m.add_pace(filepath, wavelengths=500)
m.add_colormap(cmap="jet", vmin=0, vmax=0.02, label="Reflectance")
m
```
![image](https://github.com/opengeos/HyperCoast/assets/5016453/e3627f02-ee1d-44a6-bf08-fc6c09f8ac58)
