### PR TITLE
Add support for visualizing DESIS hyperspectral data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,23 @@
 
 ## Features
 
--   Interactive visualization and analysis of hyperspectral data (e.g., [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov))
+-   Interactive visualization and analysis of hyperspectral data (e.g., [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf))
 -   Interactive extraction and visualization of spectral signatures
 -   Saving spectral signatures as CSV files
 
 ## Demos
 
--   Visualizing NASA [EMIT](https://earth.jpl.nasa.gov/emit) data interactively
+-   Visualizing NASA [EMIT](https://earth.jpl.nasa.gov/emit) hyperspectral data interactively
 
 ![](https://i.imgur.com/zeyABMq.gif)
 
--   Visualizing NASA [PACE](https://pace.gsfc.nasa.gov) data interactively
+-   Visualizing NASA [PACE](https://pace.gsfc.nasa.gov) hyperspectral data interactively
 
 ![](https://i.imgur.com/HBMjW6o.gif)
+
+-   Visualizing [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf) hyperspectral data interactively
+
+![](https://i.imgur.com/PkwOPN5.gif)
 
 ## Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ## Features
 
 -   Interactive visualization and analysis of hyperspectral data (e.g., [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf))
+-   Interactive visualization of NASA [ECOSTRESS](https://ecostress.jpl.nasa.gov) data
 -   Interactive extraction and visualization of spectral signatures
 -   Saving spectral signatures as CSV files
 

--- a/docs/desis.md
+++ b/docs/desis.md
@@ -1,0 +1,3 @@
+# desis module
+
+::: hypercoast.desis

--- a/docs/examples/desis.ipynb
+++ b/docs/examples/desis.ipynb
@@ -60,7 +60,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Plot a spectral signature of a pixel."
+    "Plot the spectral signature of a pixel."
    ]
   },
   {

--- a/docs/examples/desis.ipynb
+++ b/docs/examples/desis.ipynb
@@ -1,0 +1,151 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/HyperCoast/blob/main/docs/examples/desis.ipynb)\n",
+    "\n",
+    "# Visualizing DESIS data interactively with HyperCoast\n",
+    "\n",
+    "This notebook demonstrates how to visualize [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf) hyperspectral data interactively with HyperCoast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"hypercoast[extra]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hypercoast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://github.com/opengeos/datasets/releases/download/hypercoast/desis.tif\"\n",
+    "filepath = \"data/desis.tif\"\n",
+    "hypercoast.download_file(url, filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the dataset as a xarray.Dataset object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = hypercoast.read_desis(filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot a spectral signature of a pixel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hypercoast.filter_desis(dataset, lat=29.4315, lon=91.2927, return_plot=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualize a single band of the hyperspectral image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m.add_basemap(\"Hybrid\")\n",
+    "m.add_desis(filepath, bands=[200], vmin=0, vmax=5000, nodata=0, colormap=\"jet\")\n",
+    "m.add_colormap(cmap=\"jet\", vmin=0, vmax=0.5, label=\"Reflectance\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/owUtN8T.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the spectral signature of a pixel interactively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m.add_basemap(\"Hybrid\")\n",
+    "m.add_desis(filepath, bands=[50, 100, 200], vmin=0, vmax=1000, nodata=0)\n",
+    "m.add(\"spectral\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/PkwOPN5.gif)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hyper",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,19 +13,23 @@
 
 ## Features
 
--   Interactive visualization and analysis of hyperspectral data (e.g., [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov))
+-   Interactive visualization and analysis of hyperspectral data (e.g., [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf))
 -   Interactive extraction and visualization of spectral signatures
 -   Saving spectral signatures as CSV files
 
 ## Demos
 
--   Visualizing NASA [EMIT](https://earth.jpl.nasa.gov/emit) data interactively
+-   Visualizing NASA [EMIT](https://earth.jpl.nasa.gov/emit) hyperspectral data interactively
 
 ![](https://i.imgur.com/zeyABMq.gif)
 
--   Visualizing NASA [PACE](https://pace.gsfc.nasa.gov) data interactively
+-   Visualizing NASA [PACE](https://pace.gsfc.nasa.gov) hyperspectral data interactively
 
 ![](https://i.imgur.com/HBMjW6o.gif)
+
+-   Visualizing [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf) hyperspectral data interactively
+
+![](https://i.imgur.com/PkwOPN5.gif)
 
 ## Acknowledgement
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@
 ## Features
 
 -   Interactive visualization and analysis of hyperspectral data (e.g., [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf))
+-   Interactive visualization of NASA [ECOSTRESS](https://ecostress.jpl.nasa.gov) data
 -   Interactive extraction and visualization of spectral signatures
 -   Saving spectral signatures as CSV files
 

--- a/hypercoast/common.py
+++ b/hypercoast/common.py
@@ -334,8 +334,10 @@ def download_pace(
 
     Args:
         granules (List[dict]): The granules to download.
-        out_dir (str, optional): The output directory where the granules will be downloaded. Defaults to None (current directory).
-        threads (int, optional): The number of threads to use for downloading. Defaults to 8.
+        out_dir (str, optional): The output directory where the granules will be
+            downloaded. Defaults to None (current directory).
+        threads (int, optional): The number of threads to use for downloading.
+            Defaults to 8.
     """
 
     download_nasa_data(granules=granules, out_dir=out_dir, threads=threads)
@@ -350,8 +352,10 @@ def download_emit(
 
     Args:
         granules (List[dict]): The granules to download.
-        out_dir (str, optional): The output directory where the granules will be downloaded. Defaults to None (current directory).
-        threads (int, optional): The number of threads to use for downloading. Defaults to 8.
+        out_dir (str, optional): The output directory where the granules will be
+            downloaded. Defaults to None (current directory).
+        threads (int, optional): The number of threads to use for downloading.
+            Defaults to 8.
     """
 
     download_nasa_data(granules=granules, out_dir=out_dir, threads=threads)
@@ -366,8 +370,10 @@ def download_ecostress(
 
     Args:
         granules (List[dict]): The granules to download.
-        out_dir (str, optional): The output directory where the granules will be downloaded. Defaults to None (current directory).
-        threads (int, optional): The number of threads to use for downloading. Defaults to 8.
+        out_dir (str, optional): The output directory where the granules will be
+            downloaded. Defaults to None (current directory).
+        threads (int, optional): The number of threads to use for downloading.
+            Defaults to 8.
     """
 
     download_nasa_data(granules=granules, out_dir=out_dir, threads=threads)
@@ -382,3 +388,28 @@ def nasa_earth_login(strategy: str = "all", persist: bool = True, **kwargs) -> N
     """
 
     leafmap.nasa_data_login(strategy=strategy, persist=persist, **kwargs)
+
+
+def convert_coords(
+    coords: List[Tuple[float, float]], from_epsg: str, to_epsg: str
+) -> List[Tuple[float, float]]:
+    """
+    Convert a list of coordinates from one EPSG to another.
+
+    Args:
+        coords: List of tuples containing coordinates in the format (latitude, longitude).
+        from_epsg: Source EPSG code (default is "epsg:4326").
+        to_epsg: Target EPSG code (default is "epsg:32615").
+
+    Returns:
+        List of tuples containing converted coordinates in the format (x, y).
+    """
+    import pyproj
+
+    # Define the coordinate transformation
+    transformer = pyproj.Transformer.from_crs(from_epsg, to_epsg, always_xy=True)
+
+    # Convert each coordinate
+    converted_coords = [transformer.transform(lon, lat) for lat, lon in coords]
+
+    return converted_coords

--- a/hypercoast/desis.py
+++ b/hypercoast/desis.py
@@ -1,6 +1,11 @@
+"""
+This Module has the functions related to working with a DISES dataset.
+"""
+
 import rioxarray
 import numpy as np
 import xarray as xr
+import pandas as pd
 
 
 def read_desis(filepath, bands=None, method="nearest", **kwargs):
@@ -26,6 +31,10 @@ def read_desis(filepath, bands=None, method="nearest", **kwargs):
         dataset = dataset.sel(band=bands, method=method, **kwargs)
 
     dataset = dataset.rename({"band_data": "reflectance"})
+    url = "https://github.com/opengeos/datasets/releases/download/hypercoast/desis_wavelengths.csv"
+    df = pd.read_csv(url)
+    wavelengths = df["wavelength"].tolist()
+    dataset.attrs["wavelengths"] = wavelengths
 
     return dataset
 

--- a/hypercoast/desis.py
+++ b/hypercoast/desis.py
@@ -1,0 +1,62 @@
+import rioxarray
+import numpy as np
+import xarray as xr
+
+
+def read_desis(filepath, bands=None, method="nearest", **kwargs):
+    """
+    Reads DESIS data from a given file and returns an xarray Dataset.
+
+    Args:
+        filepath (str): Path to the file to read.
+        bands (array-like, optional): Specific bands to select. If None, all
+            bands are selected.
+        method (str, optional): Method to use for selection when bands is not
+            None. Defaults to "nearest".
+        **kwargs: Additional keyword arguments to pass to the `sel` method when
+            bands is not None.
+
+    Returns:
+        xr.Dataset: An xarray Dataset containing the DESIS data.
+    """
+
+    dataset = xr.open_dataset(filepath)
+
+    if bands is not None:
+        dataset = dataset.sel(band=bands, method=method, **kwargs)
+
+    dataset = dataset.rename({"band_data": "reflectance"})
+
+    return dataset
+
+
+def desis_to_image(dataset, bands=None, method="nearest", output=None, **kwargs):
+    """
+    Converts an DESIS dataset to an image.
+
+    Args:
+        dataset (xarray.Dataset or str): The dataset containing the DESIS data
+            or the file path to the dataset.
+        bands (array-like, optional): The specific bands to select. If None, all
+            bands are selected. Defaults to None.
+        method (str, optional): The method to use for data interpolation.
+            Defaults to "nearest".
+        output (str, optional): The file path where the image will be saved. If
+            None, the image will be returned as a PIL Image object. Defaults to None.
+        **kwargs: Additional keyword arguments to be passed to
+            `leafmap.array_to_image`.
+
+    Returns:
+        rasterio.Dataset or None: The image converted from the dataset. If
+            `output` is provided, the image will be saved to the specified file
+            and the function will return None.
+    """
+    from leafmap import array_to_image
+
+    if isinstance(dataset, str):
+        dataset = read_desis(dataset, method=method)
+
+    if bands is not None:
+        dataset = dataset.sel(band=bands, method=method)
+
+    return array_to_image(dataset["reflectance"], output=output, **kwargs)

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -5,6 +5,7 @@ import leafmap
 import xarray as xr
 import numpy as np
 from .common import *
+from .desis import *
 from .emit import *
 from .pace import *
 from .ui import SpectralWidget
@@ -215,25 +216,39 @@ class Map(leafmap.Map):
         **kwargs,
     ):
         """Add a PACE dataset to the map.
-            If you are using this function in JupyterHub on a remote server (e.g., Binder, Microsoft Planetary Computer) and
-            if the raster does not render properly, try installing jupyter-server-proxy using `pip install jupyter-server-proxy`,
-            then running the following code before calling this function. For more info, see https://bit.ly/3JbmF93.
+            If you are using this function in JupyterHub on a remote server
+                (e.g., Binder, Microsoft Planetary Computer) and
+            if the raster does not render properly, try installing
+                jupyter-server-proxy using `pip install jupyter-server-proxy`,
+            then running the following code before calling this function. For
+                more info, see https://bit.ly/3JbmF93.
 
             import os
             os.environ['LOCALTILESERVER_CLIENT_PREFIX'] = 'proxy/{port}'
 
         Args:
-            source (str): The path to the GeoTIFF file or the URL of the Cloud Optimized GeoTIFF.
-            indexes (int, optional): The band(s) to use. Band indexing starts at 1. Defaults to None.
-            colormap (str, optional): The name of the colormap from `matplotlib` to use when plotting a single band. See https://matplotlib.org/stable/gallery/color/colormap_reference.html. Default is greyscale.
-            vmin (float, optional): The minimum value to use when colormapping the palette when plotting a single band. Defaults to None.
-            vmax (float, optional): The maximum value to use when colormapping the palette when plotting a single band. Defaults to None.
-            nodata (float, optional): The value from the band to use to interpret as not valid data. Defaults to None.
-            attribution (str, optional): Attribution for the source raster. This defaults to a message about it being a local file.. Defaults to None.
+            source (str): The path to the GeoTIFF file or the URL of the Cloud
+                Optimized GeoTIFF.
+            indexes (int, optional): The band(s) to use. Band indexing starts
+                at 1. Defaults to None.
+            colormap (str, optional): The name of the colormap from `matplotlib`
+                to use when plotting a single band. See
+                    https://matplotlib.org/stable/gallery/color/colormap_reference.html.
+                    Default is greyscale.
+            vmin (float, optional): The minimum value to use when colormapping
+                the palette when plotting a single band. Defaults to None.
+            vmax (float, optional): The maximum value to use when colormapping
+                the palette when plotting a single band. Defaults to None.
+            nodata (float, optional): The value from the band to use to interpret
+                as not valid data. Defaults to None.
+            attribution (str, optional): Attribution for the source raster. This
+                defaults to a message about it being a local file.. Defaults to None.
             layer_name (str, optional): The layer name to use. Defaults to 'EMIT'.
-            zoom_to_layer (bool, optional): Whether to zoom to the extent of the layer. Defaults to True.
+            zoom_to_layer (bool, optional): Whether to zoom to the extent of the
+                layer. Defaults to True.
             visible (bool, optional): Whether the layer is visible. Defaults to True.
-            array_args (dict, optional): Additional arguments to pass to `array_to_memory_file` when reading the raster. Defaults to {}.
+            array_args (dict, optional): Additional arguments to pass to
+                `array_to_memory_file` when reading the raster. Defaults to {}.
         """
 
         if isinstance(source, str):
@@ -265,6 +280,95 @@ class Map(leafmap.Map):
         self.cog_layer_dict[layer_name]["xds"] = source
         self.cog_layer_dict[layer_name]["type"] = "PACE"
 
+    def add_desis(
+        self,
+        source,
+        bands=[50, 100, 200],
+        indexes=None,
+        colormap="jet",
+        vmin=None,
+        vmax=None,
+        nodata=np.nan,
+        attribution=None,
+        layer_name="DESIS",
+        zoom_to_layer=True,
+        visible=True,
+        method="nearest",
+        array_args={},
+        **kwargs,
+    ):
+        """Add a DESIS dataset to the map.
+            If you are using this function in JupyterHub on a remote server
+                (e.g., Binder, Microsoft Planetary Computer) and
+            if the raster does not render properly, try installing
+                jupyter-server-proxy using `pip install jupyter-server-proxy`,
+            then running the following code before calling this function. For
+                more info, see https://bit.ly/3JbmF93.
+
+            import os
+            os.environ['LOCALTILESERVER_CLIENT_PREFIX'] = 'proxy/{port}'
+
+        Args:
+            source (str): The path to the GeoTIFF file or the URL of the Cloud
+                Optimized GeoTIFF.
+            indexes (int, optional): The band(s) to use. Band indexing starts
+                at 1. Defaults to None.
+            colormap (str, optional): The name of the colormap from `matplotlib`
+                to use when plotting a single band. See
+                https://matplotlib.org/stable/gallery/color/colormap_reference.html.
+                Default is 'jet'.
+            vmin (float, optional): The minimum value to use when colormapping
+                the palette when plotting a single band. Defaults to None.
+            vmax (float, optional): The maximum value to use when colormapping
+                the palette when plotting a single band. Defaults to None.
+            nodata (float, optional): The value from the band to use to interpret
+                as not valid data. Defaults to None.
+            attribution (str, optional): Attribution for the source raster. This
+                defaults to a message about it being a local file.. Defaults to None.
+            layer_name (str, optional): The layer name to use. Defaults to 'EMIT'.
+            zoom_to_layer (bool, optional): Whether to zoom to the extent of the
+                layer. Defaults to True.
+            visible (bool, optional): Whether the layer is visible. Defaults to True.
+            array_args (dict, optional): Additional arguments to pass to
+                `array_to_memory_file` when reading the raster. Defaults to {}.
+        """
+
+        if isinstance(source, str):
+
+            source = read_desis(source)
+
+        image = desis_to_image(source, bands=bands, method=method)
+
+        if isinstance(bands, list) and len(bands) > 1:
+            colormap = None
+
+        if isinstance(bands, int):
+            bands = [bands]
+
+        if indexes is None:
+            if isinstance(bands, list) and len(bands) == 1:
+                indexes = 1
+            else:
+                indexes = [3, 2, 1]
+
+        self.add_raster(
+            image,
+            indexes=indexes,
+            colormap=colormap,
+            vmin=vmin,
+            vmax=vmax,
+            nodata=nodata,
+            attribution=attribution,
+            layer_name=layer_name,
+            zoom_to_layer=zoom_to_layer,
+            visible=visible,
+            array_args=array_args,
+            **kwargs,
+        )
+
+        self.cog_layer_dict[layer_name]["xds"] = source
+        # self.cog_layer_dict[layer_name]["type"] = "DESIS"
+
     def set_plot_options(
         self,
         add_marker_cluster=False,
@@ -280,15 +384,25 @@ class Map(leafmap.Map):
         """Sets plotting options.
 
         Args:
-            add_marker_cluster (bool, optional): Whether to add a marker cluster. Defaults to False.
-            sample_scale (float, optional):  A nominal scale in meters of the projection to sample in . Defaults to None.
-            plot_type (str, optional): The plot type can be one of "None", "bar", "scatter" or "hist". Defaults to None.
-            overlay (bool, optional): Whether to overlay plotted lines on the figure. Defaults to False.
-            position (str, optional): Position of the control, can be ‘bottomleft’, ‘bottomright’, ‘topleft’, or ‘topright’. Defaults to 'bottomright'.
-            min_width (int, optional): Min width of the widget (in pixels), if None it will respect the content size. Defaults to None.
-            max_width (int, optional): Max width of the widget (in pixels), if None it will respect the content size. Defaults to None.
-            min_height (int, optional): Min height of the widget (in pixels), if None it will respect the content size. Defaults to None.
-            max_height (int, optional): Max height of the widget (in pixels), if None it will respect the content size. Defaults to None.
+            add_marker_cluster (bool, optional): Whether to add a marker cluster.
+                Defaults to False.
+            sample_scale (float, optional):  A nominal scale in meters of the
+                projection to sample in . Defaults to None.
+            plot_type (str, optional): The plot type can be one of "None", "bar",
+                "scatter" or "hist". Defaults to None.
+            overlay (bool, optional): Whether to overlay plotted lines on the
+                figure. Defaults to False.
+            position (str, optional): Position of the control, can be
+                ‘bottomleft’, ‘bottomright’, ‘topleft’, or ‘topright’. Defaults
+                to 'bottomright'.
+            min_width (int, optional): Min width of the widget (in pixels), if
+                None it will respect the content size. Defaults to None.
+            max_width (int, optional): Max width of the widget (in pixels), if
+                None it will respect the content size. Defaults to None.
+            min_height (int, optional): Min height of the widget (in pixels), if
+                None it will respect the content size. Defaults to None.
+            max_height (int, optional): Max height of the widget (in pixels), if
+                None it will respect the content size. Defaults to None.
 
         """
         plot_options_dict = {}

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -367,7 +367,7 @@ class Map(leafmap.Map):
         )
 
         self.cog_layer_dict[layer_name]["xds"] = source
-        # self.cog_layer_dict[layer_name]["type"] = "DESIS"
+        self.cog_layer_dict[layer_name]["hyper"] = "DESIS"
 
     def set_plot_options(
         self,

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -195,7 +195,7 @@ class Map(leafmap.Map):
         )
 
         self.cog_layer_dict[layer_name]["xds"] = xds
-        self.cog_layer_dict[layer_name]["type"] = "EMIT"
+        self.cog_layer_dict[layer_name]["hyper"] = "EMIT"
 
     def add_pace(
         self,
@@ -278,7 +278,7 @@ class Map(leafmap.Map):
         )
 
         self.cog_layer_dict[layer_name]["xds"] = source
-        self.cog_layer_dict[layer_name]["type"] = "PACE"
+        self.cog_layer_dict[layer_name]["hyper"] = "PACE"
 
     def add_desis(
         self,

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -347,7 +347,7 @@ class Map(leafmap.Map):
 
         if indexes is None:
             if isinstance(bands, list) and len(bands) == 1:
-                indexes = 1
+                indexes = [1]
             else:
                 indexes = [3, 2, 1]
 

--- a/hypercoast/ui.py
+++ b/hypercoast/ui.py
@@ -158,7 +158,7 @@ class SpectralWidget(widgets.HBox):
                     self._host_map._plot_markers = []
                 markers = self._host_map._plot_markers
                 marker_cluster = self._host_map._plot_marker_cluster
-                markers.append(ipyleaflet.Marker(location=latlon))
+                markers.append(ipyleaflet.Marker(location=latlon, draggable=False))
                 marker_cluster.markers = markers
                 self._host_map._plot_marker_cluster = marker_cluster
 
@@ -192,14 +192,28 @@ class SpectralWidget(widgets.HBox):
                 self._host_map._spectral_data[f"({lat:.4f} {lon:.4f})"] = da.values
 
                 da[da < 0] = np.nan
+                axes_options = {
+                    "x": {"label_offset": "30px"},
+                    "y": {"label_offset": "35px"},
+                }
+
                 if not stack_btn.value:
                     plt.clear()
-                    plt.plot(da.coords[da.dims[0]].values, da.values)
+                    plt.plot(
+                        da.coords[da.dims[0]].values,
+                        da.values,
+                        axes_options=axes_options,
+                    )
                 else:
                     color = np.random.rand(
                         3,
                     )
-                    plt.plot(da.coords[da.dims[0]].values, da.values, color=color)
+                    plt.plot(
+                        da.coords[da.dims[0]].values,
+                        da.values,
+                        color=color,
+                        axes_options=axes_options,
+                    )
                     try:
                         if isinstance(self._fig.axes[0], bqplot.ColorAxis):
                             self._fig.axes = self._fig.axes[1:]

--- a/hypercoast/ui.py
+++ b/hypercoast/ui.py
@@ -11,6 +11,7 @@ from bqplot import pyplot as plt
 from IPython.core.display import display
 from ipyfilechooser import FileChooser
 from .pace import extract_pace
+from .desis import extract_desis
 
 
 class SpectralWidget(widgets.HBox):
@@ -162,7 +163,7 @@ class SpectralWidget(widgets.HBox):
                 self._host_map._plot_marker_cluster = marker_cluster
 
                 ds = self._host_map.cog_layer_dict[layer_name]["xds"]
-                if self._host_map.cog_layer_dict[layer_name]["type"] == "EMIT":
+                if self._host_map.cog_layer_dict[layer_name]["hyper"] == "EMIT":
                     da = ds.sel(latitude=lat, longitude=lon, method="nearest")[
                         "reflectance"
                     ]
@@ -171,7 +172,7 @@ class SpectralWidget(widgets.HBox):
                         self._host_map._spectral_data["wavelengths"] = ds[
                             "wavelengths"
                         ].values
-                elif self._host_map.cog_layer_dict[layer_name]["type"] == "PACE":
+                elif self._host_map.cog_layer_dict[layer_name]["hyper"] == "PACE":
                     try:
                         da = extract_pace(ds, lat, lon)
                     except:
@@ -184,6 +185,9 @@ class SpectralWidget(widgets.HBox):
                         self._host_map._spectral_data["wavelengths"] = ds[
                             "wavelength"
                         ].values
+
+                elif self._host_map.cog_layer_dict[layer_name]["hyper"] == "DESIS":
+                    da = extract_desis(ds, lat, lon)
 
                 self._host_map._spectral_data[f"({lat:.4f} {lon:.4f})"] = da.values
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
           - examples/ecostress.ipynb
     - API Reference:
           - common module: common.md
+          - desis module: desis.md
           - emit module: emit.md
           - hypercoast module: hypercoast.md
           - pace module: pace.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
     - Report Issues: https://github.com/opengeos/HyperCoast/issues
     - Examples:
           - examples/search_data.ipynb
+          - examples/desis.ipynb
           - examples/emit.ipynb
           - examples/pace.ipynb
           - examples/ecostress.ipynb


### PR DESCRIPTION
This PR adds support for visualizing [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf) hyperspectral data. 

```python
import hypercoast
m = hypercoast.Map()
filepath = "data/dises.tif"
m.add_desis(filepath, bands=[50, 100, 200], vmin=0, vmax=1000)
m
```
![image](https://github.com/opengeos/HyperCoast/assets/5016453/2b59545d-4c48-491b-9c63-cf947891412e)
