### PR TITLE
Fix docs.yml build env to avoid localtileserver pkg_resources regression

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,19 +35,24 @@ jobs:
                   uv pip install --find-links https://girder.github.io/large_image_wheels GDAL pyproj
                   uv pip install pytest
                   uv pip install -r requirements_dev.txt
+                  # Enforce a modern localtileserver build (no pkg_resources import)
+                  uv pip uninstall localtileserver || true
+                  uv pip install --upgrade "localtileserver==0.10.7" "setuptools<81"
+                  .venv/bin/python -c "import importlib.metadata as m; print('localtileserver', m.version('localtileserver')); print('setuptools', m.version('setuptools'))"
+                  .venv/bin/python -c "import localtileserver; print('localtileserver module:', localtileserver.__file__)"
 
             - name: Test import
               run: |
-                  uv run python -c "import hypercoast; print('hypercoast import successful')"
-                  uv run python -c "from osgeo import gdal; print('gdal import successful')"
-                  uv run gdalinfo --version
+                  .venv/bin/python -c "import hypercoast; print('hypercoast import successful')"
+                  .venv/bin/python -c "from osgeo import gdal; print('gdal import successful')"
+                  .venv/bin/gdalinfo --version
 
             - name: Running pytest
               run: |
-                  uv run pytest . --verbose
+                  .venv/bin/pytest . --verbose
 
             - name: Install mkdocs
-              run: uv run mkdocs gh-deploy --force
+              run: .venv/bin/mkdocs gh-deploy --force
               env:
                   EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
                   EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}


### PR DESCRIPTION
## Summary
Apply the same CI environment hardening used in `docs-build.yml` to `docs.yml`.

## Changes
- In `docs.yml`:
  - enforce `localtileserver==0.10.7` and `setuptools<81`
  - print resolved versions/module path for diagnostics
  - switch from `uv run ...` to direct `.venv/bin/...` commands to avoid uv resync overriding pinned deps

## Why
The docs deployment workflow was still using the old setup pattern and hitting the same `pkg_resources` import error path seen earlier.
