### PR TITLE
Refactor read_neon() function to support generalized NEON data reading

### DIFF
--- a/hypercoast/neon.py
+++ b/hypercoast/neon.py
@@ -60,15 +60,17 @@ def read_neon(
         xr.Dataset: The dataset containing the reflectance data.
     """
     with h5py.File(filepath, "r") as f:
-        # Extract site code dynamically from NEON HDF file metadata 
+        # Extract site code dynamically from NEON HDF file metadata
         # At the root of `keys` NEON stores the site code, which is the `root` folder at the [0] index of object `keys`
-        site_code = list(f.keys())[0] 
-        
+        site_code = list(f.keys())[0]
+
         # Access the reflectance data using the site code
         site_refl = f[site_code]["Reflectance"]
-        
+
         # Extract wavelengths
-        wavelengths_list = site_refl["Metadata"]["Spectral_Data"]["Wavelength"][()].tolist()
+        wavelengths_list = site_refl["Metadata"]["Spectral_Data"]["Wavelength"][
+            ()
+        ].tolist()
         wavelengths_list = [round(num, 2) for num in wavelengths_list]
 
         # Extract EPSG code
@@ -76,9 +78,11 @@ def read_neon(
         epsg_code_number = int(epsg_code.decode("utf-8"))
 
         # Extract map info
-        mapInfo_string = site_refl["Metadata"]["Coordinate_System"]["Map_Info"][()].decode("utf-8")
+        mapInfo_string = site_refl["Metadata"]["Coordinate_System"]["Map_Info"][
+            ()
+        ].decode("utf-8")
         mapInfo_split = mapInfo_string.split(",")
-        
+
         res = float(mapInfo_split[5]), float(mapInfo_split[6])
 
         # Extract reflectance array and shape
@@ -127,6 +131,7 @@ def read_neon(
         dataset.attrs = dataset["reflectance"].attrs
 
     return dataset
+
 
 def neon_to_image(
     dataset: Union[xr.Dataset, str],

--- a/hypercoast/neon.py
+++ b/hypercoast/neon.py
@@ -59,74 +59,74 @@ def read_neon(
     Returns:
         xr.Dataset: The dataset containing the reflectance data.
     """
-    f = h5py.File(filepath, "r")
+    with h5py.File(filepath, "r") as f:
+        # Extract site code dynamically from NEON HDF file metadata 
+        # At the root of `keys` NEON stores the site code, which is the `root` folder at the [0] index of object `keys`
+        site_code = list(f.keys())[0] 
+        
+        # Access the reflectance data using the site code
+        site_refl = f[site_code]["Reflectance"]
+        
+        # Extract wavelengths
+        wavelengths_list = site_refl["Metadata"]["Spectral_Data"]["Wavelength"][()].tolist()
+        wavelengths_list = [round(num, 2) for num in wavelengths_list]
 
-    serc_refl = f["SERC"]["Reflectance"]
-    wavelengths = serc_refl["Metadata"]["Spectral_Data"]["Wavelength"][()].tolist()
-    wavelengths = [round(num, 2) for num in wavelengths]
+        # Extract EPSG code
+        epsg_code = site_refl["Metadata"]["Coordinate_System"]["EPSG Code"][()]
+        epsg_code_number = int(epsg_code.decode("utf-8"))
 
-    epsg_code = serc_refl["Metadata"]["Coordinate_System"]["EPSG Code"][()]
-    epsg_code_number = int(epsg_code.decode("utf-8"))
+        # Extract map info
+        mapInfo_string = site_refl["Metadata"]["Coordinate_System"]["Map_Info"][()].decode("utf-8")
+        mapInfo_split = mapInfo_string.split(",")
+        
+        res = float(mapInfo_split[5]), float(mapInfo_split[6])
 
-    serc_mapInfo = serc_refl["Metadata"]["Coordinate_System"]["Map_Info"]
-    mapInfo_string = serc_mapInfo[()].decode("utf-8")  # read in as string
-    mapInfo_split = mapInfo_string.split(",")
+        # Extract reflectance array and shape
+        site_reflArray = site_refl["Reflectance_Data"]
+        refl_shape = site_reflArray.shape
 
-    res = float(mapInfo_split[5]), float(mapInfo_split[6])
+        # Calculate coordinates
+        xMin = float(mapInfo_split[3])
+        yMax = float(mapInfo_split[4])
 
-    serc_reflArray = serc_refl["Reflectance_Data"]
-    refl_shape = serc_reflArray.shape
+        xMax = xMin + (refl_shape[1] * res[0])
+        yMin = yMax - (refl_shape[0] * res[1])
 
-    # Extract the upper left-hand corner coordinates from mapInfo
-    xMin = float(mapInfo_split[3])
-    yMax = float(mapInfo_split[4])
+        # Handle scale factor and no-data value
+        scaleFactor = site_reflArray.attrs["Scale_Factor"]
+        noDataValue = site_reflArray.attrs["Data_Ignore_Value"]
 
-    # Calculate the xMax and yMin values from the dimensions
-    xMax = xMin + (
-        refl_shape[1] * res[0]
-    )  # xMax = left edge + (# of columns * x pixel resolution)
-    yMin = yMax - (
-        refl_shape[0] * res[1]
-    )  # yMin = top edge - (# of rows * y pixel resolution)
+        da = site_reflArray[:, :, :].astype(float)
+        da[da == int(noDataValue)] = np.nan
+        da[da < 0] = np.nan
+        da[da > 10000] = np.nan
+        da = da / scaleFactor
 
-    # serc_ext = (xMin, xMax, yMin, yMax)
+        coords = {
+            "y": np.linspace(yMax, yMin, da.shape[0]),
+            "x": np.linspace(xMin, xMax, da.shape[1]),
+            "wavelength": wavelengths_list,
+        }
 
-    # View and apply scale factor and data ignore value
-    scaleFactor = serc_reflArray.attrs["Scale_Factor"]
-    noDataValue = serc_reflArray.attrs["Data_Ignore_Value"]
+        xda = xr.DataArray(
+            da,
+            coords=coords,
+            dims=["y", "x", "wavelength"],
+            attrs={
+                "scale_factor": scaleFactor,
+                "no_data_value": noDataValue,
+                "crs": f"EPSG:{epsg_code_number}",
+                "transform": (res[0], 0.0, xMin, 0.0, -res[1], yMax),
+            },
+        )
 
-    da = serc_reflArray[:, :, :].astype(float)
-    da[da == int(noDataValue)] = np.nan
-    da[da < 0] = np.nan
-    da[da > 10000] = np.nan
-    da = da / scaleFactor
+        if wavelengths is not None:
+            xda = xda.sel(wavelength=wavelengths, method=method, **kwargs)
 
-    coords = {
-        "y": np.linspace(yMax, yMin, da.shape[0]),
-        "x": np.linspace(xMin, xMax, da.shape[1]),
-        "wavelength": wavelengths,
-    }
-
-    xda = xr.DataArray(
-        da,
-        coords=coords,
-        dims=["y", "x", "wavelength"],
-        attrs={
-            "scale_factor": scaleFactor,
-            "no_data_value": noDataValue,
-            "crs": f"EPSG:{epsg_code_number}",
-            "transform": (res[0], 0.0, xMin, 0.0, -res[1], yMax),
-        },
-    )
-
-    if wavelengths is not None:
-        xda = xda.sel(wavelength=wavelengths, method=method, **kwargs)
-
-    dataset = xda.to_dataset(name="reflectance")
-    dataset.attrs = dataset["reflectance"].attrs
+        dataset = xda.to_dataset(name="reflectance")
+        dataset.attrs = dataset["reflectance"].attrs
 
     return dataset
-
 
 def neon_to_image(
     dataset: Union[xr.Dataset, str],


### PR DESCRIPTION
The read_neon() function has been enhanced to provide generalized support for reading NEON AOP hyperspectral HDF5 files across different sites. Previously, the function was hardcoded to access data using a fixed site acronym (SERC). This enhancement should allow the function to dynamically adapt to different files without using a fixed site acronym.