### PR TITLE
Update README with conda-forge channel instructions

### DIFF
--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -28,6 +28,8 @@ Before using the plugin, please create a new conda environment to install QGIS a
 ```bash
 conda create -n geo python=3.12
 conda activate geo
+conda config --add channels conda-forge
+conda config --set channel_priority strict
 conda install -c conda-forge qgis hypercoast
 ```
 


### PR DESCRIPTION
In reference to Issue #216

In the README, instead of:
```
conda create -n geo python=3.12
conda activate geo
conda install -c conda-forge qgis hypercoast
```
Try:
```
conda create -n geo python=3.12
conda activate geo
conda config --add channels conda-forge
conda config --set channel_priority strict
conda install -c conda-forge qgis hypercoast
```
This addition to the README.md may help other users that have a default conda configuration.