### PR TITLE
Add support for AVIRIS data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,20 @@
 
 ## Features
 
--   Interactive visualization and analysis of hyperspectral data, such as [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf), [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001)
+-   Interactive visualization and analysis of hyperspectral data, such as [AVIRIS](https://aviris.jpl.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf), [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001)
 -   Interactive visualization of NASA [ECOSTRESS](https://ecostress.jpl.nasa.gov) data
 -   Interactive extraction and visualization of spectral signatures
 -   Saving spectral signatures as CSV files
 
 ## Demos
+
+-   Visualizing NASA [AVIRIS](https://aviris.jpl.nasa.gov) hyperspectral data interactively
+
+![AVIRIS](https://i.imgur.com/RdegGqx.gif)
+
+-   Visualizing [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf) hyperspectral data interactively
+
+![DESIS](https://i.imgur.com/PkwOPN5.gif)
 
 -   Visualizing NASA [EMIT](https://earth.jpl.nasa.gov/emit) hyperspectral data interactively
 
@@ -28,10 +36,6 @@
 -   Visualizing NASA [PACE](https://pace.gsfc.nasa.gov) hyperspectral data interactively
 
 ![PACE](https://i.imgur.com/HBMjW6o.gif)
-
--   Visualizing [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf) hyperspectral data interactively
-
-![DESIS](https://i.imgur.com/PkwOPN5.gif)
 
 -   Visualizing [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001) hyperspectral data interactively
 

--- a/docs/aviris.md
+++ b/docs/aviris.md
@@ -1,0 +1,3 @@
+# aviris module
+
+::: hypercoast.aviris

--- a/docs/examples/aviris.ipynb
+++ b/docs/examples/aviris.ipynb
@@ -1,0 +1,149 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/HyperCoast/blob/main/docs/examples/aviris.ipynb)\n",
+    "\n",
+    "# Visualizing AVIRIS data interactively with HyperCoast\n",
+    "\n",
+    "This notebook demonstrates how to visualize [AVIRIS](https://aviris.jpl.nasa.gov) hyperspectral data interactively with HyperCoast. For more information about AVIRIS, please visit the links below:\n",
+    "\n",
+    "- https://aviris.jpl.nasa.gov/\n",
+    "- https://aviris.jpl.nasa.gov/dataportal/\n",
+    "- https://popo.jpl.nasa.gov/mmgis-aviris/?s=ujooa\n",
+    "- https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1988\n",
+    "- https://github.com/ornldaac/deltax_workshop_2022/tree/main \n",
+    "- https://github.com/jjmcnelis/aviris-ng-notebooks/tree/master"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"hypercoast[extra]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hypercoast"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download sample dataset from Access the AVIRIS-NG L2 Surface Reflectance product page via ORNL DAAC\n",
+    "https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1988\n",
+    "\n",
+    "![](https://i.imgur.com/3hwihRA.png)\n",
+    "\n",
+    "Download `ang20210401t150456_rfl_v2z1.zip` and unzip it.\n",
+    "\n",
+    "![](https://i.imgur.com/16jcmxd.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The dataset contains 2 files: `ang20210401t150456_rfl_v2z1` and `ang20210401t150456_rfl_v2z1.hdr`. We will use the `ang20210401t150456_rfl_v2z1` file in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filepath = \"ang20210401t150456_rfl_v2z1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read the AVIRIS data as an `xarray.Dataset` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = hypercoast.read_aviris(filepath)\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an interactive map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add the AVIRIS data to the map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_aviris(ds, wavelengths=[1000, 700, 400], vmin=0, vmax=0.2)\n",
+    "m.add(\"spectral\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/RdegGqx.gif)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hyper",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,12 +13,20 @@
 
 ## Features
 
--   Interactive visualization and analysis of hyperspectral data, such as [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf), [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001)
+-   Interactive visualization and analysis of hyperspectral data, such as [AVIRIS](https://aviris.jpl.nasa.gov), [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf), [EMIT](https://earth.jpl.nasa.gov/emit), [PACE](https://pace.gsfc.nasa.gov), [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001)
 -   Interactive visualization of NASA [ECOSTRESS](https://ecostress.jpl.nasa.gov) data
 -   Interactive extraction and visualization of spectral signatures
 -   Saving spectral signatures as CSV files
 
 ## Demos
+
+-   Visualizing NASA [AVIRIS](https://aviris.jpl.nasa.gov) hyperspectral data interactively
+
+![AVIRIS](https://i.imgur.com/RdegGqx.gif)
+
+-   Visualizing [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf) hyperspectral data interactively
+
+![DESIS](https://i.imgur.com/PkwOPN5.gif)
 
 -   Visualizing NASA [EMIT](https://earth.jpl.nasa.gov/emit) hyperspectral data interactively
 
@@ -27,10 +35,6 @@
 -   Visualizing NASA [PACE](https://pace.gsfc.nasa.gov) hyperspectral data interactively
 
 ![PACE](https://i.imgur.com/HBMjW6o.gif)
-
--   Visualizing [DESIS](https://www.earthdata.nasa.gov/s3fs-public/imported/DESIS_TCloud_Mar0421.pdf) hyperspectral data interactively
-
-![DESIS](https://i.imgur.com/PkwOPN5.gif)
 
 -   Visualizing [NEON AOP](https://data.neonscience.org/data-products/DP3.30006.001) hyperspectral data interactively
 

--- a/hypercoast/aviris.py
+++ b/hypercoast/aviris.py
@@ -1,0 +1,167 @@
+"""This module contains functions to read and process NASA AVIRIS hyperspectral data.
+More info about the data can be found at https://aviris.jpl.nasa.gov.
+The source code is adapted from https://bit.ly/4bRCgqs. Credit goes to the
+original authors.
+"""
+
+import rioxarray
+import numpy as np
+import xarray as xr
+from typing import List, Union, Dict, Optional, Tuple, Any
+from .common import convert_coords
+
+
+def read_aviris(
+    filepath: str,
+    wavelengths: Optional[List[float]] = None,
+    method: str = "nearest",
+    **kwargs: Any,
+) -> xr.Dataset:
+    """
+    Reads NASA AVIRIS hyperspectral data and returns an xarray dataset.
+
+    Args:
+        filepath (str): The path to the AVIRIS data.
+        wavelengths (List[float], optional): The wavelengths to select. If None,
+            all wavelengths are selected. Defaults to None.
+        method (str, optional): The method to use for selection. Defaults to
+            "nearest".
+        **kwargs (Any): Additional arguments to pass to the selection method.
+
+    Returns:
+        xr.Dataset: The dataset containing the reflectance data.
+    """
+
+    if filepath.endswith(".hdr"):
+        filepath = filepath.replace(".hdr", "")
+
+    ds = xr.open_dataset(filepath, engine="rasterio")
+
+    wavelength = ds["wavelength"].values.tolist()
+    wavelength = [round(num, 2) for num in wavelength]
+
+    cols = ds.x.size
+    rows = ds.y.size
+
+    geo_transform = ds.rio.transform()
+    geo_transform = list(geo_transform)[:6]
+
+    # get the raster geotransform as its component parts
+    xres, xrot, xmin, yrot, yres, ymax = geo_transform
+
+    # generate coordinate arrays
+    xarr = np.array([xmin + i * xres for i in range(0, cols)])
+    yarr = np.array([ymax + i * yres for i in range(0, rows)])
+
+    ds["y"] = xr.DataArray(
+        data=yarr,
+        dims=("y"),
+        name="y",
+        attrs=dict(
+            units="m",
+            standard_name="projection_y_coordinate",
+            long_name="y coordinate of projection",
+        ),
+    )
+
+    ds["x"] = xr.DataArray(
+        data=xarr,
+        dims=("x"),
+        name="x",
+        attrs=dict(
+            units="m",
+            standard_name="projection_x_coordinate",
+            long_name="x coordinate of projection",
+        ),
+    )
+
+    global_atts = ds.attrs
+    global_atts["Conventions"] = "CF-1.6"
+    ds.attrs = dict(
+        units="unitless",
+        _FillValue=-9999,
+        grid_mapping="crs",
+        standard_name="reflectance",
+        long_name="atmospherically corrected surface reflectance",
+    )
+    ds.attrs.update(global_atts)
+
+    ds = ds.transpose("y", "x", "band")
+    ds = ds.drop_vars(["wavelength", "xc", "yc"])
+    ds = ds.rename({"band": "wavelength", "band_data": "reflectance"})
+    ds.coords["wavelength"] = wavelength
+    ds.attrs["crs"] = ds.rio.crs.to_string()
+
+    if wavelengths is not None:
+        ds = ds.sel(wavelength=wavelengths, method=method, **kwargs)
+    return ds
+
+
+def aviris_to_image(
+    dataset: Union[xr.Dataset, str],
+    wavelengths: Optional[np.ndarray] = None,
+    method: str = "nearest",
+    output: Optional[str] = None,
+    **kwargs: Any,
+):
+    """
+    Converts an AVIRIS dataset to an image.
+
+    Args:
+        dataset (Union[xr.Dataset, str]): The dataset containing the AVIRIS data
+            or the file path to the dataset.
+        wavelengths (np.ndarray, optional): The specific wavelengths to select. If None, all
+            wavelengths are selected. Defaults to None.
+        method (str, optional): The method to use for data interpolation.
+            Defaults to "nearest".
+        output (str, optional): The file path where the image will be saved. If
+            None, the image will be returned as a PIL Image object. Defaults to None.
+        **kwargs (Any): Additional keyword arguments to be passed to
+            `leafmap.array_to_image`.
+
+    Returns:
+        Optional[rasterio.Dataset]: The image converted from the dataset. If
+            `output` is provided, the image will be saved to the specified file
+            and the function will return None.
+    """
+    from leafmap import array_to_image
+
+    if isinstance(dataset, str):
+        dataset = read_aviris(dataset, method=method)
+
+    if wavelengths is not None:
+        dataset = dataset.sel(wavelength=wavelengths, method=method)
+
+    return array_to_image(
+        dataset["reflectance"],
+        output=output,
+        transpose=False,
+        dtype=np.float32,
+        **kwargs,
+    )
+
+
+def extract_aviris(ds, lat, lon):
+    """
+    Extracts NEON AOP data from a given xarray Dataset.
+
+    Args:
+        ds (xarray.Dataset): The dataset containing the NEON AOP data.
+        lat (float): The latitude of the point to extract.
+        lon (float): The longitude of the point to extract.
+
+    Returns:
+        xarray.DataArray: The extracted data.
+    """
+
+    crs = ds.attrs["crs"]
+
+    x, y = convert_coords([[lat, lon]], "epsg:4326", crs)[0]
+
+    values = ds.sel(x=x, y=y, method="nearest")["reflectance"].values
+
+    da = xr.DataArray(
+        values, dims=["wavelength"], coords={"wavelength": ds.coords["wavelength"]}
+    )
+
+    return da

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -571,6 +571,7 @@ class Map(leafmap.Map):
             **kwargs,
         )
 
+        xds.attrs["bounds"] = self.cog_layer_dict[layer_name]["bounds"]
         self.cog_layer_dict[layer_name]["xds"] = xds
         self.cog_layer_dict[layer_name]["hyper"] = "AVIRIS"
 

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -4,6 +4,7 @@ import ipyleaflet
 import leafmap
 import xarray as xr
 import numpy as np
+from .aviris import *
 from .common import *
 from .desis import *
 from .emit import *
@@ -490,6 +491,88 @@ class Map(leafmap.Map):
 
         self.cog_layer_dict[layer_name]["xds"] = xds
         self.cog_layer_dict[layer_name]["hyper"] = "NEON"
+
+    def add_aviris(
+        self,
+        source,
+        wavelengths=None,
+        indexes=None,
+        colormap=None,
+        vmin=0,
+        vmax=0.5,
+        nodata=np.nan,
+        attribution=None,
+        layer_name="AVIRIS",
+        zoom_to_layer=True,
+        visible=True,
+        array_args={},
+        method="nearest",
+        **kwargs,
+    ):
+        """Add an AVIRIS dataset to the map.
+            If you are using this function in JupyterHub on a remote server
+                (e.g., Binder, Microsoft Planetary Computer) and
+            if the raster does not render properly, try installing
+                jupyter-server-proxy using `pip install jupyter-server-proxy`,
+            then running the following code before calling this function. For
+                more info, see https://bit.ly/3JbmF93.
+
+            import os
+            os.environ['LOCALTILESERVER_CLIENT_PREFIX'] = 'proxy/{port}'
+
+        Args:
+            source (str): The path to the AVIRIS file.
+            indexes (int, optional): The band(s) to use. Band indexing starts
+                at 1. Defaults to None.
+            colormap (str, optional): The name of the colormap from `matplotlib`
+                to use when plotting a single band. See
+                    https://matplotlib.org/stable/gallery/color/colormap_reference.html.
+                    Default is greyscale.
+            vmin (float, optional): The minimum value to use when colormapping
+                the palette when plotting a single band. Defaults to 0.
+            vmax (float, optional): The maximum value to use when colormapping
+                the palette when plotting a single band. Defaults to 0.5.
+            nodata (float, optional): The value from the band to use to
+                interpret as not valid data. Defaults to np.nan.
+            attribution (str, optional): Attribution for the source raster. This
+                defaults to a message about it being a local file.. Defaults to None.
+            layer_name (str, optional): The layer name to use. Defaults to 'NEON'.
+            zoom_to_layer (bool, optional): Whether to zoom to the extent of the
+                layer. Defaults to True.
+            visible (bool, optional): Whether the layer is visible. Defaults
+                to True.
+            array_args (dict, optional): Additional arguments to pass to
+                `array_to_memory_file` when reading the raster. Defaults to {}.
+            method (str, optional): The method to use for data interpolation.
+                Defaults to "nearest".
+        """
+
+        xds = None
+        if isinstance(source, str):
+
+            xds = read_aviris(source)
+            source = neon_to_image(xds, wavelengths=wavelengths, method=method)
+        elif isinstance(source, xr.Dataset):
+            xds = source
+            source = aviris_to_image(xds, wavelengths=wavelengths, method=method)
+
+        self.add_raster(
+            source,
+            indexes=indexes,
+            colormap=colormap,
+            vmin=vmin,
+            vmax=vmax,
+            nodata=nodata,
+            attribution=attribution,
+            layer_name=layer_name,
+            zoom_to_layer=zoom_to_layer,
+            visible=visible,
+            array_args=array_args,
+            **kwargs,
+        )
+
+        self.cog_layer_dict[layer_name]["xds"] = xds
+        self.cog_layer_dict[layer_name]["hyper"] = "AVIRIS"
 
     def set_plot_options(
         self,

--- a/hypercoast/ui.py
+++ b/hypercoast/ui.py
@@ -13,6 +13,7 @@ from ipyfilechooser import FileChooser
 from .pace import extract_pace
 from .desis import extract_desis
 from .neon import extract_neon
+from .aviris import extract_aviris
 
 
 class SpectralWidget(widgets.HBox):
@@ -192,6 +193,9 @@ class SpectralWidget(widgets.HBox):
 
                 elif self._host_map.cog_layer_dict[layer_name]["hyper"] == "NEON":
                     da = extract_neon(ds, lat, lon)
+
+                elif self._host_map.cog_layer_dict[layer_name]["hyper"] == "AVIRIS":
+                    da = extract_aviris(ds, lat, lon)
 
                 self._host_map._spectral_data[f"({lat:.4f} {lon:.4f})"] = da.values
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,8 @@ plugins:
           execute: True
           allow_errors: false
           ignore: ["conf.py"]
-          execute_ignore: ["search_data.ipynb", "ecostress.ipynb"]
+          execute_ignore:
+              ["search_data.ipynb", "ecostress.ipynb", "aviris.ipynb"]
 
 markdown_extensions:
     - admonition
@@ -81,6 +82,7 @@ nav:
     - Report Issues: https://github.com/opengeos/HyperCoast/issues
     - Examples:
           - examples/search_data.ipynb
+          - examples/aviris.ipynb
           - examples/desis.ipynb
           - examples/emit.ipynb
           - examples/neon.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
           - examples/pace.ipynb
           - examples/ecostress.ipynb
     - API Reference:
+          - aviris module: aviris.md
           - common module: common.md
           - desis module: desis.md
           - emit module: emit.md


### PR DESCRIPTION
This PR adds support for AVIRIS data. 

```python
import hypercoast
filepath = "ang20210401t150456_rfl_v2z1"
m = hypercoast.Map()
m.add_aviris(ds, wavelengths=[1000, 700, 400], vmin=0, vmax=0.2)
m
```
![](https://i.imgur.com/lg0qrI4.png)