### PR TITLE
Return downloaded file paths from download_pace and siblings (#244)

### DIFF
--- a/hypercoast/common.py
+++ b/hypercoast/common.py
@@ -247,7 +247,7 @@ def download_nasa_data(
     out_dir: Optional[str] = None,
     provider: Optional[str] = None,
     threads: int = 8,
-) -> None:
+) -> List[str]:
     """Downloads NASA Earthdata granules.
 
     Args:
@@ -255,10 +255,17 @@ def download_nasa_data(
         out_dir (str, optional): The output directory where the granules will be downloaded. Defaults to None (current directory).
         provider (str, optional): The provider of the granules.
         threads (int, optional): The number of threads to use for downloading. Defaults to 8.
-    """
 
-    leafmap.nasa_data_download(
-        granules=granules, out_dir=out_dir, provider=provider, threads=threads
+    Returns:
+        List[str]: The local paths of the downloaded files.
+    """
+    import earthaccess
+
+    if os.environ.get("USE_MKDOCS") is not None:
+        return []
+
+    return earthaccess.download(
+        granules, local_path=out_dir, provider=provider, threads=threads
     )
 
 
@@ -424,7 +431,7 @@ def download_pace(
     out_dir: Optional[str] = None,
     provider: Optional[str] = None,
     threads: int = 8,
-) -> None:
+) -> List[str]:
     """Downloads NASA PACE granules.
 
     Args:
@@ -434,9 +441,12 @@ def download_pace(
         provider (str, optional): The provider of the granules.
         threads (int, optional): The number of threads to use for downloading.
             Defaults to 8.
+
+    Returns:
+        List[str]: The local paths of the downloaded files.
     """
 
-    download_nasa_data(
+    return download_nasa_data(
         granules=granules, out_dir=out_dir, provider=provider, threads=threads
     )
 
@@ -445,7 +455,7 @@ def download_emit(
     granules: List[dict],
     out_dir: Optional[str] = None,
     threads: int = 8,
-) -> None:
+) -> List[str]:
     """Downloads NASA EMIT granules.
 
     Args:
@@ -454,16 +464,19 @@ def download_emit(
             downloaded. Defaults to None (current directory).
         threads (int, optional): The number of threads to use for downloading.
             Defaults to 8.
+
+    Returns:
+        List[str]: The local paths of the downloaded files.
     """
 
-    download_nasa_data(granules=granules, out_dir=out_dir, threads=threads)
+    return download_nasa_data(granules=granules, out_dir=out_dir, threads=threads)
 
 
 def download_ecostress(
     granules: List[dict],
     out_dir: Optional[str] = None,
     threads: int = 8,
-) -> None:
+) -> List[str]:
     """Downloads NASA ECOSTRESS granules.
 
     Args:
@@ -472,9 +485,12 @@ def download_ecostress(
             downloaded. Defaults to None (current directory).
         threads (int, optional): The number of threads to use for downloading.
             Defaults to 8.
+
+    Returns:
+        List[str]: The local paths of the downloaded files.
     """
 
-    download_nasa_data(granules=granules, out_dir=out_dir, threads=threads)
+    return download_nasa_data(granules=granules, out_dir=out_dir, threads=threads)
 
 
 def nasa_earth_login(strategy: str = "all", persist: bool = True, **kwargs) -> None:

--- a/hypercoast/common.py
+++ b/hypercoast/common.py
@@ -259,10 +259,10 @@ def download_nasa_data(
     Returns:
         List[str]: The local paths of the downloaded files.
     """
-    import earthaccess
-
     if os.environ.get("USE_MKDOCS") is not None:
         return []
+
+    import earthaccess
 
     return earthaccess.download(
         granules, local_path=out_dir, provider=provider, threads=threads

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2026 Qiusheng Wu <giswqs@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for the NASA download helpers (regression tests for issue #244)."""
+
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+import hypercoast
+from hypercoast import common
+
+
+class TestDownloadNasaDataReturnValue(unittest.TestCase):
+    """Verify the NASA download helpers return the list of downloaded paths."""
+
+    def setUp(self):
+        """Ensure USE_MKDOCS is not set for the propagation tests."""
+        self._saved_use_mkdocs = os.environ.pop("USE_MKDOCS", None)
+
+    def tearDown(self):
+        """Restore USE_MKDOCS to whatever it was before the test."""
+        if self._saved_use_mkdocs is not None:
+            os.environ["USE_MKDOCS"] = self._saved_use_mkdocs
+        else:
+            os.environ.pop("USE_MKDOCS", None)
+
+    def _stub_earthaccess(self, return_value):
+        """Install a stub ``earthaccess`` module with a recording ``download``.
+
+        Args:
+            return_value: The value the stubbed ``earthaccess.download`` should
+                return.
+
+        Returns:
+            mock.MagicMock: The mock standing in for ``earthaccess.download``.
+        """
+        stub = types.ModuleType("earthaccess")
+        stub.download = mock.MagicMock(return_value=return_value)
+        patcher = mock.patch.dict(sys.modules, {"earthaccess": stub})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return stub.download
+
+    def test_download_nasa_data_returns_paths(self):
+        expected = ["/tmp/a.nc", "/tmp/b.nc"]
+        download = self._stub_earthaccess(expected)
+
+        result = common.download_nasa_data(
+            granules=[{"id": 1}], out_dir="/tmp", provider="POCLOUD", threads=2
+        )
+
+        self.assertEqual(result, expected)
+        download.assert_called_once_with(
+            [{"id": 1}], local_path="/tmp", provider="POCLOUD", threads=2
+        )
+
+    def test_download_pace_propagates_paths(self):
+        expected = ["/tmp/pace.nc"]
+        self._stub_earthaccess(expected)
+
+        result = hypercoast.download_pace(granules=[{"id": 1}], out_dir="/tmp")
+
+        self.assertEqual(result, expected)
+
+    def test_download_emit_propagates_paths(self):
+        expected = ["/tmp/emit.nc"]
+        self._stub_earthaccess(expected)
+
+        result = hypercoast.download_emit(granules=[{"id": 1}], out_dir="/tmp")
+
+        self.assertEqual(result, expected)
+
+    def test_download_ecostress_propagates_paths(self):
+        expected = ["/tmp/ecostress.nc"]
+        self._stub_earthaccess(expected)
+
+        result = hypercoast.download_ecostress(granules=[{"id": 1}], out_dir="/tmp")
+
+        self.assertEqual(result, expected)
+
+    def test_use_mkdocs_short_circuits_without_earthaccess(self):
+        """USE_MKDOCS must return [] before importing earthaccess."""
+        os.environ["USE_MKDOCS"] = "1"
+        self.addCleanup(os.environ.pop, "USE_MKDOCS", None)
+
+        patcher = mock.patch.dict(sys.modules, {"earthaccess": None})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        result = common.download_nasa_data(granules=[{"id": 1}])
+
+        self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes #244. `download_pace`, `download_emit`, `download_ecostress`, and the underlying `download_nasa_data` silently dropped `earthaccess.download`'s return value and were annotated `-> None`. Users who wrote `files = hypercoast.download_pace(...); if not files: ...` wrongly treated successful downloads as failures.
- Call `earthaccess.download` directly from `download_nasa_data`, propagate the `List[str]` result through the three public wrappers, and document the return value.
- Preserve the `USE_MKDOCS` early-return guard so docs builds remain a safe no-op.

## Test plan
- [x] `pre-commit run --all-files` passes
- [x] `pytest -q` passes (25 passed, 4 skipped)
- [x] `inspect.signature(hypercoast.download_pace).return_annotation` now reports `List[str]` for all four functions
- [ ] Manual smoke test with a real NASA Earthdata login (reviewer can run the MRE from the issue and confirm `files` is a non-empty list of existing paths)