### PR TITLE
Remove AVIRIS image bounds

### DIFF
--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -664,7 +664,6 @@ class Map(leafmap.Map):
             **kwargs,
         )
 
-        xds.attrs["bounds"] = self.cog_layer_dict[layer_name]["bounds"]
         self.cog_layer_dict[layer_name]["xds"] = xds
         self.cog_layer_dict[layer_name]["hyper"] = "AVIRIS"
         self._update_band_names(layer_name, wavelengths)


### PR DESCRIPTION
Fix #94. The AVIRIS image bounds is no longer needed for visualization. Removing it. 