### PR TITLE
Fix QGIS plugin reload cleanup

### DIFF
--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -34,6 +34,7 @@ except ImportError:
 TOOLBAR_OBJECT_NAME = "HyperCoastToolbar"
 MENU_TITLE = "&HyperCoast"
 
+
 class HyperCoastPlugin:
     """Main HyperCoast QGIS Plugin class."""
 
@@ -193,7 +194,6 @@ class HyperCoastPlugin:
 
         # Auto-check dependencies after GUI is initialized
         QTimer.singleShot(1000, self._check_dependencies_on_startup)
-
 
     def _remove_toolbar(self, toolbar):
         """Detach and schedule deletion of a plugin toolbar widget."""

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -10,7 +10,7 @@ import os
 
 from qgis.PyQt.QtCore import QCoreApplication, Qt, QTimer
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtWidgets import QAction, QMessageBox
+from qgis.PyQt.QtWidgets import QAction, QMessageBox, QToolBar
 from qgis.core import QgsMessageLog, QgsProject, Qgis
 
 # About and update checker have no heavy deps, always available
@@ -31,6 +31,9 @@ except ImportError:
     pass
 
 
+TOOLBAR_OBJECT_NAME = "HyperCoastToolbar"
+MENU_TITLE = "&HyperCoast"
+
 class HyperCoastPlugin:
     """Main HyperCoast QGIS Plugin class."""
 
@@ -46,8 +49,10 @@ class HyperCoastPlugin:
         self.plugin_dir = os.path.dirname(__file__)
         self.actions = []
         self.menu = self.tr("&HyperCoast")
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
         self.toolbar = self.iface.addToolBar("HyperCoast")
-        self.toolbar.setObjectName("HyperCoastToolbar")
+        self.toolbar.setObjectName(TOOLBAR_OBJECT_NAME)
 
         # Store reference to dialogs and dock widgets
         self.load_dialog = None
@@ -189,6 +194,93 @@ class HyperCoastPlugin:
         # Auto-check dependencies after GUI is initialized
         QTimer.singleShot(1000, self._check_dependencies_on_startup)
 
+
+    def _remove_toolbar(self, toolbar):
+        """Detach and schedule deletion of a plugin toolbar widget."""
+        if toolbar is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        actions = []
+        try:
+            actions = list(toolbar.actions())
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.clear()
+        except Exception:
+            pass  # nosec B110
+        for action in actions:
+            try:
+                action.deleteLater()
+            except Exception:
+                pass  # nosec B110
+        try:
+            main_window.removeToolBar(toolbar)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.hide()
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            toolbar.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_toolbars_by_object_name(self):
+        """Remove current or stale plugin toolbars from QGIS."""
+        main_window = self.iface.mainWindow()
+        for toolbar in main_window.findChildren(QToolBar, TOOLBAR_OBJECT_NAME):
+            self._remove_toolbar(toolbar)
+
+    def _plugin_menu_titles(self):
+        """Return possible translated and untranslated plugin menu titles."""
+        titles = {MENU_TITLE}
+        translator = getattr(self, "tr", None)
+        if callable(translator):
+            try:
+                titles.add(translator(MENU_TITLE))
+            except Exception:
+                pass  # nosec B110
+        return titles
+
+    def _remove_menu(self, menu):
+        """Detach and schedule deletion of a plugin menu."""
+        if menu is None:
+            return
+
+        main_window = self.iface.mainWindow()
+        try:
+            menu.clear()
+        except Exception:
+            pass  # nosec B110
+        try:
+            main_window.menuBar().removeAction(menu.menuAction())
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            menu.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_menus_by_title(self):
+        """Remove current or stale plugin menus from QGIS."""
+        menu_bar = self.iface.mainWindow().menuBar()
+        titles = self._plugin_menu_titles()
+        for action in menu_bar.actions():
+            menu = action.menu()
+            if menu is not None and menu.title() in titles:
+                self._remove_menu(menu)
+
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""
         for action in self.actions:
@@ -213,6 +305,9 @@ class HyperCoastPlugin:
         if self.spectral_plot_dialog:
             self.spectral_plot_dialog.close()
             self.spectral_plot_dialog = None
+
+        self._remove_toolbars_by_object_name()
+        self._remove_menus_by_title()
 
     def _check_dependencies_on_startup(self):
         """Check if required dependencies are installed on plugin startup."""


### PR DESCRIPTION
## Summary

Fix QGIS Plugin Reloader warnings caused by custom plugin toolbars and menus that can remain attached to the QGIS main window after `unload()`.

## Changes

- Remove stale plugin toolbars by object name before creating a new toolbar.
- Detach and schedule stale toolbars for deletion during unload.
- Remove stale plugin menus by title before initialization and during unload.
- Keep cleanup best-effort so reload/unload can continue even if QGIS has already detached a widget.

## Validation

- Ran `python -m py_compile` on the changed plugin entry-point file.
- Ran `git diff --check`.
