### PR TITLE
Add support for NEON AOP data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Features
 
--   Interactive visualization and analysis of hyperspectral data (e.g., [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf))
+-   Interactive visualization and analysis of hyperspectral data, such as [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf), [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001)
 -   Interactive visualization of NASA [ECOSTRESS](https://ecostress.jpl.nasa.gov) data
 -   Interactive extraction and visualization of spectral signatures
 -   Saving spectral signatures as CSV files

--- a/README.md
+++ b/README.md
@@ -23,15 +23,19 @@
 
 -   Visualizing NASA [EMIT](https://earth.jpl.nasa.gov/emit) hyperspectral data interactively
 
-![](https://i.imgur.com/zeyABMq.gif)
+![EMIT](https://i.imgur.com/zeyABMq.gif)
 
 -   Visualizing NASA [PACE](https://pace.gsfc.nasa.gov) hyperspectral data interactively
 
-![](https://i.imgur.com/HBMjW6o.gif)
+![PACE](https://i.imgur.com/HBMjW6o.gif)
 
 -   Visualizing [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf) hyperspectral data interactively
 
-![](https://i.imgur.com/PkwOPN5.gif)
+![DESIS](https://i.imgur.com/PkwOPN5.gif)
+
+-   Visualizing [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001) hyperspectral data interactively
+
+![NEON](https://i.imgur.com/CNP8E3y.gif)
 
 ## Acknowledgement
 

--- a/docs/examples/neon.ipynb
+++ b/docs/examples/neon.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "# Visualizing NEON AOP hyperspectral data interactively with HyperCoast\n",
     "\n",
-    "This notebook demonstrates how to visualize [NEON APO](https://data.neonscience.org/data-products/DP3.30006.001) hyperspectral data interactively with HyperCoast."
+    "This notebook demonstrates how to visualize [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001) hyperspectral data interactively with HyperCoast."
    ]
   },
   {
@@ -73,6 +73,31 @@
     "m = hypercoast.Map()\n",
     "m.add_neon(filepath, wavelengths=[1000, 700, 500], vmin=0, vmax=0.5)\n",
     "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.set_center(-76.5134, 38.8973, 16)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add(\"spectral\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/CNP8E3y.gif)"
    ]
   }
  ],

--- a/docs/examples/neon.ipynb
+++ b/docs/examples/neon.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/HyperCoast/blob/main/docs/examples/neon.ipynb)\n",
+    "\n",
+    "# Visualizing NEON AOP hyperspectral data interactively with HyperCoast\n",
+    "\n",
+    "This notebook demonstrates how to visualize [NEON APO](https://data.neonscience.org/data-products/DP3.30006.001) hyperspectral data interactively with HyperCoast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"hypercoast[extra]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hypercoast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://github.com/opengeos/datasets/releases/download/hypercoast/NEON_D02_SERC_DP3_368000_4306000_reflectance.h5\"\n",
+    "filepath = \"data/neon.h5\"\n",
+    "hypercoast.download_file(url, filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the dataset as a `xarray.Dataset` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = hypercoast.read_neon(filepath)\n",
+    "dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualize the data interactively with HyperCoast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m.add_neon(filepath, wavelengths=[1000, 700, 500], vmin=0, vmax=0.5)\n",
+    "m"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hyper",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,15 +22,19 @@
 
 -   Visualizing NASA [EMIT](https://earth.jpl.nasa.gov/emit) hyperspectral data interactively
 
-![](https://i.imgur.com/zeyABMq.gif)
+![EMIT](https://i.imgur.com/zeyABMq.gif)
 
 -   Visualizing NASA [PACE](https://pace.gsfc.nasa.gov) hyperspectral data interactively
 
-![](https://i.imgur.com/HBMjW6o.gif)
+![PACE](https://i.imgur.com/HBMjW6o.gif)
 
 -   Visualizing [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf) hyperspectral data interactively
 
-![](https://i.imgur.com/PkwOPN5.gif)
+![DESIS](https://i.imgur.com/PkwOPN5.gif)
+
+-   Visualizing [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001) hyperspectral data interactively
+
+![NEON](https://i.imgur.com/CNP8E3y.gif)
 
 ## Acknowledgement
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@
 
 ## Features
 
--   Interactive visualization and analysis of hyperspectral data (e.g., [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf))
+-   Interactive visualization and analysis of hyperspectral data, such as [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf), [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001)
 -   Interactive visualization of NASA [ECOSTRESS](https://ecostress.jpl.nasa.gov) data
 -   Interactive extraction and visualization of spectral signatures
 -   Saving spectral signatures as CSV files

--- a/docs/neon.md
+++ b/docs/neon.md
@@ -1,0 +1,3 @@
+# neon module
+
+::: hypercoast.neon

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -7,13 +7,15 @@ import numpy as np
 from .common import *
 from .desis import *
 from .emit import *
+from .neon import *
 from .pace import *
 from .ui import SpectralWidget
 
 
 class Map(leafmap.Map):
     """
-    A class that extends leafmap.Map to provide additional functionality for hypercoast.
+    A class that extends leafmap.Map to provide additional functionality for
+        hypercoast.
 
     Attributes:
         Any attributes inherited from leafmap.Map.
@@ -27,7 +29,8 @@ class Map(leafmap.Map):
         Initializes a new instance of the Map class.
 
         Args:
-            **kwargs: Arbitrary keyword arguments that are passed to the parent class's constructor.
+            **kwargs: Arbitrary keyword arguments that are passed to the parent
+                class's constructor.
         """
         super().__init__(**kwargs)
 
@@ -35,7 +38,8 @@ class Map(leafmap.Map):
         """Add a layer to the map.
 
         Args:
-            **kwargs: Arbitrary keyword arguments that are passed to the parent class's add_layer method.
+            **kwargs: Arbitrary keyword arguments that are passed to the parent
+                class's add_layer method.
         """
 
         if isinstance(obj, str):
@@ -51,28 +55,34 @@ class Map(leafmap.Map):
 
     def search_emit(self, default_dataset="EMITL2ARFL"):
         """
-        Adds a NASA Earth Data search tool to the map with a default dataset for EMIT.
+        Adds a NASA Earth Data search tool to the map with a default dataset for
+            EMIT.
 
         Args:
-            default_dataset (str, optional): The default dataset to search for. Defaults to "EMITL2ARFL".
+            default_dataset (str, optional): The default dataset to search for.
+                Defaults to "EMITL2ARFL".
         """
         self.add("nasa_earth_data", default_dataset=default_dataset)
 
     def search_pace(self, default_dataset="PACE_OCI_L2_AOP_NRT"):
         """
-        Adds a NASA Earth Data search tool to the map with a default dataset for PACE.
+        Adds a NASA Earth Data search tool to the map with a default dataset for
+            PACE.
 
         Args:
-            default_dataset (str, optional): The default dataset to search for. Defaults to "PACE_OCI_L2_AOP_NRT".
+            default_dataset (str, optional): The default dataset to search for.
+                Defaults to "PACE_OCI_L2_AOP_NRT".
         """
         self.add("nasa_earth_data", default_dataset=default_dataset)
 
     def search_ecostress(self, default_dataset="ECO_L2T_LSTE"):
         """
-        Adds a NASA Earth Data search tool to the map with a default dataset for ECOSTRESS.
+        Adds a NASA Earth Data search tool to the map with a default dataset for
+            ECOSTRESS.
 
         Args:
-            default_dataset (str, optional): The default dataset to search for. Defaults to "ECO_L2T_LSTE".
+            default_dataset (str, optional): The default dataset to search for.
+                Defaults to "ECO_L2T_LSTE".
         """
         self.add("nasa_earth_data", default_dataset=default_dataset)
 
@@ -92,25 +102,40 @@ class Map(leafmap.Map):
         **kwargs,
     ):
         """Add a local raster dataset to the map.
-            If you are using this function in JupyterHub on a remote server (e.g., Binder, Microsoft Planetary Computer) and
-            if the raster does not render properly, try installing jupyter-server-proxy using `pip install jupyter-server-proxy`,
-            then running the following code before calling this function. For more info, see https://bit.ly/3JbmF93.
+            If you are using this function in JupyterHub on a remote server
+                (e.g., Binder, Microsoft Planetary Computer) and
+            if the raster does not render properly, try installing
+                jupyter-server-proxy using `pip install jupyter-server-proxy`,
+            then running the following code before calling this function. For
+                more info, see https://bit.ly/3JbmF93.
 
             import os
             os.environ['LOCALTILESERVER_CLIENT_PREFIX'] = 'proxy/{port}'
 
         Args:
-            source (str): The path to the GeoTIFF file or the URL of the Cloud Optimized GeoTIFF.
-            indexes (int, optional): The band(s) to use. Band indexing starts at 1. Defaults to None.
-            colormap (str, optional): The name of the colormap from `matplotlib` to use when plotting a single band. See https://matplotlib.org/stable/gallery/color/colormap_reference.html. Default is greyscale.
-            vmin (float, optional): The minimum value to use when colormapping the palette when plotting a single band. Defaults to None.
-            vmax (float, optional): The maximum value to use when colormapping the palette when plotting a single band. Defaults to None.
-            nodata (float, optional): The value from the band to use to interpret as not valid data. Defaults to None.
-            attribution (str, optional): Attribution for the source raster. This defaults to a message about it being a local file.. Defaults to None.
+            source (str): The path to the GeoTIFF file or the URL of the Cloud
+                Optimized GeoTIFF.
+            indexes (int, optional): The band(s) to use. Band indexing starts
+                at 1. Defaults to None.
+            colormap (str, optional): The name of the colormap from `matplotlib`
+                to use when plotting a single band. See
+                https://matplotlib.org/stable/gallery/color/colormap_reference.html.
+                Default is greyscale.
+            vmin (float, optional): The minimum value to use when colormapping
+                the palette when plotting a single band. Defaults to None.
+            vmax (float, optional): The maximum value to use when colormapping
+                the palette when plotting a single band. Defaults to None.
+            nodata (float, optional): The value from the band to use to interpret
+                as not valid data. Defaults to None.
+            attribution (str, optional): Attribution for the source raster. This
+                defaults to a message about it being a local file.. Defaults to None.
             layer_name (str, optional): The layer name to use. Defaults to 'Raster'.
-            zoom_to_layer (bool, optional): Whether to zoom to the extent of the layer. Defaults to True.
-            visible (bool, optional): Whether the layer is visible. Defaults to True.
-            array_args (dict, optional): Additional arguments to pass to `array_to_memory_file` when reading the raster. Defaults to {}.
+            zoom_to_layer (bool, optional): Whether to zoom to the extent of the
+                layer. Defaults to True.
+            visible (bool, optional): Whether the layer is visible. Defaults to
+                True.
+            array_args (dict, optional): Additional arguments to pass to
+                `array_to_memory_file` when reading the raster. Defaults to {}.
         """
 
         import numpy as np
@@ -148,26 +173,41 @@ class Map(leafmap.Map):
         array_args={},
         **kwargs,
     ):
-        """Add a local raster dataset to the map.
-            If you are using this function in JupyterHub on a remote server (e.g., Binder, Microsoft Planetary Computer) and
-            if the raster does not render properly, try installing jupyter-server-proxy using `pip install jupyter-server-proxy`,
-            then running the following code before calling this function. For more info, see https://bit.ly/3JbmF93.
+        """Add an EMIT dataset to the map.
+            If you are using this function in JupyterHub on a remote server
+                (e.g., Binder, Microsoft Planetary Computer) and
+            if the raster does not render properly, try installing
+                jupyter-server-proxy using `pip install jupyter-server-proxy`,
+            then running the following code before calling this function. For
+                more info, see https://bit.ly/3JbmF93.
 
             import os
             os.environ['LOCALTILESERVER_CLIENT_PREFIX'] = 'proxy/{port}'
 
         Args:
-            source (str): The path to the GeoTIFF file or the URL of the Cloud Optimized GeoTIFF.
-            indexes (int, optional): The band(s) to use. Band indexing starts at 1. Defaults to None.
-            colormap (str, optional): The name of the colormap from `matplotlib` to use when plotting a single band. See https://matplotlib.org/stable/gallery/color/colormap_reference.html. Default is greyscale.
-            vmin (float, optional): The minimum value to use when colormapping the palette when plotting a single band. Defaults to None.
-            vmax (float, optional): The maximum value to use when colormapping the palette when plotting a single band. Defaults to None.
-            nodata (float, optional): The value from the band to use to interpret as not valid data. Defaults to None.
-            attribution (str, optional): Attribution for the source raster. This defaults to a message about it being a local file.. Defaults to None.
+            source (str): The path to the GeoTIFF file or the URL of the Cloud
+                Optimized GeoTIFF.
+            indexes (int, optional): The band(s) to use. Band indexing starts
+                at 1. Defaults to None.
+            colormap (str, optional): The name of the colormap from `matplotlib`
+                to use when plotting a single band.
+                    See https://matplotlib.org/stable/gallery/color/colormap_reference.html.
+                    Default is greyscale.
+            vmin (float, optional): The minimum value to use when colormapping
+                the palette when plotting a single band. Defaults to None.
+            vmax (float, optional): The maximum value to use when colormapping
+                the palette when plotting a single band. Defaults to None.
+            nodata (float, optional): The value from the band to use to
+                interpret as not valid data. Defaults to None.
+            attribution (str, optional): Attribution for the source raster. This
+                defaults to a message about it being a local file.. Defaults to None.
             layer_name (str, optional): The layer name to use. Defaults to 'EMIT'.
-            zoom_to_layer (bool, optional): Whether to zoom to the extent of the layer. Defaults to True.
-            visible (bool, optional): Whether the layer is visible. Defaults to True.
-            array_args (dict, optional): Additional arguments to pass to `array_to_memory_file` when reading the raster. Defaults to {}.
+            zoom_to_layer (bool, optional): Whether to zoom to the extent of the
+                layer. Defaults to True.
+            visible (bool, optional): Whether the layer is visible. Defaults to
+                True.
+            array_args (dict, optional): Additional arguments to pass to
+                `array_to_memory_file` when reading the raster. Defaults to {}.
         """
 
         xds = None
@@ -368,6 +408,88 @@ class Map(leafmap.Map):
 
         self.cog_layer_dict[layer_name]["xds"] = source
         self.cog_layer_dict[layer_name]["hyper"] = "DESIS"
+
+    def add_neon(
+        self,
+        source,
+        wavelengths=None,
+        indexes=None,
+        colormap=None,
+        vmin=0,
+        vmax=0.5,
+        nodata=np.nan,
+        attribution=None,
+        layer_name="NEON",
+        zoom_to_layer=True,
+        visible=True,
+        array_args={},
+        method="nearest",
+        **kwargs,
+    ):
+        """Add an NEON AOP dataset to the map.
+            If you are using this function in JupyterHub on a remote server
+                (e.g., Binder, Microsoft Planetary Computer) and
+            if the raster does not render properly, try installing
+                jupyter-server-proxy using `pip install jupyter-server-proxy`,
+            then running the following code before calling this function. For
+                more info, see https://bit.ly/3JbmF93.
+
+            import os
+            os.environ['LOCALTILESERVER_CLIENT_PREFIX'] = 'proxy/{port}'
+
+        Args:
+            source (str): The path to the NEON AOP HDF5 file.
+            indexes (int, optional): The band(s) to use. Band indexing starts
+                at 1. Defaults to None.
+            colormap (str, optional): The name of the colormap from `matplotlib`
+                to use when plotting a single band. See
+                    https://matplotlib.org/stable/gallery/color/colormap_reference.html.
+                    Default is greyscale.
+            vmin (float, optional): The minimum value to use when colormapping
+                the palette when plotting a single band. Defaults to 0.
+            vmax (float, optional): The maximum value to use when colormapping
+                the palette when plotting a single band. Defaults to 0.5.
+            nodata (float, optional): The value from the band to use to
+                interpret as not valid data. Defaults to np.nan.
+            attribution (str, optional): Attribution for the source raster. This
+                defaults to a message about it being a local file.. Defaults to None.
+            layer_name (str, optional): The layer name to use. Defaults to 'NEON'.
+            zoom_to_layer (bool, optional): Whether to zoom to the extent of the
+                layer. Defaults to True.
+            visible (bool, optional): Whether the layer is visible. Defaults
+                to True.
+            array_args (dict, optional): Additional arguments to pass to
+                `array_to_memory_file` when reading the raster. Defaults to {}.
+            method (str, optional): The method to use for data interpolation.
+                Defaults to "nearest".
+        """
+
+        xds = None
+        if isinstance(source, str):
+
+            xds = read_neon(source)
+            source = neon_to_image(xds, wavelengths=wavelengths, method=method)
+        elif isinstance(source, xr.Dataset):
+            xds = source
+            source = neon_to_image(xds, wavelengths=wavelengths, method=method)
+
+        self.add_raster(
+            source,
+            indexes=indexes,
+            colormap=colormap,
+            vmin=vmin,
+            vmax=vmax,
+            nodata=nodata,
+            attribution=attribution,
+            layer_name=layer_name,
+            zoom_to_layer=zoom_to_layer,
+            visible=visible,
+            array_args=array_args,
+            **kwargs,
+        )
+
+        self.cog_layer_dict[layer_name]["xds"] = xds
+        self.cog_layer_dict[layer_name]["hyper"] = "NEON"
 
     def set_plot_options(
         self,

--- a/hypercoast/neon.py
+++ b/hypercoast/neon.py
@@ -1,0 +1,168 @@
+"""This module contains functions to read and process NEON AOP hyperspectral data.
+More info about the data can be found at https://bit.ly/3Rfszdc.
+The source code is adapted from https://bit.ly/3KwyZkn. Credit goes to the
+original authors.
+"""
+
+import h5py
+import rioxarray
+import numpy as np
+import xarray as xr
+from typing import List, Union, Dict, Optional, Tuple, Any
+
+
+def list_neon_datasets(filepath: str, print_node: bool = False) -> None:
+    """
+    Lists all the datasets in an HDF5 file.
+
+    Args:
+        filepath (str): The path to the HDF5 file.
+        print_node (bool, optional): If True, prints the node object of each dataset.
+            If False, prints the name of each dataset. Defaults to False.
+    """
+
+    f = h5py.File(filepath, "r")
+
+    if print_node:
+
+        def list_dataset(_, node):
+            if isinstance(node, h5py.Dataset):
+                print(node)
+
+    else:
+
+        def list_dataset(name, node):
+            if isinstance(node, h5py.Dataset):
+                print(name)
+
+    f.visititems(list_dataset)
+
+
+def read_neon(
+    filepath: str,
+    wavelengths: Optional[List[float]] = None,
+    method: str = "nearest",
+    **kwargs: Any,
+) -> xr.Dataset:
+    """
+    Reads NEON AOP hyperspectral hdf5 files and returns an xarray dataset.
+
+    Args:
+        filepath (str): The path to the hdf5 file.
+        wavelengths (List[float], optional): The wavelengths to select. If None,
+            all wavelengths are selected. Defaults to None.
+        method (str, optional): The method to use for selection. Defaults to
+            "nearest".
+        **kwargs (Any): Additional arguments to pass to the selection method.
+
+    Returns:
+        xr.Dataset: The dataset containing the reflectance data.
+    """
+    f = h5py.File(filepath, "r")
+
+    serc_refl = f["SERC"]["Reflectance"]
+    wavelengths = serc_refl["Metadata"]["Spectral_Data"]["Wavelength"][()].tolist()
+    wavelengths = [round(num, 2) for num in wavelengths]
+
+    epsg_code = serc_refl["Metadata"]["Coordinate_System"]["EPSG Code"][()]
+    epsg_code_number = int(epsg_code.decode("utf-8"))
+
+    serc_mapInfo = serc_refl["Metadata"]["Coordinate_System"]["Map_Info"]
+    mapInfo_string = serc_mapInfo[()].decode("utf-8")  # read in as string
+    mapInfo_split = mapInfo_string.split(",")
+
+    res = float(mapInfo_split[5]), float(mapInfo_split[6])
+
+    serc_reflArray = serc_refl["Reflectance_Data"]
+    refl_shape = serc_reflArray.shape
+
+    # Extract the upper left-hand corner coordinates from mapInfo
+    xMin = float(mapInfo_split[3])
+    yMax = float(mapInfo_split[4])
+
+    # Calculate the xMax and yMin values from the dimensions
+    xMax = xMin + (
+        refl_shape[1] * res[0]
+    )  # xMax = left edge + (# of columns * x pixel resolution)
+    yMin = yMax - (
+        refl_shape[0] * res[1]
+    )  # yMin = top edge - (# of rows * y pixel resolution)
+
+    # serc_ext = (xMin, xMax, yMin, yMax)
+
+    # View and apply scale factor and data ignore value
+    scaleFactor = serc_reflArray.attrs["Scale_Factor"]
+    noDataValue = serc_reflArray.attrs["Data_Ignore_Value"]
+
+    da = serc_reflArray[:, :, :].astype(float)
+    da[da == int(noDataValue)] = np.nan
+    da = da / scaleFactor
+
+    coords = {
+        "y": np.linspace(yMax, yMin, da.shape[0]),
+        "x": np.linspace(xMin, xMax, da.shape[1]),
+        "wavelength": wavelengths,
+    }
+
+    xda = xr.DataArray(
+        da,
+        coords=coords,
+        dims=["y", "x", "wavelength"],
+        attrs={
+            "scale_factor": scaleFactor,
+            "no_data_value": noDataValue,
+            "crs": f"EPSG:{epsg_code_number}",
+            "transform": (res[0], 0.0, xMin, 0.0, -res[1], yMax),
+        },
+    )
+
+    if wavelengths is not None:
+        xda = xda.sel(wavelength=wavelengths, method=method, **kwargs)
+
+    dataset = xda.to_dataset(name="reflectance")
+
+    return dataset
+
+
+def neon_to_image(
+    dataset: Union[xr.Dataset, str],
+    wavelengths: Optional[np.ndarray] = None,
+    method: str = "nearest",
+    output: Optional[str] = None,
+    **kwargs: Any,
+):
+    """
+    Converts an NEON dataset to an image.
+
+    Args:
+        dataset (Union[xr.Dataset, str]): The dataset containing the NEON data
+            or the file path to the dataset.
+        wavelengths (np.ndarray, optional): The specific wavelengths to select. If None, all
+            wavelengths are selected. Defaults to None.
+        method (str, optional): The method to use for data interpolation.
+            Defaults to "nearest".
+        output (str, optional): The file path where the image will be saved. If
+            None, the image will be returned as a PIL Image object. Defaults to None.
+        **kwargs (Any): Additional keyword arguments to be passed to
+            `leafmap.array_to_image`.
+
+    Returns:
+        Optional[rasterio.Dataset]: The image converted from the dataset. If
+            `output` is provided, the image will be saved to the specified file
+            and the function will return None.
+    """
+    from leafmap import array_to_image
+
+    if isinstance(dataset, str):
+        dataset = read_neon(dataset, method=method)
+
+    if wavelengths is not None:
+        dataset = dataset.sel(wavelength=wavelengths, method=method)
+
+    return array_to_image(
+        dataset["reflectance"],
+        output=output,
+        transpose=False,
+        dtype=np.float32,
+        **kwargs,
+    )

--- a/hypercoast/ui.py
+++ b/hypercoast/ui.py
@@ -12,6 +12,7 @@ from IPython.core.display import display
 from ipyfilechooser import FileChooser
 from .pace import extract_pace
 from .desis import extract_desis
+from .neon import extract_neon
 
 
 class SpectralWidget(widgets.HBox):
@@ -188,6 +189,9 @@ class SpectralWidget(widgets.HBox):
 
                 elif self._host_map.cog_layer_dict[layer_name]["hyper"] == "DESIS":
                     da = extract_desis(ds, lat, lon)
+
+                elif self._host_map.cog_layer_dict[layer_name]["hyper"] == "NEON":
+                    da = extract_neon(ds, lat, lon)
 
                 self._host_map._spectral_data[f"({lat:.4f} {lon:.4f})"] = da.values
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
           - examples/search_data.ipynb
           - examples/desis.ipynb
           - examples/emit.ipynb
+          - examples/neon.ipynb
           - examples/pace.ipynb
           - examples/ecostress.ipynb
     - API Reference:
@@ -90,5 +91,6 @@ nav:
           - desis module: desis.md
           - emit module: emit.md
           - hypercoast module: hypercoast.md
+          - neon module: neon.md
           - pace module: pace.md
           - ui module: ui.md


### PR DESCRIPTION
This PR adds support for visualizing [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001) hyperspectral data. 

```python
import hypercoast
filepath = "data/neon.h5"
m = hypercoast.Map()
m.add_neon(filepath, wavelengths=[1000, 700, 500], vmin=0, vmax=0.5)
m
```

![](https://i.imgur.com/XaPLS6K.png)