### PR TITLE
Fix macOS QGIS dependency installer

### DIFF
--- a/qgis_plugin/hypercoast_qgis/core/venv_manager.py
+++ b/qgis_plugin/hypercoast_qgis/core/venv_manager.py
@@ -592,8 +592,25 @@ def venv_exists(venv_dir=None):
 # ---------------------------------------------------------------------------
 
 
+def _is_python_executable_name(path):
+    """Return True when a path name looks like a Python interpreter."""
+    name = os.path.basename(path).lower()
+    if name.endswith(".exe"):
+        name = name[:-4]
+    if name in ("python", "python3"):
+        return True
+    if not name.startswith("python"):
+        return False
+    suffix = name[6:]
+    if "-" in suffix:
+        return False
+    return suffix.isdigit() or (
+        suffix.count(".") == 1 and all(part.isdigit() for part in suffix.split("."))
+    )
+
+
 def _is_macos_qgis_app_bundle_python(path):
-    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    """Return True for unsafe Python launchers in QGIS.app/Contents/MacOS."""
     if not (platform.system() == "Darwin" or sys.platform == "darwin"):
         return False
     parts = os.path.abspath(path).split(os.sep)
@@ -601,7 +618,12 @@ def _is_macos_qgis_app_bundle_python(path):
         lower = part.lower()
         if not (lower.startswith("qgis") and lower.endswith(".app")):
             continue
-        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+        if idx + 2 >= len(parts):
+            return False
+        if parts[idx + 1].lower() != "contents" or parts[idx + 2].lower() != "macos":
+            return False
+        name = os.path.basename(path).lower()
+        return name.startswith("qgis") or _is_python_executable_name(path)
     return False
 
 
@@ -613,7 +635,10 @@ def _find_python_executable():
     executable using multiple strategies.
 
     Returns:
-        Path to a Python executable, or sys.executable as fallback.
+        Path to a Python executable.
+
+    Raises:
+        RuntimeError: If no usable Python executable is found.
     """
     if platform.system() != "Windows":
         if _is_macos_qgis_app_bundle_python(sys.executable):
@@ -624,8 +649,7 @@ def _find_python_executable():
         return sys.executable
 
     # Strategy 1: Check if sys.executable is already Python
-    exe_name = os.path.basename(sys.executable).lower()
-    if exe_name in ("python.exe", "python3.exe"):
+    if _is_python_executable_name(sys.executable):
         return sys.executable
 
     # Strategy 2: Use sys._base_prefix to find the Python installation.
@@ -667,12 +691,15 @@ def _find_python_executable():
             return best_candidate
 
     # Strategy 5: Use shutil.which as last resort
-    which_python = shutil.which("python")
-    if which_python:
-        return which_python
+    for name in ("python3", "python"):
+        which_python = shutil.which(name)
+        if which_python and _is_python_executable_name(which_python):
+            return which_python
 
-    # Fallback: return sys.executable (may fail, but preserves current behavior)
-    return sys.executable
+    raise RuntimeError(
+        f"Could not find a Python interpreter for venv creation; "
+        f"sys.executable is {sys.executable}"
+    )
 
 
 def _get_system_python():
@@ -761,6 +788,12 @@ def create_venv(venv_dir=None, progress_callback=None):
         system_python = _get_system_python()
     except RuntimeError as exc:
         python_lookup_error = str(exc)
+    if python_lookup_error and system_python is None:
+        _log(
+            "Python lookup failed; falling back to uv-managed Python if "
+            f"available: {python_lookup_error}",
+            Qgis.MessageLevel.Warning,
+        )
     if system_python:
         _log(f"Using Python: {system_python}")
 
@@ -780,7 +813,12 @@ def create_venv(venv_dir=None, progress_callback=None):
         _log("Creating venv with uv")
     else:
         if system_python is None:
-            return False, python_lookup_error
+            return (
+                False,
+                python_lookup_error
+                + "\nuv is required when QGIS does not expose a usable Python "
+                "interpreter for venv creation.",
+            )
         cmd = [system_python, "-m", "venv", venv_dir]
         _log("Creating venv with stdlib venv")
 
@@ -855,10 +893,12 @@ def create_venv(venv_dir=None, progress_callback=None):
         _cleanup_partial_venv(venv_dir)
         return False, "Virtual environment creation timed out"
     except FileNotFoundError:
+        missing_executable = cmd[0] if cmd else system_python
         _log(
-            f"Python executable not found: {system_python}", Qgis.MessageLevel.Critical
+            f"Venv creation executable not found: {missing_executable}",
+            Qgis.MessageLevel.Critical,
         )
-        return False, f"Python not found: {system_python}"
+        return False, f"Executable not found: {missing_executable}"
     except Exception as e:
         _log(f"Exception during venv creation: {str(e)}", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)

--- a/qgis_plugin/hypercoast_qgis/core/venv_manager.py
+++ b/qgis_plugin/hypercoast_qgis/core/venv_manager.py
@@ -592,6 +592,19 @@ def venv_exists(venv_dir=None):
 # ---------------------------------------------------------------------------
 
 
+def _is_macos_qgis_app_bundle_python(path):
+    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    if not (platform.system() == "Darwin" or sys.platform == "darwin"):
+        return False
+    parts = os.path.abspath(path).split(os.sep)
+    for idx, part in enumerate(parts):
+        lower = part.lower()
+        if not (lower.startswith("qgis") and lower.endswith(".app")):
+            continue
+        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+    return False
+
+
 def _find_python_executable():
     """Find a working Python executable for venv creation.
 
@@ -603,6 +616,11 @@ def _find_python_executable():
         Path to a Python executable, or sys.executable as fallback.
     """
     if platform.system() != "Windows":
+        if _is_macos_qgis_app_bundle_python(sys.executable):
+            raise RuntimeError(
+                "QGIS app-bundle Python is not safe for creating virtual "
+                "environments; use uv-managed Python instead."
+            )
         return sys.executable
 
     # Strategy 1: Check if sys.executable is already Python
@@ -737,8 +755,14 @@ def create_venv(venv_dir=None, progress_callback=None):
     if progress_callback:
         progress_callback(10, "Creating virtual environment...")
 
-    system_python = _get_system_python()
-    _log(f"Using Python: {system_python}")
+    system_python = None
+    python_lookup_error = ""
+    try:
+        system_python = _get_system_python()
+    except RuntimeError as exc:
+        python_lookup_error = str(exc)
+    if system_python:
+        _log(f"Using Python: {system_python}")
 
     from .uv_manager import uv_exists, get_uv_path
 
@@ -746,9 +770,15 @@ def create_venv(venv_dir=None, progress_callback=None):
 
     if use_uv:
         uv_path = get_uv_path()
-        cmd = [uv_path, "venv", "--python", system_python, venv_dir]
+        uv_python = system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        cmd = [uv_path, "venv"]
+        if system_python is None:
+            cmd.append("--managed-python")
+        cmd += ["--python", uv_python, venv_dir]
         _log("Creating venv with uv")
     else:
+        if system_python is None:
+            return False, python_lookup_error
         cmd = [system_python, "-m", "venv", venv_dir]
         _log("Creating venv with stdlib venv")
 

--- a/qgis_plugin/hypercoast_qgis/core/venv_manager.py
+++ b/qgis_plugin/hypercoast_qgis/core/venv_manager.py
@@ -770,7 +770,9 @@ def create_venv(venv_dir=None, progress_callback=None):
 
     if use_uv:
         uv_path = get_uv_path()
-        uv_python = system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        uv_python = (
+            system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        )
         cmd = [uv_path, "venv"]
         if system_python is None:
             cmd.append("--managed-python")

--- a/qgis_plugin/hypercoast_qgis/metadata.txt
+++ b/qgis_plugin/hypercoast_qgis/metadata.txt
@@ -30,7 +30,9 @@ deprecated=False
 
 hasProcessingProvider=no
 
-changelog=Fix macOS QGIS installer dependency installation and bump patch version.
+changelog=
+    0.7.1
+        - Fix macOS QGIS installer dependency installation
     0.7.0
         - Compatible with QGIS 4.0 (Qt6) while keeping QGIS 3.28+ support
     0.6.0

--- a/qgis_plugin/hypercoast_qgis/metadata.txt
+++ b/qgis_plugin/hypercoast_qgis/metadata.txt
@@ -5,7 +5,7 @@ name=HyperCoast
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Visualize and analyze hyperspectral data including EMIT, PACE, DESIS, NEON, AVIRIS, PRISMA, EnMAP, Tanager, and Wyvern datasets
-version=0.7.0
+version=0.7.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 

--- a/qgis_plugin/hypercoast_qgis/metadata.txt
+++ b/qgis_plugin/hypercoast_qgis/metadata.txt
@@ -30,7 +30,7 @@ deprecated=False
 
 hasProcessingProvider=no
 
-changelog=
+changelog=Fix macOS QGIS installer dependency installation and bump patch version.
     0.7.0
         - Compatible with QGIS 4.0 (Qt6) while keeping QGIS 3.28+ support
     0.6.0


### PR DESCRIPTION
## Summary
- Reject macOS QGIS app-bundle Python wrappers for dependency virtual environment creation where this plugin manages dependency venvs.
- Use uv-managed Python when no safe local Python interpreter is available.
- Bump the QGIS plugin patch version in `metadata.txt`.

## Root Cause
Official macOS QGIS installer builds can expose Python wrappers inside `QGIS*.app/Contents/MacOS` that either fail to start outside QGIS or create virtual environments pointing at the QGIS CI build prefix. Those venvs fail during dependency installation with missing stdlib modules such as `encodings`.

## Validation
- `python -m py_compile qgis_plugin/hypercoast_qgis/core/venv_manager.py`
- Focused local QGIS plugin tests were run from the source checkout before publishing these PRs.
