### PR TITLE
Add crop parameter to image_cube for nodata borders

### DIFF
--- a/docs/examples/wyvern.ipynb
+++ b/docs/examples/wyvern.ipynb
@@ -147,30 +147,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 3D Image Cube\n",
-    "\n",
-    "Create a 3D image cube from the Wyvern dataset using PyVista."
-   ]
+   "source": "## 3D Image Cube\n\nCreate a 3D image cube from the Wyvern dataset using PyVista. Use `crop` to trim edge pixels and `nodata` to mask irregular nodata borders as transparent."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "cube = hypercoast.image_cube(\n",
-    "    dataset,\n",
-    "    variable=\"reflectance\",\n",
-    "    cmap=\"jet\",\n",
-    "    clim=(0, 100),\n",
-    "    crop=100,\n",
-    "    rgb_wavelengths=[679, 570, 480],\n",
-    "    rgb_gamma=1.0,\n",
-    "    title=\"Reflectance\",\n",
-    ")\n",
-    "cube.show()"
-   ]
+   "source": "cube = hypercoast.image_cube(\n    dataset,\n    variable=\"reflectance\",\n    cmap=\"jet\",\n    clim=(0, 100),\n    crop=100,\n    nodata=0,\n    rgb_wavelengths=[679, 570, 480],\n    rgb_gamma=1.0,\n    title=\"Reflectance\",\n)\ncube.show()"
   },
   {
    "cell_type": "markdown",
@@ -184,20 +168,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "cube = hypercoast.image_cube(\n",
-    "    dataset,\n",
-    "    variable=\"reflectance\",\n",
-    "    cmap=\"jet\",\n",
-    "    clim=(0, 100),\n",
-    "    crop=100,\n",
-    "    rgb_wavelengths=[679, 570, 480],\n",
-    "    rgb_gamma=1.0,\n",
-    "    title=\"Reflectance\",\n",
-    "    widget=\"slice\",\n",
-    ")\n",
-    "cube.show()"
-   ]
+   "source": "cube = hypercoast.image_cube(\n    dataset,\n    variable=\"reflectance\",\n    cmap=\"jet\",\n    clim=(0, 100),\n    crop=100,\n    nodata=0,\n    rgb_wavelengths=[679, 570, 480],\n    rgb_gamma=1.0,\n    title=\"Reflectance\",\n    widget=\"slice\",\n)\ncube.show()"
   }
  ],
  "metadata": {

--- a/docs/examples/wyvern.ipynb
+++ b/docs/examples/wyvern.ipynb
@@ -202,7 +202,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "geo",
    "language": "python",
    "name": "python3"
   },
@@ -216,7 +216,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/docs/examples/wyvern.ipynb
+++ b/docs/examples/wyvern.ipynb
@@ -146,32 +146,63 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## 3D Image Cube\n\nCreate a 3D image cube from the Wyvern dataset using PyVista.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## 3D Image Cube\n",
+    "\n",
+    "Create a 3D image cube from the Wyvern dataset using PyVista."
+   ]
   },
   {
    "cell_type": "code",
-   "source": "cube = hypercoast.image_cube(\n    dataset,\n    variable=\"reflectance\",\n    cmap=\"jet\",\n    clim=(0, 100),\n    rgb_wavelengths=[679, 570, 480],\n    rgb_gamma=1.0,\n    title=\"Reflectance\",\n)\ncube.show()",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cube = hypercoast.image_cube(\n",
+    "    dataset,\n",
+    "    variable=\"reflectance\",\n",
+    "    cmap=\"jet\",\n",
+    "    clim=(0, 100),\n",
+    "    crop=100,\n",
+    "    rgb_wavelengths=[679, 570, 480],\n",
+    "    rgb_gamma=1.0,\n",
+    "    title=\"Reflectance\",\n",
+    ")\n",
+    "cube.show()"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": "Create an image cube with an interactive slice widget.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "Create an image cube with an interactive slice widget."
+   ]
   },
   {
    "cell_type": "code",
-   "source": "cube = hypercoast.image_cube(\n    dataset,\n    variable=\"reflectance\",\n    cmap=\"jet\",\n    clim=(0, 100),\n    rgb_wavelengths=[679, 570, 480],\n    rgb_gamma=1.0,\n    title=\"Reflectance\",\n    widget=\"slice\",\n)\ncube.show()",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cube = hypercoast.image_cube(\n",
+    "    dataset,\n",
+    "    variable=\"reflectance\",\n",
+    "    cmap=\"jet\",\n",
+    "    clim=(0, 100),\n",
+    "    crop=100,\n",
+    "    rgb_wavelengths=[679, 570, 480],\n",
+    "    rgb_gamma=1.0,\n",
+    "    title=\"Reflectance\",\n",
+    "    widget=\"slice\",\n",
+    ")\n",
+    "cube.show()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "geo",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -185,7 +216,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/hypercoast/common.py
+++ b/hypercoast/common.py
@@ -537,6 +537,7 @@ def image_cube(
     grid_origin=(0, 0, 0),
     grid_spacing=(1, 1, 1),
     z_scale: Optional[float] = None,
+    crop: Optional[Union[int, Tuple[int, int, int, int]]] = None,
     **kwargs: Any,
 ):
     """
@@ -573,6 +574,11 @@ def image_cube(
         z_scale (Optional[float], optional): Scale factor for the z-axis spacing.
             If None (default), auto-scales so the cube height is proportional to
             the smaller spatial dimension. Set to 1.0 to disable auto-scaling.
+        crop (Optional[Union[int, Tuple[int, int, int, int]]], optional): Number
+            of pixels to crop from the edges to remove nodata borders. If an int,
+            the same number of pixels is cropped from all four sides. If a tuple
+            of four ints, specifies (top, bottom, left, right) crop amounts.
+            Defaults to None (no cropping).
         **kwargs (Dict[str, Any], optional): Additional arguments for the
             `add_mesh` method. Defaults to {}.
 
@@ -596,6 +602,26 @@ def image_cube(
 
     if isinstance(dataset, str):
         dataset = xr.open_dataset(dataset)
+
+    # Crop edges to remove nodata borders
+    if crop is not None:
+        if isinstance(crop, int):
+            top, bottom, left, right = crop, crop, crop, crop
+        else:
+            top, bottom, left, right = crop
+        spatial_dims = [
+            d for d in dataset.dims if d not in {"wavelength", "wavelengths", "band"}
+        ]
+        if len(spatial_dims) >= 2:
+            y_dim, x_dim = spatial_dims[0], spatial_dims[1]
+            y_size = dataset.sizes[y_dim]
+            x_size = dataset.sizes[x_dim]
+            dataset = dataset.isel(
+                {
+                    y_dim: slice(top, y_size - bottom if bottom else None),
+                    x_dim: slice(left, x_size - right if right else None),
+                }
+            )
 
     da = dataset[variable]  # xarray DataArray
     values = da.to_numpy()

--- a/hypercoast/common.py
+++ b/hypercoast/common.py
@@ -538,6 +538,7 @@ def image_cube(
     grid_spacing=(1, 1, 1),
     z_scale: Optional[float] = None,
     crop: Optional[Union[int, Tuple[int, int, int, int]]] = None,
+    nodata: Optional[float] = None,
     **kwargs: Any,
 ):
     """
@@ -579,6 +580,10 @@ def image_cube(
             the same number of pixels is cropped from all four sides. If a tuple
             of four ints, specifies (top, bottom, left, right) crop amounts.
             Defaults to None (no cropping).
+        nodata (Optional[float], optional): Value to treat as nodata. Pixels
+            matching this value are replaced with NaN and rendered as transparent
+            in the cube. Useful for masking irregular nodata borders from
+            reprojected imagery. Defaults to None (no masking).
         **kwargs (Dict[str, Any], optional): Additional arguments for the
             `add_mesh` method. Defaults to {}.
 
@@ -654,6 +659,13 @@ def image_cube(
         order = [i for i in range(len(dims)) if i != spectral_idx] + [spectral_idx]
         values = values.transpose(order)
 
+    # Mask nodata values with NaN for transparent rendering
+    if nodata is not None:
+        import numpy as np
+
+        values = values.astype(np.float32, copy=True)
+        values[values == nodata] = np.nan
+
     # Auto-scale z-spacing for datasets with few spectral bands
     if z_scale is None:
         ny, nx, nz = values.shape
@@ -689,6 +701,9 @@ def image_cube(
 
     if "show_edges" not in kwargs:
         kwargs["show_edges"] = False
+
+    if nodata is not None and "nan_opacity" not in kwargs:
+        kwargs["nan_opacity"] = 0
 
     if widget == "box":
         p.add_mesh_clip_box(grid, cmap=cmap, clim=clim, **kwargs)

--- a/hypercoast/common.py
+++ b/hypercoast/common.py
@@ -605,10 +605,20 @@ def image_cube(
 
     # Crop edges to remove nodata borders
     if crop is not None:
+        _crop_err = (
+            "crop must be a non-negative integer or a 4-tuple of "
+            "non-negative integers (top, bottom, left, right)."
+        )
         if isinstance(crop, int):
+            if crop < 0:
+                raise ValueError(_crop_err)
             top, bottom, left, right = crop, crop, crop, crop
-        else:
+        elif isinstance(crop, tuple) and len(crop) == 4:
+            if not all(isinstance(v, int) for v in crop) or any(v < 0 for v in crop):
+                raise ValueError(_crop_err)
             top, bottom, left, right = crop
+        else:
+            raise ValueError(_crop_err)
         spatial_dims = [
             d for d in dataset.dims if d not in {"wavelength", "wavelengths", "band"}
         ]
@@ -616,6 +626,11 @@ def image_cube(
             y_dim, x_dim = spatial_dims[0], spatial_dims[1]
             y_size = dataset.sizes[y_dim]
             x_size = dataset.sizes[x_dim]
+            if top + bottom >= y_size or left + right >= x_size:
+                raise ValueError(
+                    f"crop values exceed dataset dimensions "
+                    f"({y_dim}={y_size}, {x_dim}={x_size})."
+                )
             dataset = dataset.isel(
                 {
                     y_dim: slice(top, y_size - bottom if bottom else None),


### PR DESCRIPTION
## Summary
- Adds a `crop` parameter to `image_cube` that trims pixels from the edges before building the 3D cube, removing gray nodata borders common in reprojected imagery (e.g., Wyvern data not in EPSG:3857)
- Accepts an `int` (uniform crop from all sides) or a `tuple` of four ints `(top, bottom, left, right)`
- Updates the Wyvern notebook to demonstrate `crop=100` usage

## Test plan
- [ ] Test `crop=100` with Wyvern data to verify nodata borders are removed
- [ ] Test `crop=(50, 50, 100, 100)` for asymmetric cropping
- [ ] Test `crop=None` (default) to verify no change in existing behavior
- [ ] Verify existing NEON/Tanager examples still work without crop