### PR TITLE
Fix security warning, bare excepts, duplicate import, and add Python 3.13 classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ If you find HyperCoast useful in your research, please consider citing the follo
 -   Visualizing ERA5 temperature data in 3D
 -   Interactive slicing and thresholding of hyperspectral data in 3D
 -   Saving spectral signatures as CSV files
--
 
 ## QGIS Plugin
 

--- a/hypercoast/common.py
+++ b/hypercoast/common.py
@@ -5,6 +5,7 @@
 """The common module contains common functions and classes used by the other modules."""
 
 import os
+import sys
 import leafmap
 import xarray as xr
 from typing import List, Union, Dict, Optional, Tuple, Any
@@ -109,6 +110,12 @@ def download_file(
             else:
                 mode = "r"
 
+            # Use filter='data' on Python 3.12+ to avoid DeprecationWarning
+            # and mitigate path traversal risks (CVE-2007-4559).
+            tar_kwargs = {}
+            if sys.version_info >= (3, 12):
+                tar_kwargs["filter"] = "data"
+
             with tarfile.open(output, mode) as tar_ref:
                 if not quiet:
                     print("Extracting files...")
@@ -117,9 +124,9 @@ def download_file(
                     output = os.path.join(out_dir, basename)
                     if not os.path.exists(output):
                         os.makedirs(output)
-                    tar_ref.extractall(output)
+                    tar_ref.extractall(output, **tar_kwargs)
                 else:
-                    tar_ref.extractall(os.path.dirname(output))
+                    tar_ref.extractall(os.path.dirname(output), **tar_kwargs)
 
     return os.path.abspath(output)
 
@@ -854,8 +861,14 @@ def download_acolite(outdir: str = ".", platform: Optional[str] = None) -> str:
         return
 
     # Unzip the file
+    # Use filter='data' on Python 3.12+ to avoid DeprecationWarning
+    # and mitigate path traversal risks (CVE-2007-4559).
+    tar_kwargs = {}
+    if sys.version_info >= (3, 12):
+        tar_kwargs["filter"] = "data"
+
     with tarfile.open(file_name, "r:gz") as tar:
-        tar.extractall(path=outdir)
+        tar.extractall(path=outdir, **tar_kwargs)
 
     print(f"Extracted to {extracted_path}")
     return extracted_path

--- a/hypercoast/emit_utils/data_loading.py
+++ b/hypercoast/emit_utils/data_loading.py
@@ -202,7 +202,7 @@ def load_real_test_Robust(
             wl = float(col)
             rrs_wavelengths.append(wl)
             rrs_cols.append(col)
-        except:
+        except ValueError:
             continue
 
     band_cols = []

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -21,7 +21,6 @@ from .emit import (
     plot_emit,
     viz_emit,
     emit_to_netcdf,
-    emit_to_image,
 )
 from .neon import neon_to_image, read_neon
 from .pace import (

--- a/hypercoast/moe_vae/data_loading.py
+++ b/hypercoast/moe_vae/data_loading.py
@@ -217,7 +217,7 @@ def load_real_test_Robust(
             wl = float(col)
             rrs_wavelengths.append(wl)
             rrs_cols.append(col)
-        except:
+        except ValueError:
             continue
 
     band_cols = []

--- a/hypercoast/tanager.py
+++ b/hypercoast/tanager.py
@@ -255,7 +255,7 @@ def grid_tanager(
                 inside_hull = hull_path.contains_points(grid_points).reshape(
                     grid_lat_2d.shape
                 )
-            except:
+            except Exception:
                 # Fallback: use simple bounding box
                 inside_hull = (
                     (grid_lat_2d >= valid_lat.min())

--- a/hypercoast/ui.py
+++ b/hypercoast/ui.py
@@ -228,7 +228,7 @@ class SpectralWidget(widgets.HBox):
                 elif self._host_map.cog_layer_dict[layer_name]["hyper"] == "PACE":
                     try:
                         da = extract_pace(ds, lat, lon)
-                    except:
+                    except Exception:
                         da = xr.DataArray(
                             np.full(len(ds["wavelength"]), np.nan),
                             dims=["wavelength"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.entry-points."console_scripts"]


### PR DESCRIPTION
## Summary

This PR addresses several code quality and security issues found during a codebase review.

### Changes

**Security fix: `tarfile.extractall()` without filter (CVE-2007-4559)**
- Added `filter='data'` parameter to `tarfile.extractall()` calls in `common.py` for Python 3.12+
- Without this, Python 3.12+ emits a `DeprecationWarning`, and Python 3.14 will change the default behavior
- The `'data'` filter mitigates directory traversal attacks via malicious tar archives
- Version-gated with `sys.version_info >= (3, 12)` to maintain backward compatibility

**Replace bare `except:` clauses**
- `tanager.py`: Changed `except:` to `except Exception:` in ConvexHull fallback
- `ui.py`: Changed `except:` to `except Exception:` in PACE spectral extraction
- `emit_utils/data_loading.py`: Changed `except:` to `except ValueError:` in wavelength parsing
- `moe_vae/data_loading.py`: Changed `except:` to `except ValueError:` in wavelength parsing
- Bare except clauses catch `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`, which should propagate

**Remove duplicate import**
- `hypercoast.py`: Removed duplicate `emit_to_image` in the import from `.emit`

**README cleanup**
- Removed a dangling empty bullet point (`-`) at the end of the features list

**Add Python 3.13 classifier**
- Added `Programming Language :: Python :: 3.13` to `pyproject.toml` classifiers

### Testing
- All modified files compile successfully
- `import hypercoast` works without errors