### PR TITLE
Add xlim parameter for the spectral widget

### DIFF
--- a/docs/examples/emit.ipynb
+++ b/docs/examples/emit.ipynb
@@ -75,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Visualize the data interactively with HyperCoast."
+    "Visualize the data interactively with HyperCoast. By default, the plot will show all the bands in the dataset. "
    ]
   },
   {
@@ -89,6 +89,42 @@
     "m.add_emit(dataset, wavelengths=[1000, 600, 500], vmin=0, vmax=0.3, layer_name=\"EMIT\")\n",
     "m.add(\"spectral\")\n",
     "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To visualize a certain wavelength range, you can specify the `xlim` parameter as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m.add_basemap(\"SATELLITE\")\n",
+    "m.add_emit(dataset, wavelengths=[1000, 600, 500], vmin=0, vmax=0.3, layer_name=\"EMIT\")\n",
+    "m.add(\"spectral\", xlim=(400, 1200))\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To access the selected spectral profiles from the mouse clicked location, use the `Map.spectral_to_df()` method to convert the spectral profiles to a pandas DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.spectral_to_df()"
    ]
   },
   {

--- a/hypercoast/common.py
+++ b/hypercoast/common.py
@@ -29,7 +29,7 @@ def github_raw_url(url: str) -> str:
 def download_file(
     url: Optional[str] = None,
     output: Optional[str] = None,
-    quiet: Optional[bool] = False,
+    quiet: Optional[bool] = True,
     proxy: Optional[str] = None,
     speed: Optional[float] = None,
     use_cookies: Optional[bool] = True,
@@ -46,7 +46,7 @@ def download_file(
     Args:
         url (str, optional): Google Drive URL is also supported. Defaults to None.
         output (str, optional): Output filename. Default is basename of URL.
-        quiet (bool, optional): Suppress terminal output. Default is False.
+        quiet (bool, optional): Suppress terminal output. Default is True.
         proxy (str, optional): Proxy. Defaults to None.
         speed (float, optional): Download byte size per second (e.g., 256KB/s = 256 * 1024). Defaults to None.
         use_cookies (bool, optional): Flag to use cookies. Defaults to True.

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -39,10 +39,16 @@ class Map(leafmap.Map):
         """
         super().__init__(**kwargs)
 
-    def add(self, obj, position="topright", **kwargs):
+    def add(self, obj, position="topright", xlim=None, ylim=None, **kwargs):
         """Add a layer to the map.
 
         Args:
+            obj (str or object): The name of the layer or a layer object.
+            position (str, optional): The position of the layer widget. Can be
+                'topright', 'topleft', 'bottomright', or 'bottomleft'. Defaults
+                to 'topright'.
+            xlim (tuple, optional): The x-axis limits of the plot. Defaults to None.
+            ylim (tuple, optional): The y-axis limits of the plot. Defaults to None.
             **kwargs: Arbitrary keyword arguments that are passed to the parent
                 class's add_layer method.
         """
@@ -50,7 +56,7 @@ class Map(leafmap.Map):
         if isinstance(obj, str):
             if obj == "spectral":
 
-                SpectralWidget(self, position=position, **kwargs)
+                SpectralWidget(self, position=position, xlim=xlim, ylim=ylim, **kwargs)
                 self.set_plot_options(add_marker_cluster=True)
             else:
                 super().add(obj, **kwargs)

--- a/hypercoast/ui.py
+++ b/hypercoast/ui.py
@@ -35,13 +35,18 @@ class SpectralWidget(widgets.HBox):
         _spectral_control (ipyleaflet.WidgetControl): The control for the spectral widget.
     """
 
-    def __init__(self, host_map, stack=True, position="topright"):
+    def __init__(
+        self, host_map, stack=True, position="topright", xlim=None, ylim=None, **kwargs
+    ):
         """
         Initializes a new instance of the SpectralWidget class.
 
         Args:
             host_map (Map): The map to host the widget.
+            stack (bool, optional): Whether to stack the plots. Defaults to True.
             position (str, optional): The position of the widget on the map. Defaults to "topright".
+            xlim (tuple, optional): The x-axis limits. Defaults to None.
+            ylim (tuple, optional): The y-axis limits. Defaults to None.
         """
         self._host_map = host_map
         self.on_close = None
@@ -272,6 +277,10 @@ class SpectralWidget(widgets.HBox):
 
                 plt.xlabel(xlabel)
                 plt.ylabel(ylabel)
+                if xlim:
+                    plt.xlim(xlim[0], xlim[1])
+                if ylim:
+                    plt.ylim(ylim[0], ylim[1])
 
                 if not self._show_plot:
                     with self._output_widget:


### PR DESCRIPTION
Add the `xlim` parameter for customizing the wavelength range for the spectral widget. 

```python
m = hypercoast.Map()
m.add_basemap("SATELLITE")
m.add_emit(dataset, wavelengths=[1000, 600, 500], vmin=0, vmax=0.3, layer_name="EMIT")
m.add("spectral", xlim=(400, 1200))
m
```

![image](https://github.com/user-attachments/assets/a15b720c-4a39-4ee5-a8ed-c1d6b02aef1b)
