### PR TITLE
Fix Tanager/PACE "No data variable found" in QGIS plugin (#241)

### DIFF
--- a/hypercoast/tanager.py
+++ b/hypercoast/tanager.py
@@ -129,6 +129,12 @@ def _discover_tanager_layout(h5_file, product=None):
                 data_path = path
                 cube_name = candidate
                 break
+        if data_path is None:
+            expected = [f"{df_root}/{c}" for c in candidate_names_by_product[product]]
+            raise ValueError(
+                f"Forced product '{product}' requires one of {expected} "
+                f"in the HDF5 file but none were found."
+            )
 
     if data_path is None:
         for candidate in (
@@ -365,7 +371,8 @@ def read_tanager(
         stac_url (str, optional): STAC item URL to source wavelength metadata
             from when the file does not contain it.
         wavelengths (array-like, optional): Wavelengths in nanometers to use
-            directly; must match the number of bands being read.
+            directly. Must have either the full cube band count or, when
+            ``bands`` is also supplied, the number of selected bands.
         product (str, optional): Force a specific product variant. One of
             ``basic_radiance``, ``ortho_radiance``, ``basic_sr``, ``ortho_sr``.
         **kwargs: Extra keyword arguments forwarded to ``xr.Dataset``.
@@ -385,11 +392,27 @@ def read_tanager(
     with h5py.File(filepath, "r") as f:
         layout = _discover_tanager_layout(f, product=product)
 
-        cube_shape = f[layout["data_path"]].shape
+        cube = f[layout["data_path"]]
+        cube_shape = cube.shape
         band_axis = layout["band_axis"]
         n_bands_total = cube_shape[band_axis]
 
-        data = f[layout["data_path"]][()]
+        # Read only the requested bands from disk so large Tanager scenes do
+        # not blow up memory. Fall back to a full read if h5py rejects the
+        # index expression (for example, unsorted integer lists).
+        if bands is not None:
+            index = [slice(None)] * cube.ndim
+            index[band_axis] = bands
+            try:
+                data = cube[tuple(index)]
+            except (TypeError, ValueError):
+                data = cube[()]
+                slicer = [slice(None)] * cube.ndim
+                slicer[band_axis] = bands
+                data = data[tuple(slicer)]
+        else:
+            data = cube[()]
+
         if band_axis != 0:
             data = np.moveaxis(data, band_axis, 0)
 
@@ -402,29 +425,57 @@ def read_tanager(
         lat = f[lat_path][()]
         lon = f[lon_path][()]
 
-        wl_nm, fwhm_nm = _read_wavelengths_from_hdf5(f, layout, n_bands_total)
+        wl_nm_full, fwhm_nm_full = _read_wavelengths_from_hdf5(f, layout, n_bands_total)
+
+    n_bands_selected = data.shape[0]
 
     if layout["fill_value"] is not None:
         data = np.where(data == layout["fill_value"], np.nan, data.astype(float))
     if layout["scale_factor"] != 1.0 or layout["add_offset"] != 0.0:
         data = data.astype(float) * layout["scale_factor"] + layout["add_offset"]
 
+    def _apply_band_slice(values, expected):
+        """Slice a full-length band-aligned array to the selected bands.
+
+        Args:
+            values (array-like or None): Values indexed along the band axis.
+            expected (int): Expected length before slicing.
+
+        Returns:
+            numpy.ndarray or None: Sliced values, or ``None`` if ``values`` is
+            ``None``.
+        """
+        if values is None:
+            return None
+        arr = np.asarray(values)
+        if arr.size == expected and bands is not None:
+            arr = arr[bands]
+        return arr
+
+    wl_nm = _apply_band_slice(wl_nm_full, n_bands_total)
+    fwhm_nm = _apply_band_slice(fwhm_nm_full, n_bands_total)
+
     if wavelengths is not None:
         wl_nm = np.asarray(wavelengths, dtype=float).ravel()
-        if wl_nm.size != n_bands_total:
+        if wl_nm.size == n_bands_total and bands is not None:
+            wl_nm = wl_nm[bands]
+        if wl_nm.size != n_bands_selected:
             raise ValueError(
-                f"`wavelengths` has length {wl_nm.size} but the data cube has "
-                f"{n_bands_total} bands."
+                f"`wavelengths` has length {wl_nm.size} but {n_bands_selected} "
+                f"bands are being read."
             )
-        fwhm_nm = fwhm_nm if fwhm_nm is not None else np.full(n_bands_total, np.nan)
 
     if wl_nm is None and stac_url is not None:
-        wl_nm, fwhm_nm = _read_wavelengths_from_stac(stac_url, layout["stac_asset_key"])
-        if wl_nm.size != n_bands_total:
+        wl_stac, fwhm_stac = _read_wavelengths_from_stac(
+            stac_url, layout["stac_asset_key"]
+        )
+        if wl_stac.size != n_bands_total:
             raise ValueError(
-                f"STAC item reports {wl_nm.size} bands but the data cube has "
+                f"STAC item reports {wl_stac.size} bands but the data cube has "
                 f"{n_bands_total} bands."
             )
+        wl_nm = _apply_band_slice(wl_stac, n_bands_total)
+        fwhm_nm = _apply_band_slice(fwhm_stac, n_bands_total)
 
     if wl_nm is None:
         warnings.warn(
@@ -435,16 +486,10 @@ def read_tanager(
             UserWarning,
             stacklevel=2,
         )
-        wl_nm = np.arange(n_bands_total, dtype=float)
-        fwhm_nm = np.full(n_bands_total, np.nan)
+        wl_nm = np.arange(n_bands_selected, dtype=float)
 
     if fwhm_nm is None:
-        fwhm_nm = np.full(n_bands_total, np.nan)
-
-    if bands is not None:
-        data = data[bands]
-        wl_nm = wl_nm[bands]
-        fwhm_nm = fwhm_nm[bands]
+        fwhm_nm = np.full(n_bands_selected, np.nan)
 
     data_var_name = layout["data_var_name"]
 

--- a/hypercoast/tanager.py
+++ b/hypercoast/tanager.py
@@ -1,3 +1,14 @@
+"""Reader and helpers for Planet Tanager hyperspectral HDF5 products.
+
+Supports all four published product variants via :func:`read_tanager`:
+``basic_radiance_hdf5``, ``ortho_radiance_hdf5``, ``basic_sr_hdf5``, and
+``ortho_sr_hdf5``. The reader auto-detects the HDF5 layout and sources
+wavelength metadata from inside the file when available, falling back to a
+caller-supplied STAC URL only when necessary.
+"""
+
+import warnings
+
 import h5py
 import xarray as xr
 import numpy as np
@@ -6,74 +17,467 @@ import matplotlib.pyplot as plt
 from typing import List, Tuple, Union, Optional, Any, Callable
 from .common import download_file
 
+# Recognized Planet Tanager products and their canonical output var names.
+_PRODUCT_VAR_NAME = {
+    "basic_radiance": "toa_radiance",
+    "ortho_radiance": "toa_radiance",
+    "basic_sr": "surface_reflectance",
+    "ortho_sr": "surface_reflectance",
+}
 
-def read_tanager(filepath, bands=None, stac_url=None, **kwargs):
-    """
-    Read Planet Tanager HDF5 hyperspectral data and return an xarray.Dataset.
+_PRODUCT_STAC_ASSET = {
+    "basic_radiance": "basic_radiance_hdf5",
+    "ortho_radiance": "ortho_radiance_hdf5",
+    "basic_sr": "basic_sr_hdf5",
+    "ortho_sr": "ortho_sr_hdf5",
+}
 
-    Parameters:
-        filepath (str or Path): Local file path or HTTPS URL to the .h5 file.
-        bands (list or slice, optional): Indices of spectral bands to read.
-        stac_url (str, optional): STAC item URL containing wavelength metadata.
-        **kwargs: Additional arguments (reserved for future use).
+
+def _ensure_nm(values):
+    """Return a wavelength array in nanometers.
+
+    Planet STAC expresses center wavelengths in micrometers while Tanager HDF5
+    files typically store them in nanometers. This helper uses a magnitude
+    heuristic: values with a maximum below 10 are assumed to be in micrometers
+    and are scaled by 1000.
+
+    Args:
+        values (array-like): Wavelength values in either nm or um.
 
     Returns:
-        xr.Dataset: Dataset with georeferenced radiance and band metadata.
+        numpy.ndarray: Wavelength values in nanometers.
+    """
+    arr = np.asarray(values, dtype=float)
+    if arr.size and np.nanmax(arr) < 10:
+        arr = arr * 1000.0
+    return arr
+
+
+def _cube_name_to_product(name):
+    """Map an HDF5 cube dataset name to a Tanager product identifier.
+
+    Args:
+        name (str): HDF5 dataset name such as ``toa_radiance`` or
+            ``ortho_surface_reflectance``.
+
+    Returns:
+        str or None: One of ``basic_radiance``, ``ortho_radiance``,
+        ``basic_sr``, ``ortho_sr``, or ``None`` if the name is not recognized.
+    """
+    lname = name.lower()
+    if "ortho" in lname and ("reflect" in lname or "_sr" in lname):
+        return "ortho_sr"
+    if "ortho" in lname and "radiance" in lname:
+        return "ortho_radiance"
+    if "reflect" in lname or lname.endswith("_sr"):
+        return "basic_sr"
+    if "radiance" in lname:
+        return "basic_radiance"
+    return None
+
+
+def _discover_tanager_layout(h5_file, product=None):
+    """Inspect a Tanager HDF5 file and return its layout.
+
+    Detection cascades through (1) the canonical HDFEOS SWATHS layout used by
+    the ``basic_radiance_hdf5`` and ``basic_sr_hdf5`` products, and (2) a
+    generic sweep with ``h5py.visititems`` that picks the largest 3-D float
+    cube whose band axis length falls in the Tanager-plausible range. Latitude
+    and longitude are resolved similarly, with a preference for
+    ``Geolocation Fields``.
+
+    Args:
+        h5_file (h5py.File): An open HDF5 file handle.
+        product (str, optional): If supplied, forces the product variant to one
+            of ``basic_radiance``, ``ortho_radiance``, ``basic_sr``, or
+            ``ortho_sr``. When forced, the corresponding data-field name
+            (``toa_radiance`` or ``surface_reflectance``) is required at the
+            canonical HDFEOS path.
+
+    Returns:
+        dict: A layout descriptor with keys ``product``, ``data_path``,
+        ``data_var_name``, ``lat_path``, ``lon_path``, ``wavelength_path``,
+        ``fwhm_path``, ``scale_factor``, ``add_offset``, ``fill_value``,
+        ``band_axis``, and ``stac_asset_key``.
+
+    Raises:
+        ValueError: If no 3-D data cube can be located in the file.
+    """
+    hdfeos_root = "HDFEOS/SWATHS/HYP"
+    df_root = f"{hdfeos_root}/Data Fields"
+    gf_root = f"{hdfeos_root}/Geolocation Fields"
+
+    data_path = None
+    cube_name = None
+
+    candidate_names_by_product = {
+        "basic_radiance": ["toa_radiance"],
+        "ortho_radiance": ["toa_radiance", "ortho_radiance"],
+        "basic_sr": ["surface_reflectance"],
+        "ortho_sr": ["surface_reflectance", "ortho_surface_reflectance"],
+    }
+
+    if product is not None:
+        if product not in _PRODUCT_VAR_NAME:
+            raise ValueError(
+                f"Unknown Tanager product '{product}'. Expected one of "
+                f"{sorted(_PRODUCT_VAR_NAME)}."
+            )
+        for candidate in candidate_names_by_product[product]:
+            path = f"{df_root}/{candidate}"
+            if path in h5_file:
+                data_path = path
+                cube_name = candidate
+                break
+
+    if data_path is None:
+        for candidate in (
+            "toa_radiance",
+            "surface_reflectance",
+            "ortho_radiance",
+            "ortho_surface_reflectance",
+        ):
+            path = f"{df_root}/{candidate}"
+            if path in h5_file:
+                data_path = path
+                cube_name = candidate
+                break
+
+    if data_path is None:
+        best = {"size": -1, "path": None, "name": None, "shape": None}
+
+        def _visitor(name, obj):
+            if not isinstance(obj, h5py.Dataset):
+                return
+            if obj.ndim != 3 or not np.issubdtype(obj.dtype, np.floating):
+                return
+            band_axis = int(np.argmin(obj.shape))
+            n_bands = obj.shape[band_axis]
+            if not (100 <= n_bands <= 600):
+                return
+            if obj.size > best["size"]:
+                best["size"] = obj.size
+                best["path"] = name
+                best["name"] = name.rsplit("/", 1)[-1]
+                best["shape"] = obj.shape
+
+        h5_file.visititems(_visitor)
+        if best["path"] is None:
+            raise ValueError(
+                "No 3-D hyperspectral cube found in the Tanager HDF5 file."
+            )
+        data_path = best["path"]
+        cube_name = best["name"]
+
+    if product is None:
+        product = _cube_name_to_product(cube_name) or "basic_radiance"
+
+    data_var_name = _PRODUCT_VAR_NAME[product]
+
+    cube = h5_file[data_path]
+    if data_path.startswith(f"{hdfeos_root}/"):
+        # HDFEOS SWATHS products store cubes in (band, y, x) order.
+        band_axis = 0
+    else:
+        band_axis = int(np.argmin(cube.shape))
+
+    lat_path = f"{gf_root}/Latitude" if f"{gf_root}/Latitude" in h5_file else None
+    lon_path = f"{gf_root}/Longitude" if f"{gf_root}/Longitude" in h5_file else None
+    if lat_path is None or lon_path is None:
+        found_lat = []
+        found_lon = []
+
+        def _geo_visitor(name, obj):
+            if not isinstance(obj, h5py.Dataset) or obj.ndim != 2:
+                return
+            leaf = name.rsplit("/", 1)[-1].lower()
+            if leaf in ("latitude", "lat"):
+                found_lat.append(name)
+            elif leaf in ("longitude", "lon"):
+                found_lon.append(name)
+
+        h5_file.visititems(_geo_visitor)
+        lat_path = lat_path or (found_lat[0] if found_lat else None)
+        lon_path = lon_path or (found_lon[0] if found_lon else None)
+
+    wl_path = None
+    fwhm_path = None
+    for candidate in (
+        f"{df_root}/Wavelength",
+        f"{df_root}/Wavelengths",
+        f"{df_root}/wavelength",
+        f"{df_root}/wavelengths",
+        f"{hdfeos_root}/Wavelength",
+        "Wavelengths",
+        "Wavelength",
+    ):
+        if candidate in h5_file:
+            wl_path = candidate
+            break
+    for candidate in (
+        f"{df_root}/FWHM",
+        f"{df_root}/fwhm",
+        f"{hdfeos_root}/FWHM",
+        "FWHM",
+    ):
+        if candidate in h5_file:
+            fwhm_path = candidate
+            break
+
+    def _attr(obj, *names, default=None):
+        for n in names:
+            if n in obj.attrs:
+                return obj.attrs[n]
+        return default
+
+    scale_factor = float(_attr(cube, "scale_factor", default=1.0))
+    add_offset = float(_attr(cube, "add_offset", default=0.0))
+    fill_value = _attr(cube, "_FillValue", "FillValue", "missing_value", default=None)
+    if fill_value is not None:
+        try:
+            fill_value = float(fill_value)
+        except (TypeError, ValueError):
+            fill_value = None
+
+    return {
+        "product": product,
+        "data_path": data_path,
+        "data_var_name": data_var_name,
+        "lat_path": lat_path,
+        "lon_path": lon_path,
+        "wavelength_path": wl_path,
+        "fwhm_path": fwhm_path,
+        "scale_factor": scale_factor,
+        "add_offset": add_offset,
+        "fill_value": fill_value,
+        "band_axis": band_axis,
+        "stac_asset_key": _PRODUCT_STAC_ASSET[product],
+    }
+
+
+def _read_wavelengths_from_hdf5(h5_file, layout, n_bands):
+    """Read wavelengths and FWHM from inside the HDF5 file.
+
+    Args:
+        h5_file (h5py.File): An open HDF5 file handle.
+        layout (dict): Layout descriptor from ``_discover_tanager_layout``.
+        n_bands (int): Expected number of bands; a match is required.
+
+    Returns:
+        tuple: ``(wavelengths_nm, fwhm_nm)`` as numpy arrays, or ``(None, None)``
+        if no matching in-file metadata is found.
+    """
+    wl_nm = None
+    fwhm_nm = None
+
+    wl_path = layout.get("wavelength_path")
+    if wl_path and wl_path in h5_file:
+        vals = np.asarray(h5_file[wl_path][()], dtype=float).ravel()
+        if vals.size == n_bands:
+            wl_nm = _ensure_nm(vals)
+
+    if wl_nm is None:
+        cube = h5_file[layout["data_path"]]
+        for attr_name in (
+            "wavelengths",
+            "center_wavelengths",
+            "band_center_wavelengths",
+        ):
+            if attr_name in cube.attrs:
+                vals = np.asarray(cube.attrs[attr_name], dtype=float).ravel()
+                if vals.size == n_bands:
+                    wl_nm = _ensure_nm(vals)
+                    break
+
+    fwhm_path = layout.get("fwhm_path")
+    if fwhm_path and fwhm_path in h5_file:
+        vals = np.asarray(h5_file[fwhm_path][()], dtype=float).ravel()
+        if vals.size == n_bands:
+            fwhm_nm = _ensure_nm(vals)
+    if fwhm_nm is None:
+        cube = h5_file[layout["data_path"]]
+        for attr_name in ("fwhm", "full_width_half_max"):
+            if attr_name in cube.attrs:
+                vals = np.asarray(cube.attrs[attr_name], dtype=float).ravel()
+                if vals.size == n_bands:
+                    fwhm_nm = _ensure_nm(vals)
+                    break
+
+    return wl_nm, fwhm_nm
+
+
+def _read_wavelengths_from_stac(stac_url, asset_key):
+    """Fetch wavelengths and FWHM from a Planet STAC item.
+
+    Args:
+        stac_url (str): URL to the STAC item JSON.
+        asset_key (str): Asset key whose ``eo:bands`` describes the product,
+            e.g. ``basic_radiance_hdf5`` or ``ortho_sr_hdf5``.
+
+    Returns:
+        tuple: ``(wavelengths_nm, fwhm_nm)`` as numpy arrays.
+
+    Raises:
+        KeyError: If the asset key or ``eo:bands`` block is absent.
+    """
+    stac_item = requests.get(stac_url, timeout=10).json()
+    assets = stac_item.get("assets", {})
+    if asset_key not in assets:
+        available = sorted(assets.keys())
+        raise KeyError(
+            f"STAC item has no asset '{asset_key}'. Available assets: {available}"
+        )
+    bands_meta = assets[asset_key]["eo:bands"]
+    wl = np.array([b["center_wavelength"] for b in bands_meta], dtype=float)
+    fwhm = np.array(
+        [b.get("full_width_half_max", np.nan) for b in bands_meta], dtype=float
+    )
+    return _ensure_nm(wl), _ensure_nm(fwhm)
+
+
+def read_tanager(
+    filepath,
+    bands=None,
+    stac_url=None,
+    wavelengths=None,
+    product=None,
+    **kwargs,
+):
+    """Read Planet Tanager HDF5 hyperspectral data and return an xarray.Dataset.
+
+    Auto-detects the Tanager product variant from the file contents and sources
+    wavelength metadata from inside the file when available. Supports all four
+    Planet Tanager product variants: ``basic_radiance``, ``ortho_radiance``,
+    ``basic_sr``, and ``ortho_sr``. Surface reflectance products expose their
+    data as ``surface_reflectance`` with a ``toa_radiance`` alias retained for
+    backward compatibility with the rest of the HyperCoast Tanager helpers;
+    the alias may be removed in a future major release.
+
+    Wavelengths are sourced in this precedence: (1) the ``wavelengths`` kwarg,
+    (2) a wavelength dataset or attribute inside the HDF5 file, (3) the
+    ``stac_url`` kwarg parsed for ``eo:bands`` metadata, (4) a synthesized
+    integer index with a ``UserWarning``. No hardcoded STAC URL is used.
+
+    Args:
+        filepath (str or os.PathLike): Local file path or HTTPS URL to the
+            Tanager ``.h5`` file.
+        bands (array-like, optional): Indices of spectral bands to keep.
+        stac_url (str, optional): STAC item URL to source wavelength metadata
+            from when the file does not contain it.
+        wavelengths (array-like, optional): Wavelengths in nanometers to use
+            directly; must match the number of bands being read.
+        product (str, optional): Force a specific product variant. One of
+            ``basic_radiance``, ``ortho_radiance``, ``basic_sr``, ``ortho_sr``.
+        **kwargs: Extra keyword arguments forwarded to ``xr.Dataset``.
+
+    Returns:
+        xr.Dataset: Dataset with dims ``(wavelength, y, x)``, a canonical data
+        variable (``toa_radiance`` for radiance products, ``surface_reflectance``
+        for SR products, plus a ``toa_radiance`` alias), and ``latitude`` /
+        ``longitude`` coordinates on ``(y, x)``.
+
+    Raises:
+        ValueError: If no 3-D hyperspectral cube can be located in the file.
     """
     if isinstance(filepath, str) and filepath.startswith("https://"):
-        filepath = download_file(filepath)  # You must define this if needed
-
-    if stac_url is None:
-        # Example static fallback STAC URL; update as needed
-        stac_url = (
-            "https://www.planet.com/data/stac/tanager-core-imagery/coastal-water-bodies/"
-            "20250514_193937_64_4001/20250514_193937_64_4001.json"
-        )
-
-    # Parse STAC metadata
-    stac_item = requests.get(stac_url, timeout=10).json()
-    bands_meta = stac_item["assets"]["basic_radiance_hdf5"]["eo:bands"]
-
-    wavelengths = np.array([b["center_wavelength"] * 1000 for b in bands_meta])
-    fwhm = np.array([b.get("full_width_half_max", np.nan) * 1000 for b in bands_meta])
-
-    if bands is not None:
-        wavelengths = wavelengths[bands]
-        fwhm = fwhm[bands]
+        filepath = download_file(filepath)
 
     with h5py.File(filepath, "r") as f:
-        data = f["HDFEOS/SWATHS/HYP/Data Fields/toa_radiance"][()]
-        lat = f["HDFEOS/SWATHS/HYP/Geolocation Fields/Latitude"][()]
-        lon = f["HDFEOS/SWATHS/HYP/Geolocation Fields/Longitude"][()]
+        layout = _discover_tanager_layout(f, product=product)
+
+        cube_shape = f[layout["data_path"]].shape
+        band_axis = layout["band_axis"]
+        n_bands_total = cube_shape[band_axis]
+
+        data = f[layout["data_path"]][()]
+        if band_axis != 0:
+            data = np.moveaxis(data, band_axis, 0)
+
+        lat_path = layout["lat_path"]
+        lon_path = layout["lon_path"]
+        if lat_path is None or lon_path is None:
+            raise ValueError(
+                "Could not locate Latitude/Longitude datasets in the Tanager HDF5 file."
+            )
+        lat = f[lat_path][()]
+        lon = f[lon_path][()]
+
+        wl_nm, fwhm_nm = _read_wavelengths_from_hdf5(f, layout, n_bands_total)
+
+    if layout["fill_value"] is not None:
+        data = np.where(data == layout["fill_value"], np.nan, data.astype(float))
+    if layout["scale_factor"] != 1.0 or layout["add_offset"] != 0.0:
+        data = data.astype(float) * layout["scale_factor"] + layout["add_offset"]
+
+    if wavelengths is not None:
+        wl_nm = np.asarray(wavelengths, dtype=float).ravel()
+        if wl_nm.size != n_bands_total:
+            raise ValueError(
+                f"`wavelengths` has length {wl_nm.size} but the data cube has "
+                f"{n_bands_total} bands."
+            )
+        fwhm_nm = fwhm_nm if fwhm_nm is not None else np.full(n_bands_total, np.nan)
+
+    if wl_nm is None and stac_url is not None:
+        wl_nm, fwhm_nm = _read_wavelengths_from_stac(stac_url, layout["stac_asset_key"])
+        if wl_nm.size != n_bands_total:
+            raise ValueError(
+                f"STAC item reports {wl_nm.size} bands but the data cube has "
+                f"{n_bands_total} bands."
+            )
+
+    if wl_nm is None:
+        warnings.warn(
+            "No wavelength metadata found in the Tanager HDF5 file and no "
+            "`stac_url` or `wavelengths` supplied; falling back to integer "
+            "band indices. Pass `wavelengths` or `stac_url` for physical nm "
+            "values.",
+            UserWarning,
+            stacklevel=2,
+        )
+        wl_nm = np.arange(n_bands_total, dtype=float)
+        fwhm_nm = np.full(n_bands_total, np.nan)
+
+    if fwhm_nm is None:
+        fwhm_nm = np.full(n_bands_total, np.nan)
 
     if bands is not None:
         data = data[bands]
+        wl_nm = wl_nm[bands]
+        fwhm_nm = fwhm_nm[bands]
+
+    data_var_name = layout["data_var_name"]
 
     coords = {
-        "wavelength": wavelengths,
-        "fwhm": ("wavelength", fwhm),
+        "wavelength": wl_nm,
+        "fwhm": ("wavelength", fwhm_nm),
         "latitude": (("y", "x"), lat),
         "longitude": (("y", "x"), lon),
     }
 
     da = xr.DataArray(
-        data, dims=("wavelength", "y", "x"), coords=coords, name="toa_radiance"
+        data, dims=("wavelength", "y", "x"), coords=coords, name=data_var_name
     )
 
     ds = xr.Dataset(
-        data_vars={"toa_radiance": da},
+        data_vars={data_var_name: da},
         coords={
             "wavelength": da.wavelength,
-            "fwhm": ("wavelength", fwhm),
+            "fwhm": ("wavelength", fwhm_nm),
             "latitude": (("y", "x"), lat),
             "longitude": (("y", "x"), lon),
         },
         attrs={
             "source": "Planet Tanager HDF5",
-            "stac_item": stac_url,
+            "product": layout["product"],
+            "stac_item": stac_url or "",
+            "data_var": data_var_name,
         },
         **kwargs,
     )
+
+    if data_var_name == "surface_reflectance" and "toa_radiance" not in ds.data_vars:
+        ds["toa_radiance"] = ds["surface_reflectance"]
 
     return ds
 

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -194,6 +194,7 @@ class HyperspectralDataset:
             raise ImportError("xarray is required to load hyperspectral data")
 
         self.last_error = None
+        self._reader_error = None
         _log(
             f"Starting dataset load: type={self.data_type}, file={self.filepath}",
             LOG_INFO,
@@ -640,6 +641,7 @@ class HyperspectralDataset:
             ValueError: If the export fails after a successful load.
         """
         self.last_error = None
+        self._reader_error = None
 
         # On Windows without in-process hypercoast, combine load + export
         # into a single subprocess to avoid reading the file twice.

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -146,6 +146,7 @@ class HyperspectralDataset:
         self.nodata = np.nan
         self._is_swath = False  # True for non-gridded data like PACE
         self.last_error = None
+        self._reader_error = None
 
     def _detect_type(self):
         """Auto-detect the data type based on file extension and content."""
@@ -245,7 +246,8 @@ class HyperspectralDataset:
             elif self.data_type == "PACE":
                 self.dataset = hypercoast.read_pace(self.filepath)
                 self._is_swath = True
-                self._extract_pace_metadata()
+                if not self._extract_pace_metadata():
+                    return False
 
             elif self.data_type == "DESIS":
                 self.dataset = hypercoast.read_desis(self.filepath)
@@ -269,7 +271,8 @@ class HyperspectralDataset:
 
             elif self.data_type == "Tanager":
                 self.dataset = hypercoast.read_tanager(self.filepath)
-                self._extract_tanager_metadata()
+                if not self._extract_tanager_metadata():
+                    return False
 
             elif self.data_type == "Wyvern":
                 self.dataset = hypercoast.read_wyvern(self.filepath)
@@ -294,6 +297,7 @@ class HyperspectralDataset:
 
         except Exception as e:
             self.last_error = f"Error loading with hypercoast: {e}"
+            self._reader_error = self.last_error
             _log(self.last_error, LOG_WARNING)
             _log(traceback.format_exc(limit=2), LOG_WARNING)
             # Try type-specific fallback first, then generic.
@@ -680,8 +684,22 @@ class HyperspectralDataset:
         self.crs = "EPSG:4326"
 
     def _extract_pace_metadata(self):
-        """Extract metadata from PACE dataset."""
+        """Extract metadata from PACE dataset.
+
+        Returns:
+            bool: ``True`` on success, ``False`` if the dataset is missing or
+            has no data variables, in which case ``self.dataset`` is cleared
+            and ``self.last_error`` describes the upstream reader failure.
+        """
         ds = self.dataset
+        if ds is None or len(ds.data_vars) == 0:
+            self.last_error = (
+                "PACE reader returned a dataset with no data variables. "
+                f"Upstream reader error: {self._reader_error or 'n/a'}"
+            )
+            _log(self.last_error, LOG_WARNING)
+            self.dataset = None
+            return False
 
         if "wavelength" in ds.coords:
             self.wavelengths = ds.coords["wavelength"].values
@@ -698,6 +716,7 @@ class HyperspectralDataset:
             )
 
         self.crs = "EPSG:4326"
+        return True
 
     def _extract_desis_metadata(self):
         """Extract metadata from DESIS dataset."""
@@ -734,8 +753,21 @@ class HyperspectralDataset:
             )
 
     def _extract_tanager_metadata(self):
-        """Extract metadata from Tanager dataset."""
+        """Extract metadata from Tanager dataset.
+
+        Returns:
+            bool: ``True`` on success, ``False`` if the dataset is missing or
+            has no data variables.
+        """
         ds = self.dataset
+        if ds is None or len(ds.data_vars) == 0:
+            self.last_error = (
+                "Tanager reader returned a dataset with no data variables. "
+                f"Upstream reader error: {self._reader_error or 'n/a'}"
+            )
+            _log(self.last_error, LOG_WARNING)
+            self.dataset = None
+            return False
 
         if "wavelength" in ds.coords:
             self.wavelengths = ds.coords["wavelength"].values
@@ -752,6 +784,7 @@ class HyperspectralDataset:
 
         self.crs = "EPSG:4326"
         self._is_swath = True
+        return True
 
     def _extract_generic_metadata(self):
         """Extract metadata from generic dataset."""
@@ -1031,6 +1064,16 @@ class HyperspectralDataset:
                 self.crs = "EPSG:4326"
 
             self.dataset = ds
+
+            if len(ds.data_vars) == 0:
+                self.last_error = (
+                    f"Generic loader opened {self.filepath} but the root has "
+                    f"no data variables (likely a grouped NetCDF/HDF5 file). "
+                    f"Upstream reader error: {self._reader_error or 'n/a'}"
+                )
+                _log(self.last_error, LOG_WARNING)
+                self.dataset = None
+                return False
 
             for coord_name in ["wavelength", "wavelengths", "band", "bands"]:
                 if coord_name in ds.coords:

--- a/qgis_plugin/hypercoast_qgis/metadata.txt
+++ b/qgis_plugin/hypercoast_qgis/metadata.txt
@@ -4,7 +4,7 @@
 name=HyperCoast
 qgisMinimumVersion=3.28
 description=Visualize and analyze hyperspectral data including EMIT, PACE, DESIS, NEON, AVIRIS, PRISMA, EnMAP, Tanager, and Wyvern datasets
-version=0.5.0
+version=0.6.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -30,6 +30,8 @@ deprecated=False
 hasProcessingProvider=no
 
 changelog=
+    0.6.0
+        - Fix Tanager/PACE "No data variable found" in QGIS plugin
     0.5.0
         - Fix QGIS plugin dependency installer on Windows, use uv and dockable panel
         - Fix h5py DLL conflict on Windows and PROJ database error

--- a/qgis_plugin/hypercoast_qgis/requirements.txt
+++ b/qgis_plugin/hypercoast_qgis/requirements.txt
@@ -4,7 +4,7 @@
 
 h5netcdf>=0.11.0
 h5py>=3.0.0
-hypercoast>=0.16.0
+hypercoast>=0.21.0
 leafmap>=0.30.0
 matplotlib>=3.4.0
 netCDF4>=1.6.0

--- a/tests/test_pace.py
+++ b/tests/test_pace.py
@@ -30,6 +30,26 @@ class TestHypercoast(unittest.TestCase):
         dataset = hypercoast.read_pace(self.filepath)
         self.assertIsNotNone(dataset)
 
+    def test_read_pace_populated(self):
+        """Regression check: read_pace must not return an empty-root shell.
+
+        When the PACE reader silently degrades to the empty root group the
+        QGIS plugin downstream reports ``Variables: []`` and ``No data
+        variable found``; see issue #241.
+        """
+        dataset = hypercoast.read_pace(self.filepath)
+        self.assertGreater(
+            len(dataset.data_vars),
+            0,
+            "PACE dataset must expose at least one data variable",
+        )
+        self.assertIn("wavelength", dataset.coords)
+        self.assertGreater(
+            len(dataset.coords["wavelength"]),
+            100,
+            "PACE OCI L2 AOP typically has ~170 wavelength bands",
+        )
+
     def test_map(self):
         m = hypercoast.Map()
         m.add_basemap("Hybrid")

--- a/tests/test_tanager.py
+++ b/tests/test_tanager.py
@@ -59,9 +59,7 @@ def _write_hdfeos_cube(
                 "Wavelength",
                 data=np.linspace(400.0, 2500.0, n_bands, dtype=np.float32),
             )
-            df.create_dataset(
-                "FWHM", data=np.full(n_bands, 10.0, dtype=np.float32)
-            )
+            df.create_dataset("FWHM", data=np.full(n_bands, 10.0, dtype=np.float32))
         gf = f.create_group("HDFEOS/SWATHS/HYP/Geolocation Fields")
         lat = np.tile(np.linspace(0.0, 1.0, height, dtype=np.float32), (width, 1)).T
         lon = np.tile(np.linspace(10.0, 11.0, width, dtype=np.float32), (height, 1))
@@ -128,9 +126,7 @@ class TestReadTanager(unittest.TestCase):
 
     def test_missing_wavelength_warns_and_indexes(self):
         path = os.path.join(self.tmpdir, "no_wavelength.h5")
-        _write_hdfeos_cube(
-            path, "toa_radiance", n_bands=120, include_wavelength=False
-        )
+        _write_hdfeos_cube(path, "toa_radiance", n_bands=120, include_wavelength=False)
 
         with mock.patch("hypercoast.tanager.requests.get") as mocked_get:
             with warnings.catch_warnings(record=True) as caught:
@@ -147,9 +143,7 @@ class TestReadTanager(unittest.TestCase):
 
     def test_explicit_wavelengths_kwarg_skips_network(self):
         path = os.path.join(self.tmpdir, "no_wavelength.h5")
-        _write_hdfeos_cube(
-            path, "toa_radiance", n_bands=100, include_wavelength=False
-        )
+        _write_hdfeos_cube(path, "toa_radiance", n_bands=100, include_wavelength=False)
         supplied = np.linspace(450.0, 2400.0, 100)
 
         with mock.patch("hypercoast.tanager.requests.get") as mocked_get:

--- a/tests/test_tanager.py
+++ b/tests/test_tanager.py
@@ -1,0 +1,163 @@
+"""Tests for :func:`hypercoast.read_tanager` using fabricated HDF5 fixtures.
+
+These tests do not require a real Planet Tanager file and do not touch the
+network. They build small HDF5 files that mirror the layout of the four
+Planet Tanager product variants and assert that :func:`read_tanager` recovers
+the correct canonical data variable name and wavelength values.
+"""
+
+import os
+import tempfile
+import unittest
+import warnings
+from unittest import mock
+
+import h5py
+import numpy as np
+
+import hypercoast
+
+
+def _write_hdfeos_cube(
+    path,
+    cube_name,
+    n_bands=200,
+    height=10,
+    width=8,
+    include_wavelength=True,
+    scale_factor=None,
+    add_offset=None,
+):
+    """Create a minimal HDF5 file that mimics a Tanager HDFEOS SWATHS product.
+
+    Args:
+        path (str): Destination path for the HDF5 file.
+        cube_name (str): Name of the data cube (for example ``toa_radiance`` or
+            ``surface_reflectance``).
+        n_bands (int): Number of spectral bands to fabricate.
+        height (int): Number of along-track rows.
+        width (int): Number of cross-track columns.
+        include_wavelength (bool): Whether to write a ``Wavelength`` dataset.
+        scale_factor (float, optional): If given, stored as a ``scale_factor``
+            attribute on the cube.
+        add_offset (float, optional): If given, stored as an ``add_offset``
+            attribute on the cube.
+    """
+    rng = np.random.default_rng(42)
+    with h5py.File(path, "w") as f:
+        df = f.create_group("HDFEOS/SWATHS/HYP/Data Fields")
+        cube = df.create_dataset(
+            cube_name,
+            data=rng.random((n_bands, height, width), dtype=np.float32),
+        )
+        if scale_factor is not None:
+            cube.attrs["scale_factor"] = scale_factor
+        if add_offset is not None:
+            cube.attrs["add_offset"] = add_offset
+        if include_wavelength:
+            df.create_dataset(
+                "Wavelength",
+                data=np.linspace(400.0, 2500.0, n_bands, dtype=np.float32),
+            )
+            df.create_dataset(
+                "FWHM", data=np.full(n_bands, 10.0, dtype=np.float32)
+            )
+        gf = f.create_group("HDFEOS/SWATHS/HYP/Geolocation Fields")
+        lat = np.tile(np.linspace(0.0, 1.0, height, dtype=np.float32), (width, 1)).T
+        lon = np.tile(np.linspace(10.0, 11.0, width, dtype=np.float32), (height, 1))
+        gf.create_dataset("Latitude", data=lat)
+        gf.create_dataset("Longitude", data=lon)
+
+
+class TestReadTanager(unittest.TestCase):
+    """Exercise the Tanager reader against fabricated HDF5 fixtures."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="hc_tanager_test_")
+
+    def tearDown(self):
+        for name in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, name))
+        os.rmdir(self.tmpdir)
+
+    def test_basic_radiance_product(self):
+        path = os.path.join(self.tmpdir, "basic_radiance.h5")
+        _write_hdfeos_cube(path, "toa_radiance", n_bands=200)
+
+        with mock.patch("hypercoast.tanager.requests.get") as mocked_get:
+            ds = hypercoast.read_tanager(path)
+
+        mocked_get.assert_not_called()
+        self.assertIn("toa_radiance", ds.data_vars)
+        self.assertEqual(ds.attrs["product"], "basic_radiance")
+        self.assertEqual(ds.attrs["data_var"], "toa_radiance")
+        wl = ds.coords["wavelength"].values
+        self.assertEqual(wl.size, 200)
+        self.assertAlmostEqual(float(wl[0]), 400.0, places=2)
+        self.assertAlmostEqual(float(wl[-1]), 2500.0, places=2)
+
+    def test_basic_sr_product_has_alias(self):
+        path = os.path.join(self.tmpdir, "basic_sr.h5")
+        _write_hdfeos_cube(
+            path, "surface_reflectance", n_bands=180, scale_factor=0.0001
+        )
+
+        with mock.patch("hypercoast.tanager.requests.get") as mocked_get:
+            ds = hypercoast.read_tanager(path)
+
+        mocked_get.assert_not_called()
+        self.assertIn("surface_reflectance", ds.data_vars)
+        self.assertIn("toa_radiance", ds.data_vars)
+        np.testing.assert_array_equal(
+            ds["surface_reflectance"].values, ds["toa_radiance"].values
+        )
+        self.assertEqual(ds.attrs["product"], "basic_sr")
+        self.assertEqual(ds.attrs["data_var"], "surface_reflectance")
+
+    def test_ortho_sr_product(self):
+        path = os.path.join(self.tmpdir, "ortho_sr.h5")
+        _write_hdfeos_cube(path, "ortho_surface_reflectance", n_bands=150)
+
+        with mock.patch("hypercoast.tanager.requests.get") as mocked_get:
+            ds = hypercoast.read_tanager(path)
+
+        mocked_get.assert_not_called()
+        self.assertEqual(ds.attrs["product"], "ortho_sr")
+        self.assertIn("surface_reflectance", ds.data_vars)
+        self.assertIn("toa_radiance", ds.data_vars)
+
+    def test_missing_wavelength_warns_and_indexes(self):
+        path = os.path.join(self.tmpdir, "no_wavelength.h5")
+        _write_hdfeos_cube(
+            path, "toa_radiance", n_bands=120, include_wavelength=False
+        )
+
+        with mock.patch("hypercoast.tanager.requests.get") as mocked_get:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                ds = hypercoast.read_tanager(path)
+
+        mocked_get.assert_not_called()
+        self.assertTrue(
+            any(issubclass(w.category, UserWarning) for w in caught),
+            "Expected UserWarning when no wavelength metadata is available",
+        )
+        wl = ds.coords["wavelength"].values
+        np.testing.assert_array_equal(wl, np.arange(120, dtype=float))
+
+    def test_explicit_wavelengths_kwarg_skips_network(self):
+        path = os.path.join(self.tmpdir, "no_wavelength.h5")
+        _write_hdfeos_cube(
+            path, "toa_radiance", n_bands=100, include_wavelength=False
+        )
+        supplied = np.linspace(450.0, 2400.0, 100)
+
+        with mock.patch("hypercoast.tanager.requests.get") as mocked_get:
+            ds = hypercoast.read_tanager(path, wavelengths=supplied)
+
+        mocked_get.assert_not_called()
+        np.testing.assert_allclose(ds.coords["wavelength"].values, supplied)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Tanager reader rewrite**: `hypercoast.read_tanager` now auto-detects all four Planet Tanager product variants (`basic_radiance_hdf5`, `ortho_radiance_hdf5`, `basic_sr_hdf5`, `ortho_sr_hdf5`) by inspecting the HDF5 layout, and sources wavelength metadata from inside the file when present. The previous hardcoded STAC URL and hardcoded `toa_radiance` HDF5 path were the root cause of "Error loading data: No data variable found" on SR and ortho files. A `toa_radiance` alias is kept on SR products so existing helpers (`grid_tanager`, `tanager_to_image`, `filter_tanager`, `extract_tanager`) continue to work unchanged.
- **QGIS plugin defensive fix**: `_extract_pace_metadata` and `_extract_tanager_metadata` now return `False` when the reader produced no data variables, `_load_generic` refuses to declare success on an empty root dataset, and the original reader exception is threaded through the fallback chain so users see a meaningful error in the dialog instead of an empty `Variables: []` preview.
- **Tests**: new `tests/test_tanager.py` covers basic_radiance, basic_sr (with alias), ortho_sr, missing-wavelength warning, and explicit `wavelengths=` kwarg; all assert no network access via a mocked `requests.get`. Added a regression assertion in `tests/test_pace.py` guarding against empty-shell PACE datasets.

Fixes [#241](https://github.com/opengeos/HyperCoast/issues/241).

## Test plan

- [x] `pytest tests/test_tanager.py -v` — 5 passed
- [x] `pytest tests/test_pace.py -v` — existing + new regression assertion pass
- [x] `pre-commit run --all-files` — passes
- [x] Verified `read_pace` on the user-provided sample (`PACE_OCI.20260305T100715.L2.OC_AOP.V3_1.NRT.nc`) still returns 8 data_vars and 172 wavelength bands
- [x] Verified the QGIS plugin pipeline (`HyperspectralDataset('PACE').load()`) on the same sample returns populated `wavelengths` and `data_vars`
- [ ] Open a renamed PACE `.nc` in the QGIS plugin on Windows and confirm the dialog shows the real reader error instead of `Variables: []` when `read_pace` fails
- [ ] Open a real Tanager `ortho_sr_hdf5.h5` file in the QGIS plugin and confirm the preview shows the expected band count and data variable