### PR TITLE
Add support for multi-band visualization

### DIFF
--- a/docs/examples/pace.ipynb
+++ b/docs/examples/pace.ipynb
@@ -131,6 +131,63 @@
     "longitude = (-92, -91.055)\n",
     "hypercoast.filter_pace(dataset, latitude, longitude, return_plot=True)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Single-band visualization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m.add_basemap(\"Hybrid\")\n",
+    "wavelengths = [450]\n",
+    "m.add_pace(dataset, wavelengths, colormap=\"jet\", vmin=0, vmax=0.02, layer_name=\"PACE\")\n",
+    "m.add_colormap(cmap=\"jet\", vmin=0, vmax=0.02, label=\"Reflectance\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/2rBzam8.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Multiple-band visualization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m.add_basemap(\"Hybrid\")\n",
+    "wavelengths = [450, 550, 650]\n",
+    "m.add_pace(\n",
+    "    dataset, wavelengths, indexes=[3, 2, 1], vmin=0, vmax=0.02, layer_name=\"PACE\"\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/40gX4og.png)"
+   ]
   }
  ],
  "metadata": {

--- a/hypercoast/emit.py
+++ b/hypercoast/emit.py
@@ -226,15 +226,15 @@ def emit_to_netcdf(data, output, **kwargs):
     ds_geo.to_netcdf(output, **kwargs)
 
 
-def emit_to_image(data, output=None, wavelengths=None, method="nearest", **kwargs):
+def emit_to_image(data, wavelengths=None, method="nearest", output=None, **kwargs):
     """
     Converts an EMIT dataset to an image.
 
     Args:
         data (xarray.Dataset or str): The dataset containing the EMIT data or the file path to the dataset.
-        output (str, optional): The file path where the image will be saved. If None, the image will be returned as a PIL Image object. Defaults to None.
         wavelengths (array-like, optional): The specific wavelengths to select. If None, all wavelengths are selected. Defaults to None.
         method (str, optional): The method to use for data selection. Defaults to "nearest".
+        output (str, optional): The file path where the image will be saved. If None, the image will be returned as a PIL Image object. Defaults to None.
         **kwargs: Additional keyword arguments to be passed to `leafmap.array_to_image`.
 
     Returns:

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -192,14 +192,15 @@ class Map(leafmap.Map):
         wavelengths=None,
         indexes=None,
         colormap="jet",
-        vmin=0,
-        vmax=0.02,
+        vmin=None,
+        vmax=None,
         nodata=np.nan,
         attribution=None,
         layer_name="PACE",
         zoom_to_layer=True,
         visible=True,
         method="nearest",
+        gridded=False,
         array_args={},
         **kwargs,
     ):
@@ -229,10 +230,15 @@ class Map(leafmap.Map):
 
             source = read_pace(source)
 
-        source = grid_pace(source, wavelengths, method=method)
+        image = pace_to_image(
+            source, wavelengths=wavelengths, method=method, gridded=gridded
+        )
+
+        if isinstance(wavelengths, list) and len(wavelengths) > 1:
+            colormap = None
 
         self.add_raster(
-            source,
+            image,
             indexes=indexes,
             colormap=colormap,
             vmin=vmin,


### PR DESCRIPTION

## Multi-band visualization
```python
import hypercoast
filepath = 'data/PACE_OCI.20240423T184658.L2.OC_AOP.V1_0_0.NRT.nc'
dataset = hypercoast.read_pace(filepath)
m = hypercoast.Map()
m.add_basemap("Hybrid")
wavelengths=[450, 550, 650]
m.add_pace(dataset, wavelengths, indexes=[3, 2, 1], vmin=0, vmax=0.02, layer_name="PACE")
m
```
![image](https://github.com/opengeos/HyperCoast/assets/5016453/8feb2143-d973-475b-beef-6741a6555620)

## Single-band visualization
```python
m = hypercoast.Map()
m.add_basemap("Hybrid")
wavelengths=[450]
m.add_pace(dataset, wavelengths, colormap="jet", vmin=0, vmax=0.02, layer_name="PACE")
m
```
![image](https://github.com/opengeos/HyperCoast/assets/5016453/3eef49c3-e787-4d45-97be-35fd859fec06)

