### PR TITLE
Fix Spectral Inspector RecursionError in Conda-managed QGIS (#247)

### DIFF
--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -39,6 +39,8 @@ After the installation, you can start QGIS by running the following command:
 conda run qgis
 ```
 
+When QGIS is launched from this Conda environment, the plugin automatically detects that all required packages are already provided by `conda-forge` and uses them directly. The "Install Dependencies" button is not needed in this setup, and the plugin will not create its own virtual environment. This avoids known dependency conflicts between Conda-managed and venv-managed copies of `numpy` / `matplotlib`.
+
 ### QGIS Version
 
 -   QGIS 3.22 or later

--- a/qgis_plugin/hypercoast_qgis/core/venv_manager.py
+++ b/qgis_plugin/hypercoast_qgis/core/venv_manager.py
@@ -239,6 +239,132 @@ def _get_qgis_site_packages():
     return None
 
 
+# ---------------------------------------------------------------------------
+# Conda environment detection
+# ---------------------------------------------------------------------------
+
+# Cached result of using_conda_env_with_deps() for the current process.
+# None means "not yet computed".
+_CONDA_ENV_WITH_DEPS_CACHE = None
+
+
+def _is_conda_env():
+    """Check whether the current Python process is running inside a Conda env.
+
+    Detection prefers the ``CONDA_PREFIX`` environment variable that ``conda
+    activate`` sets, then falls back to looking for the ``conda-meta``
+    directory under ``sys.prefix`` (which Conda creates for every environment
+    it manages). Either signal is sufficient.
+
+    Returns:
+        bool: True if a Conda environment is detected.
+    """
+    if os.environ.get("CONDA_PREFIX"):
+        return True
+    if os.path.isdir(os.path.join(sys.prefix, "conda-meta")):
+        return True
+    return False
+
+
+def _get_package_version_from_current_env(package_name):
+    """Get a package version from the currently active Python environment.
+
+    Uses ``importlib.metadata`` so any package installed into the running
+    interpreter (Conda env, system site-packages, etc.) is detected without
+    needing the venv site-packages on ``sys.path``.
+
+    Args:
+        package_name: Distribution name (e.g. ``"numpy"``).
+
+    Returns:
+        str or None: Version string, or None if the distribution is missing.
+    """
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def _check_requirements_in_current_env(plugin_dir):
+    """Check requirements.txt against packages in the current Python env.
+
+    Mirrors the dict shape returned by :func:`check_packages` so the settings
+    dock can render Conda-env results with the same table renderer.
+
+    Args:
+        plugin_dir: Path to the plugin directory containing requirements.txt.
+
+    Returns:
+        list: List of dicts with keys ``package``, ``required``, ``installed``,
+        ``status`` (``"ok"``, ``"missing"``, or ``"outdated"``), and ``spec``.
+    """
+    requirements = _parse_requirements(plugin_dir)
+    results = []
+
+    for req in requirements:
+        pkg_name = req["package"]
+        installed_ver = _get_package_version_from_current_env(pkg_name)
+
+        if installed_ver is None:
+            status = "missing"
+        elif _version_satisfies(installed_ver, req["operator"], req["version"]):
+            status = "ok"
+        else:
+            status = "outdated"
+
+        results.append(
+            {
+                "package": pkg_name,
+                "required": f"{req['operator']}{req['version']}",
+                "installed": installed_ver,
+                "status": status,
+                "spec": req["spec"],
+            }
+        )
+
+    return results
+
+
+def using_conda_env_with_deps(plugin_dir):
+    """Return True when running in a Conda env that already provides all deps.
+
+    When this is True, the plugin must skip its bundled venv entirely. Doing
+    otherwise causes ``ensure_venv_packages_available`` to swap ``numpy`` /
+    ``matplotlib`` out from under modules that QGIS pre-loaded from the Conda
+    env, producing the ``RecursionError`` reported in issue #247.
+
+    The result is cached for the lifetime of the process because the answer
+    cannot change without restarting QGIS.
+
+    Args:
+        plugin_dir: Path to the plugin directory containing requirements.txt.
+
+    Returns:
+        bool: True only if a Conda env is active AND every requirement in
+        requirements.txt resolves to an installed, version-satisfying package.
+    """
+    global _CONDA_ENV_WITH_DEPS_CACHE
+    if _CONDA_ENV_WITH_DEPS_CACHE is not None:
+        return _CONDA_ENV_WITH_DEPS_CACHE
+
+    if not _is_conda_env():
+        _CONDA_ENV_WITH_DEPS_CACHE = False
+        return False
+
+    statuses = _check_requirements_in_current_env(plugin_dir)
+    if not statuses:
+        # No requirements parsed; treat as "not satisfied" so we do not
+        # silently skip venv setup based on an empty requirements file.
+        _CONDA_ENV_WITH_DEPS_CACHE = False
+        return False
+
+    all_ok = all(s["status"] == "ok" for s in statuses)
+    _CONDA_ENV_WITH_DEPS_CACHE = all_ok
+    return all_ok
+
+
 def _try_qgis_h5py_fallback():
     """Try importing h5py from QGIS's host environment on Windows.
 
@@ -796,6 +922,11 @@ def _version_satisfies(installed, operator, required):
 def check_packages(plugin_dir):
     """Check which packages from requirements.txt are installed in the venv.
 
+    When the plugin is running inside a Conda env that already provides every
+    requirement, the lookup is delegated to the current Python environment
+    instead of the venv site-packages. This keeps the settings dock display in
+    sync with what the plugin actually imports at runtime.
+
     Args:
         plugin_dir: Path to the plugin directory containing requirements.txt.
 
@@ -803,6 +934,9 @@ def check_packages(plugin_dir):
         list: List of dicts with keys: package, required, installed, status, spec.
             status is one of: "ok", "missing", "outdated".
     """
+    if using_conda_env_with_deps(plugin_dir):
+        return _check_requirements_in_current_env(plugin_dir)
+
     requirements = _parse_requirements(plugin_dir)
     site_packages = get_venv_site_packages()
     results = []
@@ -1311,16 +1445,31 @@ def install_dependencies(plugin_dir, progress_callback=None, cancel_check=None):
 # ---------------------------------------------------------------------------
 
 
-def ensure_venv_packages_available():
+def ensure_venv_packages_available(plugin_dir=None):
     """Make venv packages importable by adding site-packages to sys.path.
 
     This prepends the venv's site-packages to sys.path, giving it priority
     over QGIS's bundled packages. Also clears stale entries from sys.modules
     for packages that QGIS may bundle (like numpy).
 
+    When the plugin is running inside a Conda env that already provides every
+    requirement, this is a no-op: the function returns True without touching
+    ``sys.path`` or ``sys.modules``. Mutating either would invalidate the
+    ``numpy`` and ``matplotlib`` instances QGIS pre-loaded from the Conda env,
+    causing the ``RecursionError`` reported in issue #247.
+
+    Args:
+        plugin_dir: Optional path to the plugin directory containing
+            requirements.txt, used for the Conda short-circuit. When omitted,
+            the short-circuit is skipped and the venv flow runs as before.
+
     Returns:
-        True if venv packages are available, False otherwise.
+        True if venv packages (or Conda env packages) are available.
     """
+    if plugin_dir is not None and using_conda_env_with_deps(plugin_dir):
+        _log("Conda environment detected; skipping venv activation")
+        return True
+
     if not venv_exists():
         python_path = get_venv_python_path()
         _log(
@@ -1540,12 +1689,19 @@ def _refresh_module(module_name):
 def get_venv_status(plugin_dir):
     """Check the overall status of the virtual environment.
 
+    When the plugin is running inside a Conda env that already provides every
+    requirement, the venv is unnecessary and is reported as ready without
+    inspection.
+
     Args:
         plugin_dir: Path to the plugin directory containing requirements.txt.
 
     Returns:
         tuple: (is_ready: bool, message: str)
     """
+    if using_conda_env_with_deps(plugin_dir):
+        return True, "Using Conda environment"
+
     if not venv_exists():
         return False, "Dependencies not installed"
 
@@ -1616,6 +1772,13 @@ def create_venv_and_install(plugin_dir, progress_callback=None, cancel_check=Non
     """
     from .python_manager import standalone_python_exists, download_python_standalone
     from .uv_manager import uv_exists as _uv_exists, download_uv
+
+    if using_conda_env_with_deps(plugin_dir):
+        msg = "Using Conda environment, no venv needed."
+        _log(msg, Qgis.Success)
+        if progress_callback:
+            progress_callback(100, msg)
+        return True, msg
 
     start_time = time.time()
 
@@ -1724,7 +1887,7 @@ def create_venv_and_install(plugin_dir, progress_callback=None, cancel_check=Non
         return False, f"Verification failed: {status_msg}"
 
     # Make packages available
-    ensure_venv_packages_available()
+    ensure_venv_packages_available(plugin_dir)
 
     elapsed = time.time() - start_time
     if elapsed >= 60:

--- a/qgis_plugin/hypercoast_qgis/core/venv_manager.py
+++ b/qgis_plugin/hypercoast_qgis/core/venv_manager.py
@@ -243,12 +243,8 @@ def _get_qgis_site_packages():
 # Conda environment detection
 # ---------------------------------------------------------------------------
 
-# Cached result of using_conda_env_with_deps() for the current process.
-# None means "not yet computed".
-_CONDA_ENV_WITH_DEPS_CACHE = None
 
-
-def _is_conda_env():
+def is_conda_env():
     """Check whether the current Python process is running inside a Conda env.
 
     Detection prefers the ``CONDA_PREFIX`` environment variable that ``conda
@@ -335,8 +331,10 @@ def using_conda_env_with_deps(plugin_dir):
     ``matplotlib`` out from under modules that QGIS pre-loaded from the Conda
     env, producing the ``RecursionError`` reported in issue #247.
 
-    The result is cached for the lifetime of the process because the answer
-    cannot change without restarting QGIS.
+    Recomputed on every call so that the Settings dock's ``Refresh Status``
+    button (and any in-process ``conda install`` the user runs alongside QGIS)
+    immediately picks up the new state. The check is just a handful of
+    ``importlib.metadata`` lookups, so the cost is negligible.
 
     Args:
         plugin_dir: Path to the plugin directory containing requirements.txt.
@@ -345,24 +343,16 @@ def using_conda_env_with_deps(plugin_dir):
         bool: True only if a Conda env is active AND every requirement in
         requirements.txt resolves to an installed, version-satisfying package.
     """
-    global _CONDA_ENV_WITH_DEPS_CACHE
-    if _CONDA_ENV_WITH_DEPS_CACHE is not None:
-        return _CONDA_ENV_WITH_DEPS_CACHE
-
-    if not _is_conda_env():
-        _CONDA_ENV_WITH_DEPS_CACHE = False
+    if not is_conda_env():
         return False
 
     statuses = _check_requirements_in_current_env(plugin_dir)
     if not statuses:
         # No requirements parsed; treat as "not satisfied" so we do not
         # silently skip venv setup based on an empty requirements file.
-        _CONDA_ENV_WITH_DEPS_CACHE = False
         return False
 
-    all_ok = all(s["status"] == "ok" for s in statuses)
-    _CONDA_ENV_WITH_DEPS_CACHE = all_ok
-    return all_ok
+    return all(s["status"] == "ok" for s in statuses)
 
 
 def _try_qgis_h5py_fallback():
@@ -922,10 +912,12 @@ def _version_satisfies(installed, operator, required):
 def check_packages(plugin_dir):
     """Check which packages from requirements.txt are installed in the venv.
 
-    When the plugin is running inside a Conda env that already provides every
-    requirement, the lookup is delegated to the current Python environment
-    instead of the venv site-packages. This keeps the settings dock display in
-    sync with what the plugin actually imports at runtime.
+    When the plugin is running inside any Conda environment, the lookup is
+    delegated to the current Python environment instead of the venv
+    site-packages. This keeps the settings dock display in sync with what the
+    plugin actually imports at runtime, even when only some requirements are
+    satisfied by Conda (in which case the venv may not exist yet, and the
+    venv-based lookup would otherwise report every package as missing).
 
     Args:
         plugin_dir: Path to the plugin directory containing requirements.txt.
@@ -934,7 +926,7 @@ def check_packages(plugin_dir):
         list: List of dicts with keys: package, required, installed, status, spec.
             status is one of: "ok", "missing", "outdated".
     """
-    if using_conda_env_with_deps(plugin_dir):
+    if is_conda_env():
         return _check_requirements_in_current_env(plugin_dir)
 
     requirements = _parse_requirements(plugin_dir)

--- a/qgis_plugin/hypercoast_qgis/dialogs/settings_dock.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/settings_dock.py
@@ -193,7 +193,11 @@ class SettingsDockWidget(QDockWidget):
 
     def _check_packages(self):
         """Check which packages are installed and update the table."""
-        from ..core.venv_manager import check_packages
+        from ..core.venv_manager import (
+            _is_conda_env,
+            check_packages,
+            using_conda_env_with_deps,
+        )
 
         packages = check_packages(self.plugin_dir)
         self._populate_table(packages)
@@ -202,21 +206,47 @@ class SettingsDockWidget(QDockWidget):
             1 for p in packages if p["status"] in ("missing", "outdated")
         )
         total_count = len(packages)
+        in_conda = _is_conda_env()
+        conda_with_deps = in_conda and using_conda_env_with_deps(self.plugin_dir)
 
-        if missing_count == 0:
+        if conda_with_deps:
+            # Conda env already provides every requirement. Disable the
+            # bundled venv flow entirely to avoid the numpy/matplotlib
+            # double-import bug from issue #247.
+            self.status_label.setText(
+                f"Conda environment detected. Using {total_count} package(s) "
+                "from the active Conda env."
+            )
+            self.status_label.setStyleSheet("color: green; font-weight: bold;")
+            self.install_btn.setText("Conda Environment - No Install Needed")
+            self.install_btn.setEnabled(False)
+        elif in_conda and missing_count > 0:
+            # In a Conda env but some packages missing. Recommend installing
+            # via conda rather than the bundled venv (which would re-trigger
+            # the issue #247 RecursionError).
+            self.status_label.setText(
+                f"{missing_count} of {total_count} package(s) missing. "
+                "In Conda, prefer:  conda install -c conda-forge hypercoast"
+            )
+            self.status_label.setStyleSheet("color: #ef6c00; font-weight: bold;")
+            self.install_btn.setText(
+                "Install Dependencies Anyway (not recommended in Conda)"
+            )
+            self.install_btn.setEnabled(True)
+        elif missing_count == 0:
             self.status_label.setText(
                 f"All {total_count} packages are installed and up to date."
             )
             self.status_label.setStyleSheet("color: green; font-weight: bold;")
             self.install_btn.setText("Re-install Dependencies")
+            self.install_btn.setEnabled(True)
         else:
             self.status_label.setText(
                 f"{missing_count} of {total_count} packages need to be installed."
             )
             self.status_label.setStyleSheet("color: #d32f2f; font-weight: bold;")
             self.install_btn.setText(f"Install Dependencies ({missing_count} missing)")
-
-        self.install_btn.setEnabled(True)
+            self.install_btn.setEnabled(True)
 
     def _populate_table(self, packages):
         """Populate the package table with check results.

--- a/qgis_plugin/hypercoast_qgis/dialogs/settings_dock.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/settings_dock.py
@@ -194,8 +194,8 @@ class SettingsDockWidget(QDockWidget):
     def _check_packages(self):
         """Check which packages are installed and update the table."""
         from ..core.venv_manager import (
-            _is_conda_env,
             check_packages,
+            is_conda_env,
             using_conda_env_with_deps,
         )
 
@@ -206,7 +206,7 @@ class SettingsDockWidget(QDockWidget):
             1 for p in packages if p["status"] in ("missing", "outdated")
         )
         total_count = len(packages)
-        in_conda = _is_conda_env()
+        in_conda = is_conda_env()
         conda_with_deps = in_conda and using_conda_env_with_deps(self.plugin_dir)
 
         if conda_with_deps:

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -230,7 +230,7 @@ class HyperCoastPlugin:
                     "HyperCoast",
                     Qgis.Info,
                 )
-                venv_manager.ensure_venv_packages_available()
+                venv_manager.ensure_venv_packages_available(self.plugin_dir)
                 self._try_enable_data_dialogs()
             else:
                 QgsMessageLog.logMessage(

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -225,8 +225,15 @@ class HyperCoastPlugin:
             is_ready, message = venv_manager.get_venv_status(self.plugin_dir)
 
             if is_ready:
+                if venv_manager.using_conda_env_with_deps(self.plugin_dir):
+                    startup_msg = (
+                        "Conda environment detected; using Conda-provided "
+                        "packages (skipping venv activation)"
+                    )
+                else:
+                    startup_msg = "Dependencies ready, activating venv packages..."
                 QgsMessageLog.logMessage(
-                    "Dependencies ready, activating venv packages...",
+                    startup_msg,
                     "HyperCoast",
                     Qgis.Info,
                 )


### PR DESCRIPTION
## Summary

- Detect when QGIS is launched from a Conda env that already provides every package in `qgis_plugin/hypercoast_qgis/requirements.txt`, and short-circuit the plugin's bundled venv flow in that case.
- `ensure_venv_packages_available()` becomes a no-op in the Conda case, so it no longer prepends a second `site-packages` to `sys.path` or evicts `numpy`/`pandas`/`xarray`/etc. from `sys.modules`. This is the fix for the Spectral Inspector `RecursionError` reported in #247: matplotlib's reference to Conda's numpy is no longer invalidated by a late swap to a venv numpy.
- Settings dock surfaces the new state with a green "Conda Environment - No Install Needed" banner when deps are satisfied, or an orange `conda install -c conda-forge ...` recommendation when running in Conda but missing packages.

## Why

When QGIS is installed via Conda (the recommended path in `qgis_plugin/README.md`), `conda-forge`'s `hypercoast` already pulls in numpy, matplotlib, xarray, etc. The plugin still provisioned its own venv at `~/.qgis_hypercoast/venv/` and forced its packages onto `sys.path`. By that point QGIS had already imported matplotlib from the Conda env, so matplotlib kept a reference to the Conda numpy while every fresh import resolved to the venv numpy. The two numpy instances clashed inside `numpy._core._methods._any`, producing infinite recursion the moment `SpectralPlotDialog.setup_ui` constructed a `Figure`.

## Test plan

- [ ] In a Conda `geo` env where `conda install -c conda-forge qgis hypercoast` provides all deps, launch QGIS, install the plugin, load a PACE OCI L2 AOP `.nc` file, activate the Spectral Inspector, click a pixel; confirm the spectral plot renders without `RecursionError`.
- [ ] Verify the QGIS message log shows `Conda environment detected; skipping venv activation` and does NOT show `Cleared stale module numpy`.
- [ ] Confirm the HyperCoast settings dock shows the green Conda banner and the install button label is "Conda Environment - No Install Needed" (disabled).
- [ ] Regression: on a non-Conda QGIS install, confirm the venv flow still works end-to-end (`Install Dependencies` creates the venv, packages get installed, dialogs become enabled).
- [ ] In a Conda env that is missing some deps, confirm the orange warning banner appears and the install button is renamed to "Install Dependencies Anyway (not recommended in Conda)".

Closes #247