### PR TITLE
Add spectral_to_gdf method

### DIFF
--- a/docs/examples/emit.ipynb
+++ b/docs/examples/emit.ipynb
@@ -115,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To access the selected spectral profiles from the mouse clicked location, use the `Map.spectral_to_df()` method to convert the spectral profiles to a pandas DataFrame."
+    "To access the selected spectral profiles from the mouse clicked location as a Pandas DataFrame, use the `Map.spectral_to_df()` method."
    ]
   },
   {
@@ -125,6 +125,22 @@
    "outputs": [],
    "source": [
     "m.spectral_to_df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To access the selected spectral profiles from the mouse clicked location as a GeoPandas GeoDataFrame, use the `Map.spectral_to_gdf()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.spectral_to_gdf()"
    ]
   },
   {


### PR DESCRIPTION
This PR adds the `Map.spectral_to_gdf()` method for exporting spectral profiles as a GeoDataFrame. 

Address the comments in https://github.com/openjournals/joss-reviews/issues/7025#issuecomment-2297757431 @alexgleith 

![Screenshot_20240820_001851](https://github.com/user-attachments/assets/6fae03a1-ed3f-4100-8e79-e3a1ffdca5fa)
![Screenshot_20240820_001958](https://github.com/user-attachments/assets/43a00dd6-b836-498d-b6e9-579834866ce7)
