### PR TITLE
feat: QGIS plugin dockable panels and processing provider

### DIFF
--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -23,6 +23,10 @@ Check out this [short video demo](https://youtu.be/EEUAC5BxqtM) and [full video 
     -   Geology
     -   Chlorophyll-a
 
+-   **Dockable QGIS Panels**: Open HyperCoast tools as dockable panels that can be tabbed with the QGIS interface.
+
+-   **Processing Tools**: Run batch-friendly Processing algorithms for RGB composites, single-band exports, spectral indices, and PCA components.
+
 Before using the plugin, please create a new conda environment to install QGIS and HyperCoast:
 
 ```bash
@@ -43,7 +47,7 @@ When QGIS is launched from this Conda environment, the plugin automatically dete
 
 ### QGIS Version
 
--   QGIS 3.22 or later
+-   QGIS 3.28 or later
 
 ## Installation
 
@@ -93,6 +97,10 @@ When QGIS is launched from this Conda environment, the plugin automatically dete
 4. Click multiple locations to compare spectra
 5. Export data to CSV or save the plot image
 
+### Running Processing Tools
+
+Open **Processing** → **Toolbox** → **HyperCoast** to run batch tools for RGB composites, single-band export, spectral index rasters, and PCA components.
+
 ## Supported File Formats
 
 | Sensor  | Extensions      | Description               |
@@ -107,10 +115,6 @@ When QGIS is launched from this Conda environment, the plugin automatically dete
 | Tanager | .h5             | Planet Tanager            |
 | Wyvern  | .tif, .tiff     | Wyvern Hyperspectral      |
 | Generic | .tif, .nc       | Multi-band GeoTIFF/NetCDF |
-
-## Screenshots
-
-_Coming soon_
 
 ## Development
 

--- a/qgis_plugin/hypercoast_qgis/dialogs/about_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/about_dialog.py
@@ -10,40 +10,49 @@ import os
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QPixmap
 from qgis.PyQt.QtWidgets import (
-    QDialog,
+    QDockWidget,
     QVBoxLayout,
     QHBoxLayout,
     QLabel,
     QPushButton,
     QFrame,
+    QWidget,
 )
 
 
-class AboutDialog(QDialog):
-    """About dialog for HyperCoast plugin."""
+class AboutDialog(QDockWidget):
+    """Dockable About panel for HyperCoast plugin."""
 
     def __init__(self, parent=None):
-        """Initialize the About dialog.
+        """Initialize the About panel.
 
         :param parent: Parent widget
         """
         super().__init__(parent)
         self.setWindowTitle("About HyperCoast")
-        self.setMinimumWidth(450)
+        self.setObjectName("HyperCoastAboutDock")
+        self.setMinimumWidth(360)
         self.setup_ui()
-        self.adjustSize()
 
     def setup_ui(self):
-        """Set up the dialog UI."""
-        layout = QVBoxLayout(self)
-        layout.setSpacing(10)
-        layout.setContentsMargins(20, 15, 20, 15)
+        """Set up the panel UI."""
+        content = QWidget(self)
+        self.setWidget(content)
+        layout = QVBoxLayout(content)
+        layout.setSpacing(12)
+        layout.setContentsMargins(14, 14, 14, 14)
 
         # Icon and title
         header_layout = QHBoxLayout()
+        header_layout.setSpacing(12)
+        header_layout.setContentsMargins(0, 0, 0, 0)
 
         # Load icon
         icon_label = QLabel()
+        icon_label.setFixedSize(64, 64)
+        icon_label.setAlignment(
+            Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter
+        )
         plugin_dir = os.path.dirname(os.path.dirname(__file__))
         icon_path = os.path.join(plugin_dir, "icons", "hypercoast.png")
         if os.path.exists(icon_path):
@@ -58,11 +67,12 @@ class AboutDialog(QDialog):
 
         # Title
         title_layout = QVBoxLayout()
-        title_label = QLabel("<h2>HyperCoast</h2>")
-        version_label = QLabel("<b>Version:</b> 0.3.0")
+        title_layout.setSpacing(2)
+        title_layout.setContentsMargins(0, 0, 0, 0)
+        title_label = QLabel("<h2 style='margin: 0;'>HyperCoast</h2>")
+        version_label = QLabel(f"<b>Version:</b> {self._get_plugin_version()}")
         title_layout.addWidget(title_label)
         title_layout.addWidget(version_label)
-        title_layout.addStretch()
         header_layout.addLayout(title_layout)
         header_layout.addStretch()
 
@@ -98,11 +108,26 @@ class AboutDialog(QDialog):
         author_label.setOpenExternalLinks(True)
         layout.addWidget(author_label)
 
+        layout.addStretch(1)
+
         # Close button
         button_layout = QHBoxLayout()
         button_layout.addStretch()
         close_button = QPushButton("Close")
         close_button.setFixedWidth(100)
-        close_button.clicked.connect(self.accept)
+        close_button.clicked.connect(self.close)
         button_layout.addWidget(close_button)
         layout.addLayout(button_layout)
+
+    def _get_plugin_version(self):
+        """Return the plugin version from metadata.txt."""
+        plugin_dir = os.path.dirname(os.path.dirname(__file__))
+        metadata_path = os.path.join(plugin_dir, "metadata.txt")
+        try:
+            with open(metadata_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    if line.startswith("version="):
+                        return line.split("=", 1)[1].strip()
+        except OSError:
+            pass
+        return "Unknown"

--- a/qgis_plugin/hypercoast_qgis/dialogs/band_combination_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/band_combination_dialog.py
@@ -9,9 +9,10 @@ SPDX-License-Identifier: MIT
 import os
 import tempfile
 import numpy as np
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
+from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtWidgets import (
-    QDialog,
+    QDockWidget,
     QVBoxLayout,
     QHBoxLayout,
     QLabel,
@@ -25,6 +26,8 @@ from qgis.PyQt.QtWidgets import (
     QMessageBox,
     QProgressBar,
     QRadioButton,
+    QSizePolicy,
+    QWidget,
 )
 from qgis.core import (
     QgsCoordinateReferenceSystem,
@@ -33,11 +36,47 @@ from qgis.core import (
     QgsContrastEnhancement,
     QgsMultiBandColorRenderer,
     QgsSingleBandGrayRenderer,
+    QgsColorRampShader,
+    QgsRasterShader,
+    QgsSingleBandPseudoColorRenderer,
 )
 
 
-class BandCombinationDialog(QDialog):
-    """Dialog for changing band combinations of hyperspectral layers."""
+class BandExportWorker(QThread):
+    """Worker thread for exporting selected bands without blocking QGIS."""
+
+    progress = pyqtSignal(int)
+    finished = pyqtSignal(str, str)
+
+    def __init__(self, dataset, output_path, wavelengths, parent=None):
+        """Initialize the worker.
+
+        Args:
+            dataset: Loaded HyperspectralDataset.
+            output_path: GeoTIFF path to create.
+            wavelengths: Selected wavelengths.
+            parent: Optional parent QObject.
+        """
+        super().__init__(parent)
+        self.dataset = dataset
+        self.output_path = output_path
+        self.wavelengths = wavelengths
+
+    def run(self):
+        """Export selected bands in a background thread."""
+        try:
+            self.progress.emit(60)
+            self.dataset.export_to_geotiff(
+                self.output_path, wavelengths=self.wavelengths
+            )
+            self.progress.emit(80)
+            self.finished.emit(self.output_path, "")
+        except Exception as exc:
+            self.finished.emit("", str(exc))
+
+
+class BandCombinationDialog(QDockWidget):
+    """Dockable panel for changing band combinations of hyperspectral layers."""
 
     def __init__(self, iface, plugin, parent=None):
         """Initialize the dialog.
@@ -49,8 +88,11 @@ class BandCombinationDialog(QDialog):
         super().__init__(parent or iface.mainWindow())
         self.iface = iface
         self.plugin = plugin
+        self._export_worker = None
+        self._pending_apply_context = None
 
         self.setWindowTitle("Band Combination")
+        self.setObjectName("HyperCoastBandCombinationDock")
         self.setMinimumWidth(500)
         self.setMinimumHeight(400)
 
@@ -58,11 +100,16 @@ class BandCombinationDialog(QDialog):
 
     def setup_ui(self):
         """Set up the user interface."""
-        layout = QVBoxLayout(self)
+        content = QWidget(self)
+        self.setWidget(content)
+        layout = QVBoxLayout(content)
+        layout.setContentsMargins(6, 6, 6, 6)
+        layout.setSpacing(6)
 
         # Layer selection
         layer_group = QGroupBox("Layer Selection")
         layer_layout = QFormLayout()
+        self._compact_form_layout(layer_layout)
 
         self.layer_combo = QComboBox()
         self.layer_combo.currentIndexChanged.connect(self.on_layer_changed)
@@ -73,11 +120,14 @@ class BandCombinationDialog(QDialog):
         layer_layout.addRow("Info:", self.info_label)
 
         layer_group.setLayout(layer_layout)
+        self._set_compact_group(layer_group)
         layout.addWidget(layer_group)
 
         # Band selection mode
         mode_group = QGroupBox("Display Mode")
         mode_layout = QHBoxLayout()
+        mode_layout.setContentsMargins(8, 6, 8, 6)
+        mode_layout.setSpacing(12)
 
         self.rgb_radio = QRadioButton("RGB Composite")
         self.rgb_radio.setChecked(True)
@@ -87,16 +137,20 @@ class BandCombinationDialog(QDialog):
         self.single_radio = QRadioButton("Single Band")
         self.single_radio.toggled.connect(self.on_mode_changed)
         mode_layout.addWidget(self.single_radio)
+        mode_layout.addStretch()
 
         mode_group.setLayout(mode_layout)
+        self._set_compact_group(mode_group)
         layout.addWidget(mode_group)
 
         # RGB band selection
         self.rgb_group = QGroupBox("RGB Wavelength Selection")
         rgb_layout = QFormLayout()
+        self._compact_form_layout(rgb_layout)
 
         # Red band
         red_layout = QHBoxLayout()
+        red_layout.setSpacing(8)
         self.red_spin = QDoubleSpinBox()
         self.red_spin.setRange(0, 5000)
         self.red_spin.setValue(650)
@@ -114,6 +168,7 @@ class BandCombinationDialog(QDialog):
 
         # Green band
         green_layout = QHBoxLayout()
+        green_layout.setSpacing(8)
         self.green_spin = QDoubleSpinBox()
         self.green_spin.setRange(0, 5000)
         self.green_spin.setValue(550)
@@ -131,6 +186,7 @@ class BandCombinationDialog(QDialog):
 
         # Blue band
         blue_layout = QHBoxLayout()
+        blue_layout.setSpacing(8)
         self.blue_spin = QDoubleSpinBox()
         self.blue_spin.setRange(0, 5000)
         self.blue_spin.setValue(450)
@@ -147,13 +203,16 @@ class BandCombinationDialog(QDialog):
         rgb_layout.addRow("Blue:", blue_layout)
 
         self.rgb_group.setLayout(rgb_layout)
+        self._set_compact_group(self.rgb_group)
         layout.addWidget(self.rgb_group)
 
         # Single band selection
         self.single_group = QGroupBox("Single Band Selection")
         single_layout = QFormLayout()
+        self._compact_form_layout(single_layout)
 
         single_wl_layout = QHBoxLayout()
+        single_wl_layout.setSpacing(8)
         self.single_spin = QDoubleSpinBox()
         self.single_spin.setRange(0, 5000)
         self.single_spin.setValue(550)
@@ -188,13 +247,16 @@ class BandCombinationDialog(QDialog):
 
         self.single_group.setLayout(single_layout)
         self.single_group.setVisible(False)
+        self._set_compact_group(self.single_group)
         layout.addWidget(self.single_group)
 
         # Value range
         range_group = QGroupBox("Value Range")
         range_layout = QFormLayout()
+        self._compact_form_layout(range_layout)
 
         range_row = QHBoxLayout()
+        range_row.setSpacing(8)
         self.vmin_spin = QDoubleSpinBox()
         self.vmin_spin.setRange(-1000, 1000)
         self.vmin_spin.setValue(0)
@@ -215,11 +277,14 @@ class BandCombinationDialog(QDialog):
         range_layout.addRow("", self.auto_stretch)
 
         range_group.setLayout(range_layout)
+        self._set_compact_group(range_group)
         layout.addWidget(range_group)
 
         # Presets
         presets_group = QGroupBox("Quick Presets")
         presets_layout = QHBoxLayout()
+        presets_layout.setContentsMargins(8, 6, 8, 6)
+        presets_layout.setSpacing(8)
 
         presets = [
             ("True Color", 650, 550, 450),
@@ -236,6 +301,7 @@ class BandCombinationDialog(QDialog):
             presets_layout.addWidget(btn)
 
         presets_group.setLayout(presets_layout)
+        self._set_compact_group(presets_group)
         layout.addWidget(presets_group)
 
         # Progress bar
@@ -246,15 +312,35 @@ class BandCombinationDialog(QDialog):
         # Buttons
         button_layout = QHBoxLayout()
 
-        apply_btn = QPushButton("Apply")
-        apply_btn.clicked.connect(self.apply_band_combination)
-        button_layout.addWidget(apply_btn)
+        self.apply_btn = QPushButton("Apply")
+        self.apply_btn.clicked.connect(self.apply_band_combination)
+        button_layout.addWidget(self.apply_btn)
 
         close_btn = QPushButton("Close")
         close_btn.clicked.connect(self.close)
         button_layout.addWidget(close_btn)
 
         layout.addLayout(button_layout)
+        layout.addStretch(1)
+
+    def _set_compact_group(self, group):
+        """Prevent group boxes from consuming extra vertical dock space.
+
+        Args:
+            group: QGroupBox to constrain.
+        """
+        policy = getattr(QSizePolicy, "Policy", QSizePolicy)
+        group.setSizePolicy(policy.Preferred, policy.Maximum)
+
+    def _compact_form_layout(self, layout):
+        """Apply compact spacing to a form layout.
+
+        Args:
+            layout: QFormLayout to compact.
+        """
+        layout.setContentsMargins(8, 6, 8, 6)
+        layout.setHorizontalSpacing(8)
+        layout.setVerticalSpacing(6)
 
     def refresh_layers(self):
         """Refresh the list of available hyperspectral layers."""
@@ -357,9 +443,12 @@ class BandCombinationDialog(QDialog):
         if not data_info:
             QMessageBox.warning(self, "Error", "Layer data not found.")
             return
+        if self._export_worker is not None and self._export_worker.isRunning():
+            return
 
         self.progress_bar.setVisible(True)
         self.progress_bar.setValue(20)
+        self.apply_btn.setEnabled(False)
 
         try:
             dataset = data_info.get("dataset")
@@ -382,18 +471,48 @@ class BandCombinationDialog(QDialog):
             else:
                 wavelengths = [self.single_spin.value()]
 
-            # Export new combination
-            temp_dir = tempfile.gettempdir()
-            temp_path = os.path.join(temp_dir, f"{layer.name()}_bands.tif")
+            temp_path = self._create_temp_raster_path(layer.name(), "bands")
+            self._pending_apply_context = {
+                "layer_id": layer_id,
+                "data_info": data_info,
+                "wavelengths": wavelengths,
+                "is_rgb": self.rgb_radio.isChecked(),
+                "vmin": self.vmin_spin.value(),
+                "vmax": self.vmax_spin.value(),
+                "auto_stretch": self.auto_stretch.isChecked(),
+                "colormap": self.colormap_combo.currentText(),
+            }
+            self._export_worker = BandExportWorker(
+                dataset, temp_path, wavelengths, self
+            )
+            self._export_worker.progress.connect(self.progress_bar.setValue)
+            self._export_worker.finished.connect(self._on_export_finished)
+            self._export_worker.start()
 
-            self.progress_bar.setValue(60)
+        except Exception as e:
+            self._finish_apply_ui()
+            QMessageBox.critical(self, "Error", f"Error applying bands: {str(e)}")
 
-            dataset.export_to_geotiff(temp_path, wavelengths=wavelengths)
+    def _on_export_finished(self, temp_path, error_detail):
+        """Handle selected-band export completion.
 
-            self.progress_bar.setValue(80)
+        Args:
+            temp_path: Exported GeoTIFF path, or empty string on failure.
+            error_detail: Error message when export failed.
+        """
+        try:
+            if not temp_path:
+                raise ValueError(error_detail or "Failed to export selected bands")
 
-            # Create new layer
-            new_layer = QgsRasterLayer(temp_path, layer.name())
+            context = self._pending_apply_context or {}
+            layer_id = context["layer_id"]
+            data_info = context["data_info"]
+            wavelengths = context["wavelengths"]
+            old_layer = QgsProject.instance().mapLayer(layer_id)
+            if not old_layer:
+                raise ValueError("Layer not found")
+
+            new_layer = QgsRasterLayer(temp_path, old_layer.name())
 
             if not new_layer.isValid():
                 raise ValueError("Failed to create layer")
@@ -401,6 +520,7 @@ class BandCombinationDialog(QDialog):
             # If the GeoTIFF was written without CRS (e.g. due to a PROJ DB
             # conflict on Windows), restore it from the dataset metadata so
             # the layer is placed at the correct location on the map.
+            dataset = data_info.get("dataset")
             dataset_crs = data_info.get("crs") or getattr(dataset, "crs", None)
             if not new_layer.crs().isValid() and dataset_crs:
                 known_crs = QgsCoordinateReferenceSystem(str(dataset_crs))
@@ -408,12 +528,13 @@ class BandCombinationDialog(QDialog):
                     new_layer.setCrs(known_crs)
 
             # Apply styling
-            vmin = self.vmin_spin.value()
-            vmax = self.vmax_spin.value()
+            vmin = context["vmin"]
+            vmax = context["vmax"]
 
             provider = new_layer.dataProvider()
+            self._apply_nodata(provider, new_layer.bandCount())
 
-            if self.rgb_radio.isChecked():
+            if context["is_rgb"]:
                 renderer = QgsMultiBandColorRenderer(provider, 1, 2, 3)
 
                 for band_idx in [1, 2, 3]:
@@ -421,7 +542,7 @@ class BandCombinationDialog(QDialog):
                     ce.setContrastEnhancementAlgorithm(
                         QgsContrastEnhancement.StretchToMinimumMaximum
                     )
-                    if not self.auto_stretch.isChecked():
+                    if not context["auto_stretch"]:
                         ce.setMinimumValue(vmin)
                         ce.setMaximumValue(vmax)
 
@@ -432,19 +553,19 @@ class BandCombinationDialog(QDialog):
                     else:
                         renderer.setBlueContrastEnhancement(ce)
             else:
-                renderer = QgsSingleBandGrayRenderer(provider, 1)
-                ce = QgsContrastEnhancement(provider.dataType(1))
-                ce.setContrastEnhancementAlgorithm(
-                    QgsContrastEnhancement.StretchToMinimumMaximum
+                renderer = self._create_single_band_renderer(
+                    provider,
+                    context["colormap"],
+                    vmin,
+                    vmax,
+                    context["auto_stretch"],
                 )
-                if not self.auto_stretch.isChecked():
-                    ce.setMinimumValue(vmin)
-                    ce.setMaximumValue(vmax)
-                renderer.setContrastEnhancement(ce)
 
             new_layer.setRenderer(renderer)
+            self._set_layer_custom_properties(new_layer, data_info, wavelengths)
 
-            # Replace layer in project
+            # Replacing the raster is necessary because the rendered GeoTIFF path
+            # changes, but persist the HyperCoast metadata on the replacement.
             QgsProject.instance().removeMapLayer(layer_id)
             QgsProject.instance().addMapLayer(new_layer)
 
@@ -463,4 +584,129 @@ class BandCombinationDialog(QDialog):
             QMessageBox.critical(self, "Error", f"Error applying bands: {str(e)}")
 
         finally:
-            self.progress_bar.setVisible(False)
+            self._finish_apply_ui()
+
+    def _finish_apply_ui(self):
+        """Restore controls after selected-band export."""
+        self.progress_bar.setVisible(False)
+        self.apply_btn.setEnabled(True)
+        self._pending_apply_context = None
+
+    def _create_temp_raster_path(self, layer_name, suffix):
+        """Create a unique temporary GeoTIFF path.
+
+        Args:
+            layer_name: QGIS layer name used as a readable prefix.
+            suffix: Short output kind.
+
+        Returns:
+            Path to a unique temporary GeoTIFF.
+        """
+        safe_name = "".join(
+            c if c.isalnum() or c in ("-", "_") else "_" for c in layer_name
+        )
+        safe_name = safe_name.strip("_") or "hypercoast"
+        fd, path = tempfile.mkstemp(prefix=f"{safe_name}_{suffix}_", suffix=".tif")
+        os.close(fd)
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        return path
+
+    def _set_layer_custom_properties(self, layer, data_info, wavelengths):
+        """Persist HyperCoast metadata on a replacement layer.
+
+        Args:
+            layer: New QGIS raster layer.
+            data_info: Registered HyperCoast layer metadata.
+            wavelengths: Selected wavelengths.
+        """
+        layer.setCustomProperty("hypercoast/source_path", data_info.get("filepath", ""))
+        layer.setCustomProperty("hypercoast/data_type", data_info.get("data_type", ""))
+        layer.setCustomProperty(
+            "hypercoast/rgb_wavelengths", ",".join(str(v) for v in wavelengths)
+        )
+        if data_info.get("crs"):
+            layer.setCustomProperty("hypercoast/crs", str(data_info["crs"]))
+
+    def _apply_nodata(self, provider, band_count):
+        """Mark plugin-exported no-data values on a QGIS raster provider.
+
+        Args:
+            provider: QGIS raster data provider.
+            band_count: Number of raster bands.
+        """
+        for band_idx in range(1, band_count + 1):
+            try:
+                provider.setNoDataValue(band_idx, -9999.0)
+            except Exception:
+                pass
+
+    def _create_single_band_renderer(
+        self, provider, colormap_name, vmin, vmax, auto_stretch
+    ):
+        """Create a single-band renderer honoring the selected colormap.
+
+        Args:
+            provider: Raster data provider.
+            colormap_name: UI colormap name.
+            vmin: Minimum display value.
+            vmax: Maximum display value.
+            auto_stretch: Whether to let QGIS stretch from statistics.
+
+        Returns:
+            QGIS raster renderer.
+        """
+        if colormap_name == "Grayscale":
+            renderer = QgsSingleBandGrayRenderer(provider, 1)
+            ce = QgsContrastEnhancement(provider.dataType(1))
+            ce.setContrastEnhancementAlgorithm(
+                QgsContrastEnhancement.StretchToMinimumMaximum
+            )
+            if not auto_stretch:
+                ce.setMinimumValue(vmin)
+                ce.setMaximumValue(vmax)
+            renderer.setContrastEnhancement(ce)
+            return renderer
+
+        ramp = QgsColorRampShader()
+        try:
+            ramp.setColorRampType(QgsColorRampShader.Type.Interpolated)
+        except AttributeError:
+            ramp.setColorRampType(QgsColorRampShader.Interpolated)
+        ramp.setColorRampItemList(self._color_ramp_items(colormap_name, vmin, vmax))
+        shader = QgsRasterShader()
+        shader.setRasterShaderFunction(ramp)
+        return QgsSingleBandPseudoColorRenderer(provider, 1, shader)
+
+    def _color_ramp_items(self, colormap_name, vmin, vmax):
+        """Return QGIS color ramp items for a named colormap.
+
+        Args:
+            colormap_name: UI colormap name.
+            vmin: Minimum display value.
+            vmax: Maximum display value.
+
+        Returns:
+            List of QgsColorRampShader.ColorRampItem objects.
+        """
+        palettes = {
+            "Jet": ["#00007f", "#0000ff", "#00ffff", "#ffff00", "#ff0000", "#7f0000"],
+            "Viridis": ["#440154", "#31688e", "#35b779", "#fde725"],
+            "Plasma": ["#0d0887", "#9c179e", "#ed7953", "#f0f921"],
+            "Inferno": ["#000004", "#781c6d", "#ed6925", "#fcffa4"],
+            "Magma": ["#000004", "#721f81", "#f1605d", "#fcfdbf"],
+            "Hot": ["#000000", "#ff0000", "#ffff00", "#ffffff"],
+            "Cool": ["#00ffff", "#ff00ff"],
+            "Rainbow": ["#6e40aa", "#1ac7c2", "#aff05b", "#ff8c38", "#d41159"],
+            "Spectral": ["#9e0142", "#fdae61", "#ffffbf", "#abdda4", "#5e4fa2"],
+        }
+        colors = palettes.get(colormap_name, palettes["Viridis"])
+        if vmax <= vmin:
+            vmax = vmin + 1.0
+        step = (vmax - vmin) / max(len(colors) - 1, 1)
+        return [
+            QgsColorRampShader.ColorRampItem(vmin + i * step, QColor(color), color)
+            for i, color in enumerate(colors)
+        ]

--- a/qgis_plugin/hypercoast_qgis/dialogs/band_combination_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/band_combination_dialog.py
@@ -710,3 +710,20 @@ class BandCombinationDialog(QDockWidget):
             QgsColorRampShader.ColorRampItem(vmin + i * step, QColor(color), color)
             for i, color in enumerate(colors)
         ]
+
+    def closeEvent(self, event):
+        """Stop the background export worker before the dock closes.
+
+        Args:
+            event: Qt close event.
+        """
+        worker = self._export_worker
+        if worker is not None:
+            try:
+                if worker.isRunning():
+                    worker.requestInterruption()
+                    worker.quit()
+                    worker.wait(5000)
+            except RuntimeError:
+                pass  # nosec B110
+        super().closeEvent(event)

--- a/qgis_plugin/hypercoast_qgis/dialogs/dependency_installer.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/dependency_installer.py
@@ -14,7 +14,7 @@ import traceback
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
 from qgis.PyQt.QtGui import QColor, QFont
 from qgis.PyQt.QtWidgets import (
-    QDialog,
+    QDockWidget,
     QHBoxLayout,
     QHeaderView,
     QLabel,
@@ -24,6 +24,7 @@ from qgis.PyQt.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
+    QWidget,
 )
 
 
@@ -64,13 +65,13 @@ class DepsInstallWorker(QThread):
             self.finished.emit(False, error_msg)
 
 
-class DependencyInstallerDialog(QDialog):
-    """Dialog for checking and installing plugin dependencies."""
+class DependencyInstallerDialog(QDockWidget):
+    """Dockable panel for checking and installing plugin dependencies."""
 
     deps_installed = pyqtSignal()
 
     def __init__(self, plugin_dir, parent=None):
-        """Initialize the dialog.
+        """Initialize the panel.
 
         Args:
             plugin_dir: Path to the plugin directory containing requirements.txt.
@@ -81,6 +82,7 @@ class DependencyInstallerDialog(QDialog):
         self.install_worker = None
 
         self.setWindowTitle("HyperCoast - Install Dependencies")
+        self.setObjectName("HyperCoastDependencyInstallerDock")
         self.setMinimumWidth(600)
         self.setMinimumHeight(500)
 
@@ -88,8 +90,10 @@ class DependencyInstallerDialog(QDialog):
         self._check_packages()
 
     def _setup_ui(self):
-        """Set up the dialog UI."""
-        layout = QVBoxLayout(self)
+        """Set up the panel UI."""
+        content = QWidget(self)
+        self.setWidget(content)
+        layout = QVBoxLayout(content)
         layout.setSpacing(12)
 
         # Header

--- a/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
@@ -8,9 +8,9 @@ SPDX-License-Identifier: MIT
 
 import os
 import tempfile
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
 from qgis.PyQt.QtWidgets import (
-    QDialog,
+    QDockWidget,
     QVBoxLayout,
     QHBoxLayout,
     QLabel,
@@ -19,15 +19,12 @@ from qgis.PyQt.QtWidgets import (
     QLineEdit,
     QFileDialog,
     QGroupBox,
-    QSpinBox,
     QDoubleSpinBox,
-    QCheckBox,
     QProgressBar,
     QMessageBox,
     QFormLayout,
     QListWidget,
     QListWidgetItem,
-    QSplitter,
     QTextEdit,
     QTabWidget,
     QWidget,
@@ -38,6 +35,9 @@ from qgis.core import (
     QgsMessageLog,
     QgsCoordinateTransform,
     QgsCoordinateReferenceSystem,
+    QgsContrastEnhancement,
+    QgsMultiBandColorRenderer,
+    QgsSingleBandGrayRenderer,
     Qgis,
 )
 
@@ -48,8 +48,104 @@ from ..hyperspectral_provider import (
 )
 
 
-class LoadDataDialog(QDialog):
-    """Dialog for loading hyperspectral data."""
+class DatasetPreviewWorker(QThread):
+    """Worker thread for loading dataset metadata without blocking QGIS."""
+
+    progress = pyqtSignal(int)
+    finished = pyqtSignal(object, str)
+
+    def __init__(self, filepath, data_type, parent=None):
+        """Initialize the worker.
+
+        Args:
+            filepath: Dataset path to preview.
+            data_type: Requested HyperCoast data type.
+            parent: Optional parent QObject.
+        """
+        super().__init__(parent)
+        self.filepath = filepath
+        self.data_type = data_type
+
+    def run(self):
+        """Load dataset metadata in a background thread."""
+        try:
+            self.progress.emit(50)
+            dataset = HyperspectralDataset(self.filepath, self.data_type)
+            if dataset.load():
+                self.progress.emit(80)
+                self.finished.emit(dataset, "")
+            else:
+                self.finished.emit(None, dataset.last_error or "Unknown error")
+        except Exception as exc:
+            self.finished.emit(None, str(exc))
+
+
+class DatasetLoadWorker(QThread):
+    """Worker thread for loading and exporting an RGB raster."""
+
+    progress = pyqtSignal(int)
+    finished = pyqtSignal(object, str, str)
+
+    def __init__(
+        self,
+        filepath,
+        data_type,
+        output_path,
+        wavelengths,
+        variable_name=None,
+        existing_dataset=None,
+        parent=None,
+    ):
+        """Initialize the worker.
+
+        Args:
+            filepath: Dataset path to load.
+            data_type: Requested HyperCoast data type.
+            output_path: GeoTIFF path to create.
+            wavelengths: RGB wavelengths.
+            variable_name: Data variable to export.
+            existing_dataset: Optional preloaded dataset to reuse.
+            parent: Optional parent QObject.
+        """
+        super().__init__(parent)
+        self.filepath = filepath
+        self.data_type = data_type
+        self.output_path = output_path
+        self.wavelengths = wavelengths
+        self.variable_name = variable_name
+        self.existing_dataset = existing_dataset
+
+    def run(self):
+        """Load/export the dataset in a background thread."""
+        try:
+            self.progress.emit(40)
+            dataset = self.existing_dataset
+            if dataset is None:
+                dataset = HyperspectralDataset(self.filepath, self.data_type)
+                dataset.set_selected_variable(self.variable_name)
+                result = dataset.load_and_export(
+                    self.output_path, wavelengths=self.wavelengths
+                )
+            else:
+                dataset.set_selected_variable(self.variable_name)
+                self.progress.emit(60)
+                result = dataset.export_to_geotiff(
+                    self.output_path, wavelengths=self.wavelengths
+                )
+
+            if result is None:
+                detail = getattr(dataset, "last_error", None) or "Unknown error"
+                self.finished.emit(None, "", detail)
+                return
+
+            self.progress.emit(80)
+            self.finished.emit(dataset, self.output_path, "")
+        except Exception as exc:
+            self.finished.emit(None, "", str(exc))
+
+
+class LoadDataDialog(QDockWidget):
+    """Dockable panel for loading hyperspectral data."""
 
     def __init__(self, iface, plugin, parent=None):
         """Initialize the dialog.
@@ -62,8 +158,12 @@ class LoadDataDialog(QDialog):
         self.iface = iface
         self.plugin = plugin
         self.dataset = None
+        self._preview_worker = None
+        self._load_worker = None
+        self._pending_load_context = None
 
         self.setWindowTitle("Load Hyperspectral Data")
+        self.setObjectName("HyperCoastLoadDataDock")
         self.setMinimumWidth(600)
         self.setMinimumHeight(500)
 
@@ -71,7 +171,9 @@ class LoadDataDialog(QDialog):
 
     def setup_ui(self):
         """Set up the user interface."""
-        layout = QVBoxLayout(self)
+        content = QWidget(self)
+        self.setWidget(content)
+        layout = QVBoxLayout(content)
 
         # Tab widget for different loading options
         tab_widget = QTabWidget()
@@ -100,6 +202,7 @@ class LoadDataDialog(QDialog):
         self.data_type_combo.addItem("Auto-detect", "auto")
         for dtype, info in DATA_TYPES.items():
             self.data_type_combo.addItem(f"{dtype} - {info['description']}", dtype)
+        self.data_type_combo.currentIndexChanged.connect(self._clear_dataset_preview)
         file_group_layout.addRow("Data Type:", self.data_type_combo)
 
         file_group.setLayout(file_group_layout)
@@ -108,6 +211,11 @@ class LoadDataDialog(QDialog):
         # Visualization options
         vis_group = QGroupBox("Visualization Options")
         vis_layout = QFormLayout()
+
+        self.variable_combo = QComboBox()
+        self.variable_combo.setEnabled(False)
+        self.variable_combo.addItem("Default variable", None)
+        vis_layout.addRow("Variable:", self.variable_combo)
 
         # RGB wavelength selection
         rgb_layout = QHBoxLayout()
@@ -168,9 +276,9 @@ class LoadDataDialog(QDialog):
         self.info_text.setMaximumHeight(150)
         info_layout.addWidget(self.info_text)
 
-        preview_btn = QPushButton("Preview Dataset")
-        preview_btn.clicked.connect(self.preview_dataset)
-        info_layout.addWidget(preview_btn)
+        self.preview_btn = QPushButton("Preview Dataset")
+        self.preview_btn.clicked.connect(self.preview_dataset)
+        info_layout.addWidget(self.preview_btn)
 
         info_group.setLayout(info_layout)
         file_layout.addWidget(info_group)
@@ -202,12 +310,9 @@ class LoadDataDialog(QDialog):
             item.setData(Qt.ItemDataRole.UserRole, (r, g, b))
             self.presets_list.addItem(item)
 
+        self.presets_list.currentItemChanged.connect(self.apply_preset)
         self.presets_list.itemDoubleClicked.connect(self.apply_preset)
         presets_group_layout.addWidget(self.presets_list)
-
-        apply_preset_btn = QPushButton("Apply Selected Preset")
-        apply_preset_btn.clicked.connect(self.apply_selected_preset)
-        presets_group_layout.addWidget(apply_preset_btn)
 
         presets_group.setLayout(presets_group_layout)
         presets_layout.addWidget(presets_group)
@@ -225,9 +330,9 @@ class LoadDataDialog(QDialog):
         # Buttons
         button_layout = QHBoxLayout()
 
-        load_btn = QPushButton("Load Data")
-        load_btn.clicked.connect(self.load_data)
-        button_layout.addWidget(load_btn)
+        self.load_btn = QPushButton("Load Data")
+        self.load_btn.clicked.connect(self.load_data)
+        button_layout.addWidget(self.load_btn)
 
         close_btn = QPushButton("Close")
         close_btn.clicked.connect(self.close)
@@ -252,6 +357,13 @@ class LoadDataDialog(QDialog):
             # Clear dataset info since we have a new file
             self.dataset = None
             self.info_text.clear()
+            self._populate_variable_combo(None)
+
+    def _clear_dataset_preview(self, *args):
+        """Clear loaded preview state after the requested data type changes."""
+        self.dataset = None
+        self.info_text.clear()
+        self._populate_variable_combo(None)
 
     def preview_dataset(self):
         """Preview the selected dataset."""
@@ -259,101 +371,139 @@ class LoadDataDialog(QDialog):
         if not filepath or not os.path.exists(filepath):
             QMessageBox.warning(self, "Error", "Please select a valid file.")
             return
+        if self._preview_worker is not None and self._preview_worker.isRunning():
+            return
 
         self.progress_bar.setVisible(True)
         self.progress_bar.setValue(20)
+        self.preview_btn.setEnabled(False)
 
+        data_type = self.data_type_combo.currentData()
+        QgsMessageLog.logMessage(
+            f"Preview dataset requested: file={filepath}, selected_type={data_type}",
+            "HyperCoast",
+            Qgis.MessageLevel.Info,
+        )
+        self._preview_worker = DatasetPreviewWorker(filepath, data_type, self)
+        self._preview_worker.progress.connect(self.progress_bar.setValue)
+        self._preview_worker.finished.connect(self._on_preview_finished)
+        self._preview_worker.start()
+
+    def _on_preview_finished(self, dataset, error_detail):
+        """Handle dataset preview completion.
+
+        Args:
+            dataset: Loaded HyperspectralDataset, or None on failure.
+            error_detail: Error message when preview failed.
+        """
+        self.preview_btn.setEnabled(True)
         try:
-            data_type = self.data_type_combo.currentData()
-            QgsMessageLog.logMessage(
-                f"Preview dataset requested: file={filepath}, selected_type={data_type}",
-                "HyperCoast",
-                Qgis.MessageLevel.Info,
-            )
-            self.dataset = HyperspectralDataset(filepath, data_type)
-
-            self.progress_bar.setValue(50)
-
-            if self.dataset.load():
+            if dataset is not None:
+                self.dataset = dataset
                 self.progress_bar.setValue(80)
-
-                # Display dataset info
-                info_lines = []
-                info_lines.append(f"File: {os.path.basename(filepath)}")
-                info_lines.append(f"Data Type: {self.dataset.data_type}")
-
-                if self.dataset.wavelengths is not None:
-                    n_bands = len(self.dataset.wavelengths)
-                    info_lines.append(f"Bands: {n_bands}")
-                    try:
-                        wl_min = float(self.dataset.wavelengths.min())
-                        wl_max = float(self.dataset.wavelengths.max())
-                        info_lines.append(
-                            f"Wavelength Range: {wl_min:.1f} - {wl_max:.1f} nm"
-                        )
-                    except Exception:
-                        info_lines.append("Wavelength Range: unavailable")
-
-                if self.dataset.bounds:
-                    info_lines.append(f"Bounds: {self.dataset.bounds}")
-
-                if self.dataset.crs:
-                    info_lines.append(f"CRS: {self.dataset.crs}")
-
-                if self.dataset.dataset is not None:
-                    ds = self.dataset.dataset
-                    dims_str = ", ".join(f"{k}: {v}" for k, v in ds.dims.items())
-                    info_lines.append(f"Dimensions: {dims_str}")
-                    info_lines.append(f"Variables: {list(ds.data_vars)}")
-
-                self.info_text.setText("\n".join(info_lines))
+                self.info_text.setText(self._format_dataset_info(dataset))
+                self._populate_variable_combo(dataset)
                 self.progress_bar.setValue(100)
                 QgsMessageLog.logMessage(
-                    f"Preview dataset succeeded: resolved_type={self.dataset.data_type}",
+                    f"Preview dataset succeeded: resolved_type={dataset.data_type}",
                     "HyperCoast",
                     Qgis.MessageLevel.Info,
                 )
             else:
-                # Ensure failed preview does not leave a half-initialized dataset
-                # that would block reloading in load_data().
-                error_detail = self.dataset.last_error or "Unknown error"
+                self.dataset = None
+                self._populate_variable_combo(None)
                 QgsMessageLog.logMessage(
-                    f"Preview dataset failed: file={filepath}, "
-                    f"selected_type={data_type}, details={error_detail}",
+                    f"Preview dataset failed: details={error_detail}",
                     "HyperCoast",
                     Qgis.MessageLevel.Warning,
                 )
-                self.dataset = None
                 QMessageBox.warning(
                     self,
                     "Error",
                     f"Failed to load dataset preview.\n\nDetails:\n{error_detail}",
                 )
-
-        except Exception as e:
-            self.dataset = None
-            QgsMessageLog.logMessage(
-                f"Preview dataset exception: file={filepath}, error={e}",
-                "HyperCoast",
-                Qgis.MessageLevel.Critical,
-            )
-            QMessageBox.critical(self, "Error", f"Error loading dataset: {str(e)}")
-
         finally:
             self.progress_bar.setVisible(False)
 
-    def apply_preset(self, item):
+    def _format_dataset_info(self, dataset):
+        """Return display text for loaded dataset metadata.
+
+        Args:
+            dataset: Loaded HyperspectralDataset.
+
+        Returns:
+            Formatted metadata text.
+        """
+        filepath = dataset.filepath
+        info_lines = []
+        info_lines.append(f"File: {os.path.basename(filepath)}")
+        info_lines.append(f"Data Type: {dataset.data_type}")
+
+        if dataset.wavelengths is not None:
+            n_bands = len(dataset.wavelengths)
+            info_lines.append(f"Bands: {n_bands}")
+            try:
+                wl_min = float(dataset.wavelengths.min())
+                wl_max = float(dataset.wavelengths.max())
+                info_lines.append(f"Wavelength Range: {wl_min:.1f} - {wl_max:.1f} nm")
+            except Exception:
+                info_lines.append("Wavelength Range: unavailable")
+
+        if dataset.bounds:
+            info_lines.append(f"Bounds: {dataset.bounds}")
+
+        if dataset.crs:
+            info_lines.append(f"CRS: {dataset.crs}")
+
+        if dataset.dataset is not None:
+            ds = dataset.dataset
+            dims_str = ", ".join(f"{k}: {v}" for k, v in ds.dims.items())
+            info_lines.append(f"Dimensions: {dims_str}")
+            info_lines.append(f"Variables: {list(ds.data_vars)}")
+
+        return "\n".join(info_lines)
+
+    def _populate_variable_combo(self, dataset):
+        """Populate the export variable combo from a loaded dataset.
+
+        Args:
+            dataset: Loaded HyperspectralDataset, or None to reset.
+        """
+        current = self.variable_combo.currentData()
+        self.variable_combo.blockSignals(True)
+        self.variable_combo.clear()
+        self.variable_combo.addItem("Default variable", None)
+
+        variables = dataset.list_data_variables() if dataset is not None else []
+        for variable in variables:
+            data_var = dataset.dataset[variable]
+            dims = " x ".join(str(size) for size in data_var.shape)
+            self.variable_combo.addItem(f"{variable} ({dims})", variable)
+
+        if current in variables:
+            index = self.variable_combo.findData(current)
+            if index >= 0:
+                self.variable_combo.setCurrentIndex(index)
+
+        self.variable_combo.setEnabled(bool(variables))
+        self.variable_combo.blockSignals(False)
+
+    def _selected_variable_name(self):
+        """Return the variable selected for export.
+
+        Returns:
+            Selected variable name, or None for the provider default.
+        """
+        return self.variable_combo.currentData()
+
+    def apply_preset(self, item, previous=None):
         """Apply a wavelength preset."""
+        if item is None:
+            return
         r, g, b = item.data(Qt.ItemDataRole.UserRole)
         self.red_spin.setValue(r)
         self.green_spin.setValue(g)
         self.blue_spin.setValue(b)
-
-    def apply_selected_preset(self):
-        """Apply the selected preset from the list."""
-        item = self.presets_list.currentItem()
-        if item:
-            self.apply_preset(item)
 
     def load_data(self):
         """Load the hyperspectral data and add to QGIS."""
@@ -361,14 +511,19 @@ class LoadDataDialog(QDialog):
         if not filepath or not os.path.exists(filepath):
             QMessageBox.warning(self, "Error", "Please select a valid file.")
             return
+        if self._load_worker is not None and self._load_worker.isRunning():
+            return
 
         self.progress_bar.setVisible(True)
         self.progress_bar.setValue(10)
+        self.load_btn.setEnabled(False)
+        self.preview_btn.setEnabled(False)
 
         try:
             requested_type = self.data_type_combo.currentData()
             QgsMessageLog.logMessage(
-                f"Load dataset requested: file={filepath}, selected_type={requested_type}",
+                "Load dataset requested: "
+                f"file={filepath}, selected_type={requested_type}",
                 "HyperCoast",
                 Qgis.MessageLevel.Info,
             )
@@ -384,14 +539,16 @@ class LoadDataDialog(QDialog):
                 self.green_spin.value(),
                 self.blue_spin.value(),
             ]
+            variable_name = self._selected_variable_name()
 
-            # Export to temporary GeoTIFF
-            temp_dir = tempfile.gettempdir()
             layer_name = (
                 self.layer_name_edit.text()
                 or os.path.splitext(os.path.basename(filepath))[0]
             )
-            temp_path = os.path.join(temp_dir, f"{layer_name}_rgb.tif")
+            default_layer_name = os.path.splitext(os.path.basename(filepath))[0]
+            if variable_name and layer_name == default_layer_name:
+                layer_name = f"{layer_name} - {variable_name}"
+            temp_path = self._create_temp_raster_path(layer_name, "rgb")
 
             # Load dataset if not already loaded, file changed, or previous load
             # left an uninitialized dataset object.
@@ -402,38 +559,73 @@ class LoadDataDialog(QDialog):
                 or type_changed
             )
 
-            if needs_load:
-                self.dataset = HyperspectralDataset(filepath, requested_type)
-
-                self.progress_bar.setValue(40)
-
-                # Combined load+export reads the file only once on Windows
-                # (avoids a second subprocess + file re-read for the export).
-                result = self.dataset.load_and_export(
-                    temp_path, wavelengths=wavelengths
-                )
-                if result is None:
-                    detail = self.dataset.last_error or "Unknown error"
-                    QgsMessageLog.logMessage(
-                        f"Load dataset failed during read: file={filepath}, "
-                        f"selected_type={requested_type}, details={detail}",
-                        "HyperCoast",
-                        Qgis.MessageLevel.Warning,
-                    )
-                    raise ValueError(f"Failed to load dataset. Details: {detail}")
-            else:
+            existing_dataset = None
+            if not needs_load:
                 if self.dataset.dataset is None:
                     raise ValueError(
                         "Dataset object is initialized but data is not loaded"
                     )
+                existing_dataset = self.dataset
+                existing_dataset.set_selected_variable(variable_name)
 
-                self.progress_bar.setValue(60)
+            self._pending_load_context = {
+                "filepath": filepath,
+                "layer_name": layer_name,
+                "wavelengths": wavelengths,
+                "variable_name": variable_name,
+            }
+            self._load_worker = DatasetLoadWorker(
+                filepath,
+                requested_type,
+                temp_path,
+                wavelengths,
+                variable_name=variable_name,
+                existing_dataset=existing_dataset,
+                parent=self,
+            )
+            self._load_worker.progress.connect(self.progress_bar.setValue)
+            self._load_worker.finished.connect(self._on_load_finished)
+            self._load_worker.start()
 
-                self.dataset.export_to_geotiff(temp_path, wavelengths=wavelengths)
+        except Exception as e:
+            self._finish_load_ui()
+            QMessageBox.critical(self, "Error", f"Error loading data: {str(e)}")
+            QgsMessageLog.logMessage(
+                f"Error loading hyperspectral data: {str(e)}",
+                "HyperCoast",
+                Qgis.MessageLevel.Critical,
+            )
 
+    def _on_load_finished(self, dataset, temp_path, error_detail):
+        """Add the exported raster to QGIS after the load worker completes.
+
+        Args:
+            dataset: Loaded HyperspectralDataset, or None on failure.
+            temp_path: Exported GeoTIFF path.
+            error_detail: Error message when loading failed.
+        """
+        try:
+            context = self._pending_load_context or {}
+            filepath = context.get("filepath", "")
+            layer_name = context.get("layer_name", "HyperCoast")
+            wavelengths = context.get("wavelengths", [])
+            variable_name = context.get("variable_name")
+
+            if dataset is None:
+                QgsMessageLog.logMessage(
+                    f"Load dataset failed: file={filepath}, details={error_detail}",
+                    "HyperCoast",
+                    Qgis.MessageLevel.Warning,
+                )
+                raise ValueError(f"Failed to load dataset. Details: {error_detail}")
+
+            self.dataset = dataset
             self.progress_bar.setValue(80)
+            selected_data_var = self.dataset.get_data_variable()
+            selected_variable = variable_name or getattr(
+                selected_data_var, "name", None
+            )
 
-            # Add to QGIS
             raster_layer = QgsRasterLayer(temp_path, layer_name)
 
             if not raster_layer.isValid():
@@ -457,17 +649,20 @@ class LoadDataDialog(QDialog):
             # Set value range for better visualization
             provider = raster_layer.dataProvider()
             if provider:
+                self._apply_nodata(provider, raster_layer.bandCount())
                 vmin = self.vmin_spin.value()
                 vmax = self.vmax_spin.value()
 
-                # Apply contrast enhancement
-                from qgis.core import QgsContrastEnhancement, QgsMultiBandColorRenderer
+                if raster_layer.bandCount() >= 3:
+                    renderer = QgsMultiBandColorRenderer(
+                        raster_layer.dataProvider(), 1, 2, 3
+                    )
+                    renderer_bands = [1, 2, 3]
+                else:
+                    renderer = QgsSingleBandGrayRenderer(raster_layer.dataProvider(), 1)
+                    renderer_bands = [1]
 
-                renderer = QgsMultiBandColorRenderer(
-                    raster_layer.dataProvider(), 1, 2, 3  # R, G, B band indices
-                )
-
-                for band_idx in [1, 2, 3]:
+                for band_idx in renderer_bands:
                     ce = QgsContrastEnhancement(provider.dataType(band_idx))
                     ce.setContrastEnhancementAlgorithm(
                         QgsContrastEnhancement.StretchToMinimumMaximum
@@ -475,7 +670,9 @@ class LoadDataDialog(QDialog):
                     ce.setMinimumValue(vmin)
                     ce.setMaximumValue(vmax)
 
-                    if band_idx == 1:
+                    if raster_layer.bandCount() < 3:
+                        renderer.setContrastEnhancement(ce)
+                    elif band_idx == 1:
                         renderer.setRedContrastEnhancement(ce)
                     elif band_idx == 2:
                         renderer.setGreenContrastEnhancement(ce)
@@ -484,6 +681,9 @@ class LoadDataDialog(QDialog):
 
                 raster_layer.setRenderer(renderer)
 
+            self._set_layer_custom_properties(
+                raster_layer, filepath, wavelengths, selected_variable
+            )
             QgsProject.instance().addMapLayer(raster_layer)
 
             self.progress_bar.setValue(90)
@@ -495,6 +695,7 @@ class LoadDataDialog(QDialog):
                 "data_type": self.dataset.data_type,
                 "wavelengths": self.dataset.wavelengths,
                 "rgb_wavelengths": wavelengths,
+                "selected_variable": selected_variable,
                 "bounds": self.dataset.bounds,
                 "crs": self.dataset.crs,
             }
@@ -542,4 +743,69 @@ class LoadDataDialog(QDialog):
             )
 
         finally:
-            self.progress_bar.setVisible(False)
+            self._finish_load_ui()
+
+    def _finish_load_ui(self):
+        """Restore the load panel controls after background work."""
+        self.progress_bar.setVisible(False)
+        self.load_btn.setEnabled(True)
+        self.preview_btn.setEnabled(True)
+        self._pending_load_context = None
+
+    def _create_temp_raster_path(self, layer_name, suffix):
+        """Create a unique temporary GeoTIFF path.
+
+        Args:
+            layer_name: QGIS layer name used as a readable prefix.
+            suffix: Short output kind, such as ``"rgb"``.
+
+        Returns:
+            Path to a unique temporary GeoTIFF.
+        """
+        safe_name = "".join(
+            c if c.isalnum() or c in ("-", "_") else "_" for c in layer_name
+        )
+        safe_name = safe_name.strip("_") or "hypercoast"
+        fd, path = tempfile.mkstemp(prefix=f"{safe_name}_{suffix}_", suffix=".tif")
+        os.close(fd)
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        return path
+
+    def _set_layer_custom_properties(
+        self, raster_layer, filepath, wavelengths, selected_variable=None
+    ):
+        """Persist plugin state on a QGIS layer.
+
+        Args:
+            raster_layer: Layer receiving custom properties.
+            filepath: Source hyperspectral dataset path.
+            wavelengths: Selected RGB wavelengths.
+            selected_variable: Data variable exported to the layer.
+        """
+        raster_layer.setCustomProperty("hypercoast/source_path", filepath)
+        raster_layer.setCustomProperty("hypercoast/data_type", self.dataset.data_type)
+        if selected_variable:
+            raster_layer.setCustomProperty(
+                "hypercoast/selected_variable", selected_variable
+            )
+        raster_layer.setCustomProperty(
+            "hypercoast/rgb_wavelengths", ",".join(str(v) for v in wavelengths)
+        )
+        if self.dataset.crs:
+            raster_layer.setCustomProperty("hypercoast/crs", str(self.dataset.crs))
+
+    def _apply_nodata(self, provider, band_count):
+        """Mark plugin-exported no-data values on a QGIS raster provider.
+
+        Args:
+            provider: QGIS raster data provider.
+            band_count: Number of raster bands.
+        """
+        for band_idx in range(1, band_count + 1):
+            try:
+                provider.setNoDataValue(band_idx, -9999.0)
+            except Exception:
+                pass

--- a/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
@@ -808,4 +808,30 @@ class LoadDataDialog(QDockWidget):
             try:
                 provider.setNoDataValue(band_idx, -9999.0)
             except Exception:
-                pass
+                pass  # nosec B110
+
+    def _stop_worker(self, worker):
+        """Request a worker thread to stop and wait for it to finish.
+
+        Args:
+            worker: QThread instance, or None.
+        """
+        if worker is None:
+            return
+        try:
+            if worker.isRunning():
+                worker.requestInterruption()
+                worker.quit()
+                worker.wait(5000)
+        except RuntimeError:
+            pass  # nosec B110
+
+    def closeEvent(self, event):
+        """Stop background workers before the dock closes.
+
+        Args:
+            event: Qt close event.
+        """
+        self._stop_worker(self._preview_worker)
+        self._stop_worker(self._load_worker)
+        super().closeEvent(event)

--- a/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
@@ -8,9 +8,9 @@ SPDX-License-Identifier: MIT
 
 import csv
 import numpy as np
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import Qt, QTimer
 from qgis.PyQt.QtWidgets import (
-    QDialog,
+    QDockWidget,
     QVBoxLayout,
     QHBoxLayout,
     QLabel,
@@ -18,7 +18,6 @@ from qgis.PyQt.QtWidgets import (
     QComboBox,
     QGroupBox,
     QCheckBox,
-    QSpinBox,
     QDoubleSpinBox,
     QFormLayout,
     QTableWidget,
@@ -32,10 +31,16 @@ from qgis.PyQt.QtWidgets import (
 )
 
 try:
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
-    from matplotlib.backends.backend_qt5agg import (
-        NavigationToolbar2QT as NavigationToolbar,
-    )
+    try:
+        from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+        from matplotlib.backends.backend_qtagg import (
+            NavigationToolbar2QT as NavigationToolbar,
+        )
+    except ImportError:
+        from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+        from matplotlib.backends.backend_qt5agg import (
+            NavigationToolbar2QT as NavigationToolbar,
+        )
     from matplotlib.figure import Figure
     import matplotlib.pyplot as plt
 
@@ -44,8 +49,8 @@ except ImportError:
     HAS_MATPLOTLIB = False
 
 
-class SpectralPlotDialog(QDialog):
-    """Dialog for displaying spectral plots."""
+class SpectralPlotDialog(QDockWidget):
+    """Dockable panel for displaying spectral plots."""
 
     def __init__(self, iface, plugin, parent=None):
         """Initialize the dialog.
@@ -59,6 +64,7 @@ class SpectralPlotDialog(QDialog):
         self.plugin = plugin
 
         self.setWindowTitle("Spectral Plot")
+        self.setObjectName("HyperCoastSpectralPlotDock")
         self.setMinimumWidth(800)
         self.setMinimumHeight(600)
 
@@ -70,7 +76,9 @@ class SpectralPlotDialog(QDialog):
 
     def setup_ui(self):
         """Set up the user interface."""
-        layout = QVBoxLayout(self)
+        content = QWidget(self)
+        self.setWidget(content)
+        layout = QVBoxLayout(content)
 
         if not HAS_MATPLOTLIB:
             layout.addWidget(
@@ -116,7 +124,7 @@ class SpectralPlotDialog(QDialog):
         options_form = QFormLayout()
 
         self.stack_check = QCheckBox("Stack Spectra")
-        self.stack_check.setChecked(True)
+        self.stack_check.setChecked(False)
         self.stack_check.stateChanged.connect(self.update_plot)
         options_form.addRow("", self.stack_check)
 
@@ -261,8 +269,8 @@ class SpectralPlotDialog(QDialog):
 
         layout.addWidget(splitter)
 
-        # Initialize empty plot
-        self.update_plot()
+        # Defer the first draw until Qt has assigned the dock/canvas geometry.
+        QTimer.singleShot(0, self.update_plot)
 
     def add_spectrum(self, lat, lon, wavelengths, values, layer_name):
         """Add a new spectrum to the plot.
@@ -316,7 +324,7 @@ class SpectralPlotDialog(QDialog):
                 fontsize=12,
                 color="gray",
             )
-            self.canvas.draw()
+            self._draw_canvas()
             return
 
         # Plot each spectrum
@@ -324,14 +332,20 @@ class SpectralPlotDialog(QDialog):
             color = self.colors[i % len(self.colors)]
 
             wavelengths = spectrum["wavelengths"]
-            values = spectrum["values"]
+            values = self._transform_values(spectrum["values"])
+            x_values = self._transform_x_values(wavelengths)
 
             # Filter negative values (often used as nodata)
             mask = ~np.isnan(values) & (values > -0.1)
             if np.any(mask):
+                plot_values = values[mask]
+                if self.stack_check.isChecked():
+                    span = np.nanmax(plot_values) - np.nanmin(plot_values)
+                    offset = (span if span > 0 else 0.1) * i
+                    plot_values = plot_values + offset
                 self.ax.plot(
-                    wavelengths[mask],
-                    values[mask],
+                    x_values[mask],
+                    plot_values,
                     color=color,
                     label=spectrum["label"],
                     linewidth=1.5,
@@ -339,8 +353,13 @@ class SpectralPlotDialog(QDialog):
 
         # Set labels
         self.ax.set_xlabel(self.xlabel_combo.currentText())
-        self.ax.set_ylabel(self.ylabel_combo.currentText())
-        self.ax.set_title("Spectral Signatures")
+        ylabel = self.ylabel_combo.currentText()
+        title = "Spectral Signatures"
+        if self.stack_check.isChecked():
+            ylabel = f"{ylabel} + display offset"
+            title = "Spectral Signatures (Stacked)"
+        self.ax.set_ylabel(ylabel)
+        self.ax.set_title(title)
 
         # Grid
         if self.grid_check.isChecked():
@@ -356,12 +375,65 @@ class SpectralPlotDialog(QDialog):
             self.ax.set_ylim(self.ymin_spin.value(), self.ymax_spin.value())
 
         self.figure.tight_layout()
-        self.canvas.draw()
+        self._draw_canvas()
 
     def apply_axis_range(self):
         """Apply custom axis range."""
         self.auto_scale.setChecked(False)
         self.update_plot()
+
+    def _transform_x_values(self, wavelengths):
+        """Return x-axis values for the selected axis mode.
+
+        Args:
+            wavelengths: Wavelength array in nanometers.
+
+        Returns:
+            Numpy array for plotting.
+        """
+        mode = self.xlabel_combo.currentText()
+        wavelengths = np.array(wavelengths, dtype=float)
+        if mode == "Band Number":
+            return np.arange(1, len(wavelengths) + 1)
+        if mode == "Frequency (THz)":
+            with np.errstate(divide="ignore", invalid="ignore"):
+                return 299792.458 / wavelengths
+        return wavelengths
+
+    def _draw_canvas(self):
+        """Draw the matplotlib canvas when its Qt geometry is valid."""
+        if not HAS_MATPLOTLIB:
+            return
+        if self.canvas.width() <= 0 or self.canvas.height() <= 0:
+            QTimer.singleShot(50, self.update_plot)
+            return
+        try:
+            self.canvas.draw_idle()
+        except ValueError as exc:
+            if "Invalid affine transformation matrix" not in str(exc):
+                raise
+            QTimer.singleShot(50, self.update_plot)
+
+    def _transform_values(self, values):
+        """Return y-axis values for the selected value mode.
+
+        Args:
+            values: Raw spectral values.
+
+        Returns:
+            Numpy array for plotting.
+        """
+        values = np.array(values, dtype=float)
+        if self.ylabel_combo.currentText() != "Normalized Reflectance":
+            return values
+        valid = values[~np.isnan(values)]
+        if valid.size == 0:
+            return values
+        vmin = np.nanmin(valid)
+        vmax = np.nanmax(valid)
+        if vmax <= vmin:
+            return values * 0
+        return (values - vmin) / (vmax - vmin)
 
     def remove_selected_spectrum(self):
         """Remove the selected spectrum from the plot."""

--- a/qgis_plugin/hypercoast_qgis/dialogs/update_checker.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/update_checker.py
@@ -19,7 +19,7 @@ from urllib.error import URLError, HTTPError
 
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
 from qgis.PyQt.QtWidgets import (
-    QDialog,
+    QDockWidget,
     QVBoxLayout,
     QHBoxLayout,
     QLabel,
@@ -29,6 +29,7 @@ from qgis.PyQt.QtWidgets import (
     QGroupBox,
     QFormLayout,
     QTextEdit,
+    QWidget,
 )
 from qgis.PyQt.QtGui import QFont
 
@@ -215,8 +216,8 @@ class DownloadWorker(QThread):
                     pass
 
 
-class UpdateCheckerDialog(QDialog):
-    """Dialog for checking and installing plugin updates."""
+class UpdateCheckerDialog(QDockWidget):
+    """Dockable panel for checking and installing plugin updates."""
 
     def __init__(self, plugin_dir, parent=None):
         super().__init__(parent)
@@ -228,6 +229,7 @@ class UpdateCheckerDialog(QDialog):
         self.download_worker = None
 
         self.setWindowTitle("HyperCoast Plugin Update")
+        self.setObjectName("HyperCoastUpdateDock")
         self.setMinimumWidth(500)
         self.setMinimumHeight(400)
 
@@ -247,8 +249,10 @@ class UpdateCheckerDialog(QDialog):
         return "Unknown"
 
     def _setup_ui(self):
-        """Set up the dialog UI."""
-        layout = QVBoxLayout(self)
+        """Set up the panel UI."""
+        content = QWidget(self)
+        self.setWidget(content)
+        layout = QVBoxLayout(content)
         layout.setSpacing(15)
 
         # Header

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -10,8 +10,8 @@ import os
 
 from qgis.PyQt.QtCore import QCoreApplication, Qt, QTimer
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtWidgets import QAction, QMessageBox, QToolBar
-from qgis.core import QgsMessageLog, QgsProject, Qgis
+from qgis.PyQt.QtWidgets import QAction, QDockWidget, QMessageBox, QToolBar
+from qgis.core import QgsApplication, QgsMessageLog, QgsProject, Qgis
 
 # About and update checker have no heavy deps, always available
 from .dialogs.about_dialog import AboutDialog
@@ -33,6 +33,15 @@ except ImportError:
 
 TOOLBAR_OBJECT_NAME = "HyperCoastToolbar"
 MENU_TITLE = "&HyperCoast"
+DOCK_OBJECT_NAMES = {
+    "HyperCoastSettingsDock",
+    "HyperCoastLoadDataDock",
+    "HyperCoastBandCombinationDock",
+    "HyperCoastSpectralPlotDock",
+    "HyperCoastAboutDock",
+    "HyperCoastUpdateDock",
+    "HyperCoastDependencyInstallerDock",
+}
 
 
 class HyperCoastPlugin:
@@ -52,6 +61,7 @@ class HyperCoastPlugin:
         self.menu = self.tr("&HyperCoast")
         self._remove_toolbars_by_object_name()
         self._remove_menus_by_title()
+        self._remove_docks_by_object_name()
         self.toolbar = self.iface.addToolBar("HyperCoast")
         self.toolbar.setObjectName(TOOLBAR_OBJECT_NAME)
 
@@ -63,6 +73,9 @@ class HyperCoastPlugin:
         self.about_dialog = None
         self.update_dialog = None
         self._settings_dock = None
+        self._dock_actions = {}
+        self._registered_docks = []
+        self.processing_provider = None
 
         # Track whether dependencies are available
         self._deps_available = False
@@ -135,25 +148,27 @@ class HyperCoastPlugin:
         icons_dir = os.path.join(self.plugin_dir, "icons")
 
         # Load Hyperspectral Data action
-        self.add_action(
+        self.load_action = self.add_action(
             os.path.join(icons_dir, "load_data.png"),
             text=self.tr("Load Hyperspectral Data"),
             callback=self.show_load_dialog,
             parent=self.iface.mainWindow(),
             status_tip=self.tr("Load hyperspectral data (EMIT, PACE, DESIS, etc.)"),
+            checkable=True,
         )
 
         # Band Combination action
-        self.add_action(
+        self.band_action = self.add_action(
             os.path.join(icons_dir, "band_combination.png"),
             text=self.tr("Band Combination"),
             callback=self.show_band_dialog,
             parent=self.iface.mainWindow(),
             status_tip=self.tr("Change band combination for visualization"),
+            checkable=True,
         )
 
         # Spectral Inspector action
-        self.add_action(
+        self.spectral_action = self.add_action(
             os.path.join(icons_dir, "hypercoast.png"),
             text=self.tr("Spectral Inspector"),
             callback=self.toggle_spectral_inspector,
@@ -174,22 +189,24 @@ class HyperCoastPlugin:
         )
 
         # Check for Updates action (menu only, no toolbar)
-        self.add_action(
+        self.update_action = self.add_action(
             ":/images/themes/default/mActionRefresh.svg",
             text=self.tr("Check for Updates..."),
             callback=self.show_update_checker,
             parent=self.iface.mainWindow(),
             status_tip=self.tr("Check for plugin updates from GitHub"),
             add_to_toolbar=False,
+            checkable=True,
         )
 
         # About action
-        self.add_action(
+        self.about_action = self.add_action(
             os.path.join(icons_dir, "about.svg"),
             text=self.tr("About"),
             callback=self.show_about_dialog,
             parent=self.iface.mainWindow(),
             status_tip=self.tr("About HyperCoast plugin"),
+            checkable=True,
         )
 
         # Auto-check dependencies after GUI is initialized
@@ -281,6 +298,114 @@ class HyperCoastPlugin:
             if menu is not None and menu.title() in titles:
                 self._remove_menu(menu)
 
+    def _remove_dock(self, dock):
+        """Detach and schedule deletion of a plugin dock widget."""
+        if dock is None:
+            return
+        try:
+            self.iface.removeDockWidget(dock)
+        except Exception:
+            pass  # nosec B110
+        try:
+            dock.hide()
+        except Exception:
+            pass  # nosec B110
+        try:
+            dock.setParent(None)
+        except Exception:
+            pass  # nosec B110
+        try:
+            dock.deleteLater()
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_docks_by_object_name(self):
+        """Remove current or stale plugin dock widgets from QGIS."""
+        main_window = self.iface.mainWindow()
+        for dock in main_window.findChildren(QDockWidget):
+            if dock.objectName() in DOCK_OBJECT_NAMES:
+                self._remove_dock(dock)
+
+    def _register_dock(self, dock, action):
+        """Register a dock widget and sync it with a checkable action.
+
+        Args:
+            dock: Dock widget to manage.
+            action: QAction that toggles dock visibility.
+        """
+        dock.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
+        dock.visibilityChanged.connect(
+            lambda visible, dock=dock, action=action: self._on_dock_visibility_changed(
+                dock, action, visible
+            )
+        )
+        self.iface.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock)
+        for existing in self._registered_docks:
+            if existing is not dock:
+                try:
+                    self.iface.mainWindow().tabifyDockWidget(existing, dock)
+                    break
+                except Exception:
+                    pass  # nosec B110
+        self._registered_docks.append(dock)
+        self._dock_actions[dock.objectName()] = action
+
+    def _on_dock_visibility_changed(self, dock, action, visible):
+        """Keep dock action checked state aligned with dock visibility.
+
+        Args:
+            dock: Dock widget whose visibility changed.
+            action: QAction associated with the dock.
+            visible: Whether the dock is visible.
+        """
+        action.blockSignals(True)
+        action.setChecked(visible)
+        action.blockSignals(False)
+
+    def _show_dock(self, attr_name, factory, action, before_show=None):
+        """Create if needed, then show and raise a dock widget.
+
+        Args:
+            attr_name: Plugin attribute that stores the dock instance.
+            factory: Callable that creates the dock widget.
+            action: QAction associated with the dock.
+            before_show: Optional callable invoked before showing the dock.
+
+        Returns:
+            The dock widget.
+        """
+        dock = getattr(self, attr_name, None)
+        if dock is None:
+            dock = factory()
+            setattr(self, attr_name, dock)
+            self._register_dock(dock, action)
+        if before_show is not None:
+            before_show(dock)
+        dock.show()
+        dock.raise_()
+        action.setChecked(True)
+        return dock
+
+    def _toggle_dock(self, attr_name, factory, action, before_show=None):
+        """Toggle a dock widget's visibility.
+
+        Args:
+            attr_name: Plugin attribute that stores the dock instance.
+            factory: Callable that creates the dock widget.
+            action: QAction associated with the dock.
+            before_show: Optional callable invoked before showing the dock.
+
+        Returns:
+            The dock widget.
+        """
+        dock = getattr(self, attr_name, None)
+        if dock is not None and dock.isVisible():
+            dock.hide()
+            return dock
+        return self._show_dock(attr_name, factory, action, before_show)
+
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""
         for action in self.actions:
@@ -290,11 +415,23 @@ class HyperCoastPlugin:
         # Remove the toolbar
         del self.toolbar
 
+        self._remove_processing_provider()
+
         # Clean up dock widgets
-        if self._settings_dock:
-            self.iface.removeDockWidget(self._settings_dock)
-            self._settings_dock.deleteLater()
-            self._settings_dock = None
+        for attr_name in (
+            "_settings_dock",
+            "load_dialog",
+            "band_dialog",
+            "spectral_plot_dialog",
+            "about_dialog",
+            "update_dialog",
+        ):
+            dock = getattr(self, attr_name, None)
+            if dock is not None:
+                self._remove_dock(dock)
+                setattr(self, attr_name, None)
+        self._registered_docks.clear()
+        self._dock_actions.clear()
 
         # Clean up tools
         if self.spectral_tool:
@@ -308,6 +445,7 @@ class HyperCoastPlugin:
 
         self._remove_toolbars_by_object_name()
         self._remove_menus_by_title()
+        self._remove_docks_by_object_name()
 
     def _check_dependencies_on_startup(self):
         """Check if required dependencies are installed on plugin startup."""
@@ -426,6 +564,7 @@ class HyperCoastPlugin:
         if _DATA_DIALOGS_AVAILABLE:
             self._deps_available = True
             self._set_data_actions_enabled(True)
+            self._ensure_processing_provider()
             QgsMessageLog.logMessage(
                 "All data features enabled",
                 "HyperCoast",
@@ -434,6 +573,39 @@ class HyperCoastPlugin:
         else:
             self._deps_available = False
             self._set_data_actions_enabled(False)
+            self._remove_processing_provider()
+
+    def _ensure_processing_provider(self):
+        """Register the HyperCoast Processing provider if available."""
+        if self.processing_provider is not None:
+            return
+        try:
+            from .processing_provider import HyperCoastProcessingProvider
+
+            self.processing_provider = HyperCoastProcessingProvider(self.plugin_dir)
+            QgsApplication.processingRegistry().addProvider(self.processing_provider)
+            QgsMessageLog.logMessage(
+                "HyperCoast Processing provider registered",
+                "HyperCoast",
+                Qgis.MessageLevel.Info,
+            )
+        except Exception as e:
+            self.processing_provider = None
+            QgsMessageLog.logMessage(
+                f"Could not register Processing provider: {e}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+
+    def _remove_processing_provider(self):
+        """Remove the HyperCoast Processing provider if registered."""
+        if self.processing_provider is None:
+            return
+        try:
+            QgsApplication.processingRegistry().removeProvider(self.processing_provider)
+        except Exception:
+            pass  # nosec B110
+        self.processing_provider = None
 
     def _set_data_actions_enabled(self, enabled):
         """Enable or disable data-related actions.
@@ -449,39 +621,35 @@ class HyperCoastPlugin:
 
     def toggle_settings_dock(self):
         """Toggle the Settings dock widget visibility."""
-        if self._settings_dock is None:
-            try:
-                from .dialogs.settings_dock import SettingsDockWidget
+        try:
+            from .dialogs.settings_dock import SettingsDockWidget
 
-                self._settings_dock = SettingsDockWidget(
-                    self.plugin_dir, self.iface, self.iface.mainWindow()
-                )
-                self._settings_dock.setObjectName("HyperCoastSettingsDock")
-                self._settings_dock.visibilityChanged.connect(
-                    self._on_settings_visibility_changed
-                )
-                self._settings_dock.deps_installed.connect(self._on_deps_installed)
-                self.iface.addDockWidget(
-                    Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
-                )
-                self._settings_dock.show()
-                self._settings_dock.raise_()
-                return
-            except Exception as e:
-                QMessageBox.critical(
-                    self.iface.mainWindow(),
-                    "Error",
-                    f"Failed to create Settings panel:\n{str(e)}",
-                )
-                self.settings_action.setChecked(False)
-                return
+            self._toggle_dock(
+                "_settings_dock",
+                lambda: self._create_settings_dock(SettingsDockWidget),
+                self.settings_action,
+            )
+        except Exception as e:
+            QMessageBox.critical(
+                self.iface.mainWindow(),
+                "Error",
+                f"Failed to create Settings panel:\n{str(e)}",
+            )
+            self.settings_action.setChecked(False)
 
-        # Toggle visibility
-        if self._settings_dock.isVisible():
-            self._settings_dock.hide()
-        else:
-            self._settings_dock.show()
-            self._settings_dock.raise_()
+    def _create_settings_dock(self, dock_class):
+        """Create the Settings dock and connect dependency signals.
+
+        Args:
+            dock_class: Settings dock widget class.
+
+        Returns:
+            Settings dock widget.
+        """
+        dock = dock_class(self.plugin_dir, self.iface, self.iface.mainWindow())
+        dock.setObjectName("HyperCoastSettingsDock")
+        dock.deps_installed.connect(self._on_deps_installed)
+        return dock
 
     def _on_settings_visibility_changed(self, visible):
         """Handle Settings dock visibility change.
@@ -504,33 +672,36 @@ class HyperCoastPlugin:
         """Show the load hyperspectral data dialog."""
         if not self._deps_available:
             self._show_deps_required_warning()
+            self.load_action.setChecked(False)
             return
         from .dialogs.load_data_dialog import LoadDataDialog
 
-        if self.load_dialog is None:
-            self.load_dialog = LoadDataDialog(self.iface, self)
-        self.load_dialog.show()
-        self.load_dialog.raise_()
-        self.load_dialog.activateWindow()
+        self._toggle_dock(
+            "load_dialog",
+            lambda: LoadDataDialog(self.iface, self, self.iface.mainWindow()),
+            self.load_action,
+        )
 
     def show_band_dialog(self):
         """Show the band combination dialog."""
         if not self._deps_available:
             self._show_deps_required_warning()
+            self.band_action.setChecked(False)
             return
         from .dialogs.band_combination_dialog import BandCombinationDialog
 
-        if self.band_dialog is None:
-            self.band_dialog = BandCombinationDialog(self.iface, self)
-        self.band_dialog.refresh_layers()
-        self.band_dialog.show()
-        self.band_dialog.raise_()
-        self.band_dialog.activateWindow()
+        self._toggle_dock(
+            "band_dialog",
+            lambda: BandCombinationDialog(self.iface, self, self.iface.mainWindow()),
+            self.band_action,
+            before_show=lambda dock: dock.refresh_layers(),
+        )
 
     def toggle_spectral_inspector(self):
         """Toggle the spectral inspector tool."""
         if not self._deps_available:
             self._show_deps_required_warning()
+            self.spectral_action.setChecked(False)
             return
         from .dialogs.spectral_inspector_tool import SpectralInspectorTool
 
@@ -540,6 +711,8 @@ class HyperCoastPlugin:
         if self.spectral_tool.is_active:
             self.spectral_tool.deactivate()
             self.iface.mapCanvas().unsetMapTool(self.spectral_tool)
+            if self.spectral_plot_dialog is not None:
+                self.spectral_plot_dialog.hide()
         else:
             self.spectral_tool.activate()
             self.iface.mapCanvas().setMapTool(self.spectral_tool)
@@ -550,14 +723,15 @@ class HyperCoastPlugin:
         """Show the spectral plot dialog."""
         if not self._deps_available:
             self._show_deps_required_warning()
+            self.spectral_action.setChecked(False)
             return
         from .dialogs.spectral_plot_dialog import SpectralPlotDialog
 
-        if self.spectral_plot_dialog is None:
-            self.spectral_plot_dialog = SpectralPlotDialog(self.iface, self)
-        self.spectral_plot_dialog.show()
-        self.spectral_plot_dialog.raise_()
-        self.spectral_plot_dialog.activateWindow()
+        self._show_dock(
+            "spectral_plot_dialog",
+            lambda: SpectralPlotDialog(self.iface, self, self.iface.mainWindow()),
+            self.spectral_action,
+        )
 
     def _show_deps_required_warning(self):
         """Show a warning that dependencies need to be installed."""
@@ -578,17 +752,8 @@ class HyperCoastPlugin:
             try:
                 from .dialogs.settings_dock import SettingsDockWidget
 
-                self._settings_dock = SettingsDockWidget(
-                    self.plugin_dir, self.iface, self.iface.mainWindow()
-                )
-                self._settings_dock.setObjectName("HyperCoastSettingsDock")
-                self._settings_dock.visibilityChanged.connect(
-                    self._on_settings_visibility_changed
-                )
-                self._settings_dock.deps_installed.connect(self._on_deps_installed)
-                self.iface.addDockWidget(
-                    Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
-                )
+                self._settings_dock = self._create_settings_dock(SettingsDockWidget)
+                self._register_dock(self._settings_dock, self.settings_action)
             except Exception as e:
                 QMessageBox.critical(
                     self.iface.mainWindow(),
@@ -597,34 +762,34 @@ class HyperCoastPlugin:
                 )
                 return
 
-        self._settings_dock.show()
-        self._settings_dock.raise_()
-        self.settings_action.setChecked(True)
+        self._show_dock(
+            "_settings_dock",
+            lambda: self._settings_dock,
+            self.settings_action,
+        )
         self._settings_dock.show_dependencies_tab()
 
     def show_about_dialog(self):
         """Show the About dialog."""
-        if self.about_dialog is None:
-            self.about_dialog = AboutDialog(self.iface.mainWindow())
-        self.about_dialog.show()
-        self.about_dialog.raise_()
-        self.about_dialog.activateWindow()
+        self._toggle_dock(
+            "about_dialog",
+            lambda: AboutDialog(self.iface.mainWindow()),
+            self.about_action,
+        )
 
     def show_update_checker(self):
         """Show the update checker dialog."""
-        if self.update_dialog is None:
-            self.update_dialog = UpdateCheckerDialog(
-                self.plugin_dir, self.iface.mainWindow()
-            )
-        self.update_dialog.show()
-        self.update_dialog.raise_()
-        self.update_dialog.activateWindow()
+        self._toggle_dock(
+            "update_dialog",
+            lambda: UpdateCheckerDialog(self.plugin_dir, self.iface.mainWindow()),
+            self.update_action,
+        )
 
     def register_hyperspectral_layer(self, layer_id, data_info):
         """Register a hyperspectral layer with its metadata.
 
         :param layer_id: The QGIS layer ID
-        :param data_info: Dictionary containing dataset info (xarray dataset, type, wavelengths, etc.)
+        :param data_info: Dictionary containing dataset info.
         """
         self.hyperspectral_data[layer_id] = data_info
 

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -1444,6 +1444,7 @@ class HyperspectralDataset:
 
     def _export_with_hypercoast(self, output_path, wavelengths):
         """Export using hypercoast library."""
+        image = None
         try:
             if wavelengths is None:
                 wavelengths = [650, 550, 450]  # Default RGB
@@ -1492,14 +1493,18 @@ class HyperspectralDataset:
         except Exception as e:
             msg = str(e)
             # If PROJ can't find its database, try configuring PROJ_DATA and retry
-            if "no database context" in msg or "proj_create" in msg:
+            if image is not None and (
+                "no database context" in msg or "proj_create" in msg
+            ):
                 proj_data = self._find_and_set_proj_data()
                 if proj_data:
                     try:
+                        from leafmap import image_to_geotiff
+
                         image_to_geotiff(image, output_path, dtype="float32")
                         return output_path
                     except Exception:
-                        pass
+                        pass  # nosec B110
             _log(f"Error in hypercoast export: {e}", LOG_WARNING)
             return self._export_fallback(output_path, wavelengths, None)
 

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -127,6 +127,17 @@ DATA_TYPES = {
 }
 
 
+PACE_BGC_VARIABLES = [
+    "chlor_a",
+    "carbon_phyto",
+    "pic",
+    "poc",
+    "chlor_a_unc",
+    "carbon_phyto_unc",
+    "l2_flags",
+]
+
+
 class HyperspectralDataset:
     """Class to represent a hyperspectral dataset."""
 
@@ -147,6 +158,7 @@ class HyperspectralDataset:
         self._is_swath = False  # True for non-gridded data like PACE
         self.last_error = None
         self._reader_error = None
+        self.selected_variable = None
 
     def _detect_type(self):
         """Auto-detect the data type based on file extension and content."""
@@ -1163,24 +1175,71 @@ class HyperspectralDataset:
         if self.dataset is None:
             return None
 
+        if self.selected_variable in self.dataset.data_vars:
+            data_var = self.dataset[self.selected_variable]
+            if self._is_exportable_data_variable(data_var):
+                return data_var
+
         var_name = DATA_TYPES.get(self.data_type, {}).get("variable", "data")
 
-        for name in [
+        preferred_names = [
             var_name,
             "reflectance",
             "Rrs",
+            *PACE_BGC_VARIABLES,
             "toa_radiance",
             "data",
             "band_data",
-        ]:
+        ]
+        for name in preferred_names:
             if name in self.dataset.data_vars:
-                return self.dataset[name]
+                data_var = self.dataset[name]
+                if self._is_exportable_data_variable(data_var):
+                    return data_var
 
-        data_vars = list(self.dataset.data_vars)
+        for data_var in self.dataset.data_vars.values():
+            if self._is_exportable_data_variable(data_var):
+                return data_var
+
+        data_vars = list(self.dataset.data_vars.values())
         if data_vars:
-            return self.dataset[data_vars[0]]
+            return data_vars[0]
 
         return None
+
+    def list_data_variables(self):
+        """Return exportable data variable names for the loaded dataset.
+
+        Returns:
+            List of variable names that can be exported as rasters.
+        """
+        if self.dataset is None:
+            return []
+
+        return [
+            name
+            for name, data_var in self.dataset.data_vars.items()
+            if self._is_exportable_data_variable(data_var)
+        ]
+
+    def set_selected_variable(self, variable_name):
+        """Set the preferred data variable for export.
+
+        Args:
+            variable_name: Dataset variable name, or None to use the default.
+        """
+        self.selected_variable = variable_name or None
+
+    def _is_exportable_data_variable(self, data_var):
+        """Return whether a data variable can be exported as a raster.
+
+        Args:
+            data_var: Xarray DataArray candidate.
+
+        Returns:
+            True if the variable has at least two dimensions.
+        """
+        return getattr(data_var, "ndim", 0) >= 2
 
     def extract_spectral_signature(self, x, y, crs="EPSG:4326"):
         """Extract spectral signature at a given location.
@@ -1211,7 +1270,7 @@ class HyperspectralDataset:
             else:
                 return None, None
 
-            return self.wavelengths, values
+            return self._filter_good_wavelengths(self.wavelengths, values)
 
         except Exception as e:
             _log(f"Error extracting spectral signature: {e}", LOG_WARNING)
@@ -1226,19 +1285,25 @@ class HyperspectralDataset:
                     .sel(latitude=lat, longitude=lon, method="nearest")
                     .values
                 )
-                return self.wavelengths, values
+                return self._filter_good_wavelengths(self.wavelengths, values)
 
             elif self.data_type == "PACE":
                 da = hypercoast.extract_pace(self.dataset, lat, lon)
-                return da.coords["wavelength"].values, da.values
+                return self._filter_good_wavelengths(
+                    da.coords["wavelength"].values, da.values
+                )
 
             elif self.data_type == "DESIS":
                 da = hypercoast.extract_desis(self.dataset, lat, lon)
-                return da.coords["wavelength"].values, da.values
+                return self._filter_good_wavelengths(
+                    da.coords["wavelength"].values, da.values
+                )
 
             elif self.data_type == "NEON":
                 da = hypercoast.extract_neon(self.dataset, lat, lon)
-                return da.coords["wavelength"].values, da.values
+                return self._filter_good_wavelengths(
+                    da.coords["wavelength"].values, da.values
+                )
 
             else:
                 data_var = self.get_data_variable()
@@ -1248,11 +1313,46 @@ class HyperspectralDataset:
                     values = data_var.sel(
                         latitude=lat, longitude=lon, method="nearest"
                     ).values
-                return self.wavelengths, values
+                return self._filter_good_wavelengths(self.wavelengths, values)
 
         except Exception as e:
             _log(f"Error in hypercoast extraction: {e}", LOG_WARNING)
             return None, None
+
+    def _filter_good_wavelengths(self, wavelengths, values):
+        """Filter spectral values using dataset good-wavelength metadata.
+
+        Args:
+            wavelengths: Spectral wavelength array.
+            values: Spectral value array.
+
+        Returns:
+            Tuple of filtered wavelength and value arrays.
+        """
+        if wavelengths is None or values is None:
+            return wavelengths, values
+
+        wavelengths = np.asarray(wavelengths)
+        values = np.asarray(values)
+        if values.ndim != 1 or wavelengths.ndim != 1:
+            return wavelengths, values
+        if len(values) != len(wavelengths):
+            return wavelengths, values
+
+        good = None
+        try:
+            if self.dataset is not None and "good_wavelengths" in self.dataset.coords:
+                good = np.asarray(self.dataset.coords["good_wavelengths"].values)
+            elif self.dataset is not None and "good_wavelengths" in self.dataset:
+                good = np.asarray(self.dataset["good_wavelengths"].values)
+        except Exception:
+            good = None
+
+        mask = np.isfinite(wavelengths) & np.isfinite(values)
+        if good is not None and good.ndim == 1 and len(good) == len(wavelengths):
+            mask &= good.astype(float) > 0
+
+        return wavelengths[mask], values[mask]
 
     @staticmethod
     def _find_and_set_proj_data():
@@ -1320,6 +1420,15 @@ class HyperspectralDataset:
             LOG_INFO,
         )
 
+        # EMIT exports must use HyperCoast's orthorectified writer when
+        # available. If the module-level HAS_HYPERCOAST flag is stale because
+        # dependencies were activated after import, retry the runtime import
+        # here before falling back to generic xarray dimension handling.
+        if self.data_type == "EMIT":
+            result = self._export_emit_with_runtime_hypercoast(output_path, wavelengths)
+            if result:
+                return result
+
         # Use hypercoast's export functions if available
         if HAS_HYPERCOAST:
             return self._export_with_hypercoast(output_path, wavelengths)
@@ -1336,16 +1445,25 @@ class HyperspectralDataset:
     def _export_with_hypercoast(self, output_path, wavelengths):
         """Export using hypercoast library."""
         try:
-            from leafmap import array_to_image
-
             if wavelengths is None:
                 wavelengths = [650, 550, 450]  # Default RGB
 
             if self.data_type == "EMIT":
+                result = self._export_emit_with_runtime_hypercoast(
+                    output_path, wavelengths
+                )
+                if result:
+                    return result
                 image = hypercoast.emit_to_image(self.dataset, wavelengths=wavelengths)
 
             elif self.data_type == "PACE":
-                # PACE needs gridding first
+                if "Rrs" not in self.dataset.data_vars:
+                    result = self._export_pace_bgc_with_hypercoast(output_path)
+                    if result:
+                        return result
+                    return self._export_fallback(output_path, wavelengths, None)
+
+                # PACE AOP needs gridding first
                 image = hypercoast.pace_to_image(
                     self.dataset, wavelengths=wavelengths, method="nearest"
                 )
@@ -1385,6 +1503,279 @@ class HyperspectralDataset:
             _log(f"Error in hypercoast export: {e}", LOG_WARNING)
             return self._export_fallback(output_path, wavelengths, None)
 
+    def _export_pace_bgc_with_hypercoast(self, output_path, method="linear"):
+        """Export a PACE BGC 2D product after gridding swath coordinates.
+
+        Args:
+            output_path: Output GeoTIFF file path.
+            method: Interpolation method passed to HyperCoast gridding.
+
+        Returns:
+            Output path on success, otherwise None.
+        """
+        variable = self._pace_bgc_variable_name()
+        if variable is None:
+            return None
+
+        try:
+            method = self._pace_bgc_interpolation_method(variable, method)
+            grid = hypercoast.grid_pace_bgc(
+                self.dataset, variable=variable, method=method
+            )
+            data = np.asarray(grid.values, dtype="float32")
+            if data.ndim != 2:
+                raise ValueError(f"Expected 2D PACE BGC grid, got {data.shape}")
+
+            y_values = np.asarray(grid.coords["latitude"].values, dtype="float64")
+            x_values = np.asarray(grid.coords["longitude"].values, dtype="float64")
+            data = self._orient_array_north_up(data, y_values, y_axis=0)
+            height, width = data.shape
+            transform = from_bounds(
+                float(np.nanmin(x_values)),
+                float(np.nanmin(y_values)),
+                float(np.nanmax(x_values)),
+                float(np.nanmax(y_values)),
+                width,
+                height,
+            )
+            nodata = -9999.0
+            data = np.where(np.isfinite(data), data, nodata).astype("float32")
+
+            with rasterio.open(
+                output_path,
+                "w",
+                driver="GTiff",
+                height=height,
+                width=width,
+                count=1,
+                dtype="float32",
+                crs=self.crs or "EPSG:4326",
+                transform=transform,
+                nodata=nodata,
+                tiled=True,
+                compress="deflate",
+            ) as dst:
+                dst.write(data, 1)
+                dst.set_band_description(1, variable)
+
+            _log(
+                f"PACE BGC GeoTIFF export succeeded: variable={variable}, "
+                f"output={output_path}",
+                LOG_INFO,
+            )
+            return output_path
+        except Exception as exc:
+            _log(f"PACE BGC HyperCoast export failed: {exc}", LOG_WARNING)
+            return None
+
+    def _pace_bgc_variable_name(self):
+        """Return the preferred PACE BGC product variable name.
+
+        Returns:
+            Variable name, or None when the dataset has no BGC raster product.
+        """
+        if self.dataset is None:
+            return None
+        if self.selected_variable in self.dataset.data_vars:
+            data_var = self.dataset[self.selected_variable]
+            if self._is_exportable_data_variable(data_var):
+                return self.selected_variable
+        for name in PACE_BGC_VARIABLES:
+            if name in self.dataset.data_vars and self._is_exportable_data_variable(
+                self.dataset[name]
+            ):
+                return name
+        return None
+
+    def _pace_bgc_interpolation_method(self, variable, default_method):
+        """Return the interpolation method for a PACE BGC variable.
+
+        Args:
+            variable: PACE BGC variable name.
+            default_method: Default interpolation method.
+
+        Returns:
+            Interpolation method name.
+        """
+        data_var = self.dataset[variable]
+        if np.issubdtype(data_var.dtype, np.integer):
+            return "nearest"
+        return default_method
+
+    def _orient_array_north_up(self, data, y_values, y_axis):
+        """Flip raster data when y coordinates are stored south-to-north.
+
+        Args:
+            data: Raster data array.
+            y_values: One-dimensional y coordinate values.
+            y_axis: Axis in ``data`` that corresponds to y rows.
+
+        Returns:
+            Raster data array with row 0 representing the northern edge.
+        """
+        if len(y_values) > 1 and y_values[0] < y_values[-1]:
+            return np.flip(data, axis=y_axis)
+        return data
+
+    def _export_emit_with_runtime_hypercoast(self, output_path, wavelengths):
+        """Export EMIT RGB using HyperCoast's orthorectified writer.
+
+        Args:
+            output_path: Output GeoTIFF file path.
+            wavelengths: RGB wavelengths.
+
+        Returns:
+            Output path on success, otherwise None.
+        """
+        if wavelengths is None:
+            wavelengths = [650, 550, 450]
+        try:
+            try:
+                hc = hypercoast if HAS_HYPERCOAST else None
+            except NameError:
+                hc = None
+            if hc is None:
+                from ._hypercoast_lib import get_hypercoast
+
+                hc = get_hypercoast()
+            result = hc.emit_to_image(
+                self.filepath,
+                wavelengths=wavelengths,
+                output=output_path,
+            )
+            if result and os.path.isfile(output_path):
+                _log(f"HyperCoast EMIT export succeeded: {output_path}", LOG_INFO)
+                return output_path
+        except Exception as exc:
+            _log(f"Runtime HyperCoast EMIT export failed: {exc}", LOG_WARNING)
+        return None
+
+    def _export_rectilinear_geotiff(self, output_path, wavelengths=None, bands=None):
+        """Export a rectilinear hyperspectral cube directly to GeoTIFF.
+
+        This path preserves float reflectance values, CRS, transform, band order,
+        and no-data metadata. It avoids routing orthorectified EMIT cubes through
+        PIL image conversion, which can produce visually misleading striping in
+        QGIS and does not reliably preserve no-data transparency.
+
+        Args:
+            output_path: Output GeoTIFF file path.
+            wavelengths: Wavelengths to select.
+            bands: Band indexes to select when wavelengths are unavailable.
+
+        Returns:
+            Output GeoTIFF file path.
+
+        Raises:
+            ValueError: If the dataset is not a rectilinear raster cube.
+        """
+        data_var = self.get_data_variable()
+        if data_var is None:
+            raise ValueError("No data variable found")
+
+        spatial_dims = self._get_spatial_dims(data_var)
+        if spatial_dims is None:
+            raise ValueError(f"Cannot identify spatial dimensions: {data_var.dims}")
+        y_dim, x_dim = spatial_dims
+
+        if wavelengths is not None and "wavelength" in data_var.dims:
+            data = data_var.sel(wavelength=wavelengths, method="nearest")
+        elif bands is not None:
+            spectral_dim = self._get_spectral_dim(data_var, y_dim, x_dim)
+            data = data_var.isel({spectral_dim: bands})
+        else:
+            spectral_dim = self._get_spectral_dim(data_var, y_dim, x_dim)
+            data = data_var.isel({spectral_dim: slice(0, 3)})
+
+        arr = np.asarray(data.values, dtype="float32")
+        if arr.ndim == 2:
+            arr = arr[np.newaxis, :, :]
+        elif arr.ndim == 3:
+            dims = list(data.dims)
+            spectral_dim = self._get_spectral_dim(data, y_dim, x_dim)
+            spectral_axis = dims.index(spectral_dim)
+            if spectral_axis != 0:
+                arr = np.moveaxis(arr, spectral_axis, 0)
+        else:
+            raise ValueError(f"Cannot export array with shape {arr.shape}")
+
+        y_values = np.asarray(data_var.coords[y_dim].values, dtype="float64")
+        x_values = np.asarray(data_var.coords[x_dim].values, dtype="float64")
+        bounds = (
+            float(np.nanmin(x_values)),
+            float(np.nanmin(y_values)),
+            float(np.nanmax(x_values)),
+            float(np.nanmax(y_values)),
+        )
+        height = arr.shape[1]
+        width = arr.shape[2]
+        transform = from_bounds(*bounds, width, height)
+
+        nodata = -9999.0
+        arr = np.where(np.isfinite(arr), arr, nodata).astype("float32")
+
+        with rasterio.open(
+            output_path,
+            "w",
+            driver="GTiff",
+            height=height,
+            width=width,
+            count=arr.shape[0],
+            dtype="float32",
+            crs=self.crs or "EPSG:4326",
+            transform=transform,
+            nodata=nodata,
+            tiled=True,
+            compress="deflate",
+        ) as dst:
+            dst.write(arr)
+            if "wavelength" in data.coords:
+                selected_wavelengths = np.atleast_1d(data.coords["wavelength"].values)
+                for idx, wavelength in enumerate(selected_wavelengths, start=1):
+                    dst.set_band_description(idx, f"{float(wavelength):.2f} nm")
+
+        _log(f"Rectilinear GeoTIFF export succeeded: {output_path}", LOG_INFO)
+        return output_path
+
+    def _get_spatial_dims(self, data_var):
+        """Return y/x dimension names for a raster-like DataArray.
+
+        Args:
+            data_var: Xarray DataArray.
+
+        Returns:
+            Tuple of ``(y_dim, x_dim)`` or None.
+        """
+        dims = set(data_var.dims)
+        for y_dim, x_dim in (
+            ("latitude", "longitude"),
+            ("y", "x"),
+            ("northing", "easting"),
+            ("downtrack", "crosstrack"),
+        ):
+            if y_dim in dims and x_dim in dims:
+                return y_dim, x_dim
+        return None
+
+    def _get_spectral_dim(self, data_var, y_dim, x_dim):
+        """Return the spectral dimension name for a DataArray.
+
+        Args:
+            data_var: Xarray DataArray.
+            y_dim: Spatial y dimension name.
+            x_dim: Spatial x dimension name.
+
+        Returns:
+            Spectral dimension name.
+
+        Raises:
+            ValueError: If no spectral dimension can be found.
+        """
+        for dim in data_var.dims:
+            if dim not in (y_dim, x_dim):
+                return dim
+        raise ValueError(f"No spectral dimension found: {data_var.dims}")
+
     def _export_fallback(self, output_path, wavelengths, bands):
         """Fallback export without hypercoast."""
         _log("Using fallback GeoTIFF export path", LOG_INFO)
@@ -1421,16 +1812,28 @@ class HyperspectralDataset:
         elif arr.ndim == 2:
             arr = arr[np.newaxis, :, :]
         elif arr.ndim == 3:
-            # Find wavelength dimension and move to first
-            dims = list(data.dims)
-            for i, d in enumerate(dims):
-                if d not in ["x", "y", "latitude", "longitude"]:
-                    if i != 0:
-                        arr = np.moveaxis(arr, i, 0)
-                    break
+            spatial_dims = self._get_spatial_dims(data)
+            if spatial_dims is not None:
+                y_dim, x_dim = spatial_dims
+                spectral_dim = self._get_spectral_dim(data, y_dim, x_dim)
+                dims = list(data.dims)
+                axis_order = [
+                    dims.index(spectral_dim),
+                    dims.index(y_dim),
+                    dims.index(x_dim),
+                ]
+                arr = np.transpose(arr, axis_order)
+            else:
+                # Last-resort behavior for unusual datasets.
+                dims = list(data.dims)
+                for i, d in enumerate(dims):
+                    if d not in ["x", "y", "latitude", "longitude"]:
+                        if i != 0:
+                            arr = np.moveaxis(arr, i, 0)
+                        break
 
-        # Handle NaN values
-        arr = np.nan_to_num(arr, nan=0.0)
+        nodata = -9999.0
+        arr = np.where(np.isfinite(arr), arr, nodata)
 
         if arr.ndim < 3:
             raise ValueError(
@@ -1455,6 +1858,7 @@ class HyperspectralDataset:
                 dtype="float32",
                 crs=crs_value,
                 transform=transform,
+                nodata=nodata,
             ) as dst:
                 dst.write(arr.astype("float32"))
 

--- a/qgis_plugin/hypercoast_qgis/metadata.txt
+++ b/qgis_plugin/hypercoast_qgis/metadata.txt
@@ -5,7 +5,7 @@ name=HyperCoast
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Visualize and analyze hyperspectral data including EMIT, PACE, DESIS, NEON, AVIRIS, PRISMA, EnMAP, Tanager, and Wyvern datasets
-version=0.7.1
+version=0.8.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -28,9 +28,15 @@ icon=icons/hypercoast.png
 experimental=False
 deprecated=False
 
-hasProcessingProvider=no
+hasProcessingProvider=yes
 
 changelog=
+    0.8.0
+        - Convert plugin windows to dockable QGIS panels
+        - Add HyperCoast Processing provider with RGB, single-band, spectral index, and PCA tools
+        - Add background workers for dataset preview, data loading, and band export
+        - Improve spectral plot controls and single-band colormap rendering
+        - Align plugin documentation with QGIS 3.28+ support
     0.7.1
         - Fix macOS QGIS installer dependency installation
     0.7.0

--- a/qgis_plugin/hypercoast_qgis/processing_provider.py
+++ b/qgis_plugin/hypercoast_qgis/processing_provider.py
@@ -192,6 +192,7 @@ class BaseHyperCoastAlgorithm(QgsProcessingAlgorithm):
         count, height, width = arr.shape
         bounds = dataset.bounds or (0, 0, width, height)
         transform = from_bounds(*bounds, width, height)
+        nodata_value = -9999.0
         with rasterio.open(
             output_path,
             "w",
@@ -202,8 +203,9 @@ class BaseHyperCoastAlgorithm(QgsProcessingAlgorithm):
             dtype="float32",
             crs=dataset.crs or "EPSG:4326",
             transform=transform,
+            nodata=nodata_value,
         ) as dst:
-            dst.write(np.nan_to_num(arr, nan=0.0).astype("float32"))
+            dst.write(np.nan_to_num(arr, nan=nodata_value).astype("float32"))
         return output_path
 
 
@@ -469,17 +471,50 @@ class PCAAlgorithm(BaseHyperCoastAlgorithm):
 
         pixels = arr.reshape(bands, height * width).T
         valid = np.all(np.isfinite(pixels), axis=1)
-        if not np.any(valid):
+        n_valid = int(np.count_nonzero(valid))
+        if n_valid == 0:
             raise QgsProcessingException("No finite pixels available for PCA")
 
-        x = pixels[valid]
-        x = x - np.nanmean(x, axis=0)
-        _, singular_values, vt = np.linalg.svd(x, full_matrices=False)
+        # Cap fitting set to keep memory bounded; project full cube in chunks.
+        max_fit_pixels = 500_000
+        max_total_pixels = 50_000_000
+        if pixels.shape[0] > max_total_pixels:
+            raise QgsProcessingException(
+                f"Raster has {pixels.shape[0]:,} pixels which exceeds the "
+                f"PCA limit of {max_total_pixels:,}. Crop or downsample the "
+                "input before running PCA."
+            )
+
+        valid_indices = np.flatnonzero(valid)
+        if n_valid > max_fit_pixels:
+            rng = np.random.default_rng(0)
+            fit_indices = rng.choice(valid_indices, size=max_fit_pixels, replace=False)
+        else:
+            fit_indices = valid_indices
+
+        fit_pixels = pixels[fit_indices].astype(np.float64, copy=False)
+        mean = fit_pixels.mean(axis=0)
+        fit_centered = fit_pixels - mean
+        # Covariance-based PCA: eigendecompose a (bands x bands) matrix.
+        cov = np.cov(fit_centered, rowvar=False)
+        eigenvalues, eigenvectors = np.linalg.eigh(cov)
+        order = np.argsort(eigenvalues)[::-1]
+        components_matrix = eigenvectors[:, order[:n_components]]
+        eig_top = eigenvalues[order[:n_components]]
+        scales = np.sqrt(np.maximum(eig_top, 0.0))
+
         scores = np.zeros((pixels.shape[0], n_components), dtype="float32")
-        scores[valid] = np.dot(x, vt[:n_components].T)
-        for i in range(n_components):
-            if singular_values[i] > 0:
-                scores[valid, i] = scores[valid, i] / singular_values[i]
+        chunk = 200_000
+        for start in range(0, valid_indices.size, chunk):
+            stop = min(start + chunk, valid_indices.size)
+            idx = valid_indices[start:stop]
+            block = (
+                pixels[idx].astype(np.float64, copy=False) - mean
+            ) @ components_matrix
+            for i, scale in enumerate(scales):
+                if scale > 0:
+                    block[:, i] /= scale
+            scores[idx] = block.astype("float32")
 
         components = scores.T.reshape(n_components, height, width)
         self._write_raster(dataset, output_path, components)

--- a/qgis_plugin/hypercoast_qgis/processing_provider.py
+++ b/qgis_plugin/hypercoast_qgis/processing_provider.py
@@ -1,0 +1,490 @@
+# -*- coding: utf-8 -*-
+"""
+HyperCoast QGIS Processing provider.
+
+SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+SPDX-License-Identifier: MIT
+"""
+
+import os
+
+import numpy as np
+from qgis.PyQt.QtGui import QIcon
+from qgis.core import (
+    QgsProcessingAlgorithm,
+    QgsProcessingException,
+    QgsProcessingParameterEnum,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingProvider,
+)
+
+from .hyperspectral_provider import DATA_TYPES, HyperspectralDataset
+
+DATA_TYPE_OPTIONS = ["auto"] + list(DATA_TYPES.keys())
+
+
+def _file_behavior_file():
+    """Return the QGIS file-parameter enum for file inputs."""
+    behavior = getattr(QgsProcessingParameterFile, "Behavior", None)
+    if behavior is not None:
+        return behavior.File
+    return QgsProcessingParameterFile.File
+
+
+def _number_type(name):
+    """Return a QGIS number-parameter enum value by name.
+
+    Args:
+        name: Number type name, such as ``"Double"`` or ``"Integer"``.
+
+    Returns:
+        QGIS number parameter enum value.
+    """
+    enum = getattr(QgsProcessingParameterNumber, "Type", None)
+    if enum is not None:
+        return getattr(enum, name)
+    return getattr(QgsProcessingParameterNumber, name)
+
+
+class HyperCoastProcessingProvider(QgsProcessingProvider):
+    """Processing provider for HyperCoast batch algorithms."""
+
+    def __init__(self, plugin_dir=None):
+        """Initialize the provider.
+
+        Args:
+            plugin_dir: Path to the plugin directory.
+        """
+        super().__init__()
+        self.plugin_dir = plugin_dir or os.path.dirname(__file__)
+
+    def loadAlgorithms(self):
+        """Register HyperCoast processing algorithms."""
+        self.addAlgorithm(RGBCompositeAlgorithm())
+        self.addAlgorithm(SingleBandExportAlgorithm())
+        self.addAlgorithm(SpectralIndexAlgorithm())
+        self.addAlgorithm(PCAAlgorithm())
+
+    def id(self):
+        """Return the provider ID."""
+        return "hypercoast"
+
+    def name(self):
+        """Return the provider display name."""
+        return "HyperCoast"
+
+    def longName(self):
+        """Return the provider long display name."""
+        return "HyperCoast Hyperspectral Tools"
+
+    def icon(self):
+        """Return the provider icon."""
+        icon_path = os.path.join(self.plugin_dir, "icons", "hypercoast.png")
+        return QIcon(icon_path)
+
+
+class BaseHyperCoastAlgorithm(QgsProcessingAlgorithm):
+    """Base class for HyperCoast file-based processing algorithms."""
+
+    INPUT = "INPUT"
+    DATA_TYPE = "DATA_TYPE"
+    OUTPUT = "OUTPUT"
+
+    def group(self):
+        """Return the Processing group name."""
+        return "Hyperspectral"
+
+    def groupId(self):
+        """Return the Processing group ID."""
+        return "hyperspectral"
+
+    def _add_common_inputs(self):
+        """Add common input and data-type parameters."""
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.INPUT,
+                "Input hyperspectral dataset",
+                behavior=_file_behavior_file(),
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterEnum(
+                self.DATA_TYPE,
+                "Data type",
+                options=DATA_TYPE_OPTIONS,
+                defaultValue=0,
+            )
+        )
+
+    def _load_dataset(self, parameters, context):
+        """Load the requested HyperCoast dataset.
+
+        Args:
+            parameters: Processing parameter dict.
+            context: Processing context.
+
+        Returns:
+            Loaded HyperspectralDataset.
+
+        Raises:
+            QgsProcessingException: If the dataset cannot be loaded.
+        """
+        input_path = self.parameterAsFile(parameters, self.INPUT, context)
+        data_type_index = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
+        data_type = DATA_TYPE_OPTIONS[data_type_index]
+        dataset = HyperspectralDataset(input_path, data_type)
+        if not dataset.load():
+            raise QgsProcessingException(dataset.last_error or "Failed to load dataset")
+        return dataset
+
+    def _data_cube(self, dataset):
+        """Return a data cube arranged as bands, rows, columns.
+
+        Args:
+            dataset: Loaded HyperspectralDataset.
+
+        Returns:
+            Tuple of array, height, width.
+
+        Raises:
+            QgsProcessingException: If no raster-like data variable is available.
+        """
+        data_var = dataset.get_data_variable()
+        if data_var is None:
+            raise QgsProcessingException("No data variable found")
+        arr = np.asarray(data_var.values, dtype="float32")
+        if arr.ndim != 3:
+            raise QgsProcessingException(
+                f"Expected a 3D hyperspectral cube, got shape {arr.shape}"
+            )
+
+        dims = list(data_var.dims)
+        band_axis = None
+        for i, dim in enumerate(dims):
+            if dim not in ("x", "y", "latitude", "longitude"):
+                band_axis = i
+                break
+        if band_axis is None:
+            raise QgsProcessingException("Could not identify spectral dimension")
+        if band_axis != 0:
+            arr = np.moveaxis(arr, band_axis, 0)
+        _, height, width = arr.shape
+        return arr, height, width
+
+    def _write_raster(self, dataset, output_path, arr):
+        """Write a raster array using dataset bounds and CRS.
+
+        Args:
+            dataset: Loaded HyperspectralDataset.
+            output_path: Output GeoTIFF path.
+            arr: Array shaped as bands, rows, columns or rows, columns.
+
+        Returns:
+            Output path.
+        """
+        import rasterio
+        from rasterio.transform import from_bounds
+
+        if arr.ndim == 2:
+            arr = arr[np.newaxis, :, :]
+        count, height, width = arr.shape
+        bounds = dataset.bounds or (0, 0, width, height)
+        transform = from_bounds(*bounds, width, height)
+        with rasterio.open(
+            output_path,
+            "w",
+            driver="GTiff",
+            height=height,
+            width=width,
+            count=count,
+            dtype="float32",
+            crs=dataset.crs or "EPSG:4326",
+            transform=transform,
+        ) as dst:
+            dst.write(np.nan_to_num(arr, nan=0.0).astype("float32"))
+        return output_path
+
+
+class RGBCompositeAlgorithm(BaseHyperCoastAlgorithm):
+    """Export a wavelength-based RGB composite."""
+
+    RED = "RED"
+    GREEN = "GREEN"
+    BLUE = "BLUE"
+
+    def name(self):
+        """Return the algorithm ID."""
+        return "rgb_composite"
+
+    def displayName(self):
+        """Return the algorithm display name."""
+        return "Export RGB Composite"
+
+    def shortHelpString(self):
+        """Return help text."""
+        return "Exports a three-band RGB GeoTIFF from selected wavelengths."
+
+    def initAlgorithm(self, config=None):
+        """Define algorithm parameters."""
+        self._add_common_inputs()
+        self.addParameter(
+            QgsProcessingParameterNumber(
+                self.RED,
+                "Red wavelength (nm)",
+                type=_number_type("Double"),
+                defaultValue=650,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterNumber(
+                self.GREEN,
+                "Green wavelength (nm)",
+                type=_number_type("Double"),
+                defaultValue=550,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterNumber(
+                self.BLUE,
+                "Blue wavelength (nm)",
+                type=_number_type("Double"),
+                defaultValue=450,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterRasterDestination(self.OUTPUT, "Output")
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        """Run RGB composite export."""
+        input_path = self.parameterAsFile(parameters, self.INPUT, context)
+        data_type_index = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
+        data_type = DATA_TYPE_OPTIONS[data_type_index]
+        wavelengths = [
+            self.parameterAsDouble(parameters, self.RED, context),
+            self.parameterAsDouble(parameters, self.GREEN, context),
+            self.parameterAsDouble(parameters, self.BLUE, context),
+        ]
+        output_path = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
+        dataset = HyperspectralDataset(input_path, data_type)
+        result = dataset.load_and_export(output_path, wavelengths=wavelengths)
+        if result is None:
+            raise QgsProcessingException(dataset.last_error or "Failed to export RGB")
+        return {self.OUTPUT: result}
+
+    def createInstance(self):
+        """Create a new algorithm instance."""
+        return RGBCompositeAlgorithm()
+
+
+class SingleBandExportAlgorithm(BaseHyperCoastAlgorithm):
+    """Export one wavelength as a single-band GeoTIFF."""
+
+    WAVELENGTH = "WAVELENGTH"
+
+    def name(self):
+        """Return the algorithm ID."""
+        return "single_band"
+
+    def displayName(self):
+        """Return the algorithm display name."""
+        return "Export Single Band"
+
+    def shortHelpString(self):
+        """Return help text."""
+        return "Exports the nearest band to the requested wavelength."
+
+    def initAlgorithm(self, config=None):
+        """Define algorithm parameters."""
+        self._add_common_inputs()
+        self.addParameter(
+            QgsProcessingParameterNumber(
+                self.WAVELENGTH,
+                "Wavelength (nm)",
+                type=_number_type("Double"),
+                defaultValue=550,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterRasterDestination(self.OUTPUT, "Output")
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        """Run single-band export."""
+        dataset = self._load_dataset(parameters, context)
+        output_path = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
+        wavelength = self.parameterAsDouble(parameters, self.WAVELENGTH, context)
+        result = dataset.export_to_geotiff(output_path, wavelengths=[wavelength])
+        if result is None:
+            raise QgsProcessingException("Failed to export selected wavelength")
+        return {self.OUTPUT: result}
+
+    def createInstance(self):
+        """Create a new algorithm instance."""
+        return SingleBandExportAlgorithm()
+
+
+class SpectralIndexAlgorithm(BaseHyperCoastAlgorithm):
+    """Calculate common wavelength-based spectral indices."""
+
+    INDEX = "INDEX"
+    RED = "RED"
+    GREEN = "GREEN"
+    NIR = "NIR"
+
+    INDEX_OPTIONS = ["NDVI", "NDWI"]
+
+    def name(self):
+        """Return the algorithm ID."""
+        return "spectral_index"
+
+    def displayName(self):
+        """Return the algorithm display name."""
+        return "Calculate Spectral Index"
+
+    def shortHelpString(self):
+        """Return help text."""
+        return "Calculates NDVI or NDWI from nearest wavelength bands."
+
+    def initAlgorithm(self, config=None):
+        """Define algorithm parameters."""
+        self._add_common_inputs()
+        self.addParameter(
+            QgsProcessingParameterEnum(
+                self.INDEX, "Index", options=self.INDEX_OPTIONS, defaultValue=0
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterNumber(
+                self.RED,
+                "Red wavelength (nm)",
+                type=_number_type("Double"),
+                defaultValue=660,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterNumber(
+                self.GREEN,
+                "Green wavelength (nm)",
+                type=_number_type("Double"),
+                defaultValue=560,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterNumber(
+                self.NIR,
+                "NIR wavelength (nm)",
+                type=_number_type("Double"),
+                defaultValue=850,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterRasterDestination(self.OUTPUT, "Output")
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        """Run spectral index calculation."""
+        dataset = self._load_dataset(parameters, context)
+        output_path = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
+        index = self.INDEX_OPTIONS[
+            self.parameterAsEnum(parameters, self.INDEX, context)
+        ]
+        data_var = dataset.get_data_variable()
+        if data_var is None or "wavelength" not in data_var.dims:
+            raise QgsProcessingException(
+                "Dataset does not expose a wavelength dimension"
+            )
+
+        red = data_var.sel(
+            wavelength=self.parameterAsDouble(parameters, self.RED, context),
+            method="nearest",
+        ).values.astype("float32")
+        green = data_var.sel(
+            wavelength=self.parameterAsDouble(parameters, self.GREEN, context),
+            method="nearest",
+        ).values.astype("float32")
+        nir = data_var.sel(
+            wavelength=self.parameterAsDouble(parameters, self.NIR, context),
+            method="nearest",
+        ).values.astype("float32")
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            if index == "NDWI":
+                output = (green - nir) / (green + nir)
+            else:
+                output = (nir - red) / (nir + red)
+
+        self._write_raster(dataset, output_path, output)
+        return {self.OUTPUT: output_path}
+
+    def createInstance(self):
+        """Create a new algorithm instance."""
+        return SpectralIndexAlgorithm()
+
+
+class PCAAlgorithm(BaseHyperCoastAlgorithm):
+    """Calculate PCA component rasters from a hyperspectral cube."""
+
+    COMPONENTS = "COMPONENTS"
+
+    def name(self):
+        """Return the algorithm ID."""
+        return "pca"
+
+    def displayName(self):
+        """Return the algorithm display name."""
+        return "PCA Components"
+
+    def shortHelpString(self):
+        """Return help text."""
+        return "Calculates leading PCA component rasters from a hyperspectral cube."
+
+    def initAlgorithm(self, config=None):
+        """Define algorithm parameters."""
+        self._add_common_inputs()
+        self.addParameter(
+            QgsProcessingParameterNumber(
+                self.COMPONENTS,
+                "Number of components",
+                type=_number_type("Integer"),
+                minValue=1,
+                maxValue=20,
+                defaultValue=3,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterRasterDestination(self.OUTPUT, "Output")
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        """Run PCA component export."""
+        dataset = self._load_dataset(parameters, context)
+        output_path = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
+        n_components = self.parameterAsInt(parameters, self.COMPONENTS, context)
+        arr, height, width = self._data_cube(dataset)
+        bands, _, _ = arr.shape
+        n_components = min(n_components, bands)
+
+        pixels = arr.reshape(bands, height * width).T
+        valid = np.all(np.isfinite(pixels), axis=1)
+        if not np.any(valid):
+            raise QgsProcessingException("No finite pixels available for PCA")
+
+        x = pixels[valid]
+        x = x - np.nanmean(x, axis=0)
+        _, singular_values, vt = np.linalg.svd(x, full_matrices=False)
+        scores = np.zeros((pixels.shape[0], n_components), dtype="float32")
+        scores[valid] = np.dot(x, vt[:n_components].T)
+        for i in range(n_components):
+            if singular_values[i] > 0:
+                scores[valid, i] = scores[valid, i] / singular_values[i]
+
+        components = scores.T.reshape(n_components, height, width)
+        self._write_raster(dataset, output_path, components)
+        return {self.OUTPUT: output_path}
+
+    def createInstance(self):
+        """Create a new algorithm instance."""
+        return PCAAlgorithm()

--- a/qgis_plugin/qt6_tests/test_dock_panels.py
+++ b/qgis_plugin/qt6_tests/test_dock_panels.py
@@ -1,0 +1,27 @@
+"""Smoke tests for the dockable HyperCoast panel classes."""
+
+from qgis.PyQt.QtWidgets import QDockWidget
+
+from hypercoast_qgis.dialogs.about_dialog import AboutDialog
+from hypercoast_qgis.dialogs.band_combination_dialog import BandCombinationDialog
+from hypercoast_qgis.dialogs.dependency_installer import DependencyInstallerDialog
+from hypercoast_qgis.dialogs.load_data_dialog import LoadDataDialog
+from hypercoast_qgis.dialogs.settings_dock import SettingsDockWidget
+from hypercoast_qgis.dialogs.spectral_plot_dialog import SpectralPlotDialog
+from hypercoast_qgis.dialogs.update_checker import UpdateCheckerDialog
+
+
+def test_plugin_windows_are_dock_widgets():
+    """All user-facing plugin windows should be dockable panels."""
+    dock_classes = [
+        AboutDialog,
+        BandCombinationDialog,
+        DependencyInstallerDialog,
+        LoadDataDialog,
+        SettingsDockWidget,
+        SpectralPlotDialog,
+        UpdateCheckerDialog,
+    ]
+
+    for dock_class in dock_classes:
+        assert issubclass(dock_class, QDockWidget)

--- a/qgis_plugin/qt6_tests/test_hyperspectral_provider.py
+++ b/qgis_plugin/qt6_tests/test_hyperspectral_provider.py
@@ -1,0 +1,93 @@
+"""Tests for hyperspectral dataset variable selection."""
+
+import numpy as np
+import pytest
+
+xr = pytest.importorskip("xarray")
+
+from hypercoast_qgis.hyperspectral_provider import HyperspectralDataset
+
+
+def test_pace_bgc_prefers_raster_product_over_tilt():
+    """PACE BGC products should select a 2D geophysical raster variable."""
+    dataset = xr.Dataset(
+        {
+            "tilt": (("latitude",), np.array([1.0, 2.0])),
+            "chlor_a": (
+                ("latitude", "longitude"),
+                np.array([[0.1, 0.2], [0.3, 0.4]], dtype="float32"),
+            ),
+            "poc": (
+                ("latitude", "longitude"),
+                np.array([[10.0, 20.0], [30.0, 40.0]], dtype="float32"),
+            ),
+            "l2_flags": (
+                ("latitude", "longitude"),
+                np.array([[1, 2], [3, 4]], dtype="int32"),
+            ),
+        },
+        coords={
+            "latitude": np.array([29.0, 30.0]),
+            "longitude": np.array([-91.0, -90.0]),
+        },
+    )
+    provider = HyperspectralDataset("PACE_OCI_test.nc", "PACE")
+    provider.dataset = dataset
+
+    data_var = provider.get_data_variable()
+
+    assert data_var.name == "chlor_a"
+    assert data_var.ndim == 2
+    assert provider.list_data_variables() == ["chlor_a", "poc", "l2_flags"]
+
+
+def test_selected_variable_overrides_default_product():
+    """A selected export variable should override the provider default."""
+    dataset = xr.Dataset(
+        {
+            "chlor_a": (
+                ("latitude", "longitude"),
+                np.array([[0.1, 0.2], [0.3, 0.4]], dtype="float32"),
+            ),
+            "poc": (
+                ("latitude", "longitude"),
+                np.array([[10.0, 20.0], [30.0, 40.0]], dtype="float32"),
+            ),
+        }
+    )
+    provider = HyperspectralDataset("PACE_OCI_test.nc", "PACE")
+    provider.dataset = dataset
+    provider.set_selected_variable("poc")
+
+    data_var = provider.get_data_variable()
+
+    assert data_var.name == "poc"
+
+
+def test_pace_integer_variable_uses_nearest_interpolation():
+    """Integer PACE variables should not be linearly interpolated."""
+    dataset = xr.Dataset(
+        {
+            "l2_flags": (
+                ("latitude", "longitude"),
+                np.array([[1, 2], [3, 4]], dtype="int32"),
+            )
+        }
+    )
+    provider = HyperspectralDataset("PACE_OCI_test.nc", "PACE")
+    provider.dataset = dataset
+
+    method = provider._pace_bgc_interpolation_method("l2_flags", "linear")
+
+    assert method == "nearest"
+
+
+def test_north_up_orientation_flips_ascending_latitude():
+    """Ascending latitude rows must be flipped before GeoTIFF writing."""
+    provider = HyperspectralDataset("PACE_OCI_test.nc", "PACE")
+    data = np.array([[1, 2], [3, 4]], dtype="float32")
+    y_values = np.array([10.0, 20.0])
+
+    oriented = provider._orient_array_north_up(data, y_values, y_axis=0)
+
+    np.testing.assert_array_equal(oriented, np.array([[3, 4], [1, 2]]))

--- a/qgis_plugin/qt6_tests/test_metadata_docs.py
+++ b/qgis_plugin/qt6_tests/test_metadata_docs.py
@@ -1,0 +1,28 @@
+"""Tests for QGIS plugin metadata and docs consistency."""
+
+import configparser
+
+
+def _metadata_path():
+    """Return the plugin metadata path."""
+    return __import__("pathlib").Path(__file__).resolve().parents[1] / (
+        "hypercoast_qgis/metadata.txt"
+    )
+
+
+def test_readme_qgis_minimum_matches_metadata():
+    """README should advertise the same QGIS minimum version as metadata."""
+    root = __import__("pathlib").Path(__file__).resolve().parents[1]
+    parser = configparser.ConfigParser()
+    parser.read(_metadata_path(), encoding="utf-8")
+    minimum = parser["general"]["qgisMinimumVersion"]
+
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    assert f"QGIS {minimum} or later" in readme
+
+
+def test_processing_provider_is_advertised():
+    """The metadata should expose the implemented Processing provider."""
+    parser = configparser.ConfigParser()
+    parser.read(_metadata_path(), encoding="utf-8")
+    assert parser["general"]["hasProcessingProvider"] == "yes"

--- a/qgis_plugin/qt6_tests/test_pyqt6_imports.py
+++ b/qgis_plugin/qt6_tests/test_pyqt6_imports.py
@@ -48,6 +48,8 @@ if _PLUGIN_PARENT not in sys.path:
 def _module_names():
     """Yield dotted module names for every .py file under the plugin package."""
     for path in sorted(PLUGIN_ROOT.rglob("*.py")):
+        if path.parent.name == "icons" and path.stem.startswith("create_icon"):
+            continue
         rel = path.relative_to(PLUGIN_ROOT.parent).with_suffix("")
         parts = rel.parts
         if parts[-1] == "__init__":


### PR DESCRIPTION
## Summary
- Convert HyperCoast plugin windows into dockable QGIS panels that can be tabbed with the QGIS interface.
- Add a HyperCoast Processing provider with RGB composite, single-band export, spectral index, and PCA component algorithms.
- Add background workers for dataset preview, data loading, and band export; improve spectral plot controls and single-band colormap rendering.
- Bump plugin version to 0.8.0, align documentation with QGIS 3.28+ support, and add PyQt6 import-smoke tests for the new modules.

## Test plan
- [ ] Load the plugin in QGIS 3.28+ and verify each tool opens as a dockable panel.
- [ ] Run each Processing algorithm (RGB, single-band, spectral index, PCA) from the Processing Toolbox.
- [ ] Confirm background workers populate dataset previews and load data without blocking the UI.
- [ ] Run `python -m pytest qgis_plugin/qt6_tests` and confirm the new PyQt6 import tests pass.