### PR TITLE
feat: rehydrate QGIS plugin layers and harden spectral extraction

### DIFF
--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -125,7 +125,7 @@ The recommended way to package and install the plugin:
 ```bash
 cd qgis_plugin
 
-# Package the plugin (creates dist/hypercoast_qgis_0.1.0.zip)
+# Package the plugin (creates dist/hypercoast_qgis_0.8.0.zip)
 python install_plugin.py
 
 # Package and install directly to QGIS
@@ -163,7 +163,7 @@ zip -r hypercoast_qgis.zip hypercoast_qgis -x "*.pyc" -x "__pycache__/*"
 
 ```bash
 cd qgis_plugin
-python -m pytest tests/
+python -m pytest qt6_tests/
 ```
 
 ## License

--- a/qgis_plugin/hypercoast_qgis/cache_manager.py
+++ b/qgis_plugin/hypercoast_qgis/cache_manager.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""
+Cache helpers for HyperCoast QGIS generated rasters.
+
+SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+SPDX-License-Identifier: MIT
+"""
+
+import os
+import uuid
+
+
+def generated_raster_cache_dir(project=None):
+    """Return the persistent cache directory for plugin-generated rasters.
+
+    Args:
+        project: Optional QgsProject-like object. This argument is accepted
+            for caller compatibility and is not used.
+
+    Returns:
+        Absolute cache directory path.
+    """
+    _ = project
+    cache_dir = os.path.join(os.path.expanduser("~"), ".qgis_hypercoast", "cache")
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir
+
+
+def sanitize_cache_name(name):
+    """Return a filesystem-safe cache filename component.
+
+    Args:
+        name: User-facing layer name.
+
+    Returns:
+        Sanitized filename component.
+    """
+    safe_name = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in name)
+    return safe_name.strip("_") or "hypercoast"
+
+
+def create_generated_raster_path(layer_name, suffix, project=None):
+    """Create a unique persistent path for a generated GeoTIFF.
+
+    Args:
+        layer_name: QGIS layer name used as a readable prefix.
+        suffix: Short output kind, such as ``"rgb"`` or ``"bands"``.
+        project: Optional QgsProject-like object.
+
+    Returns:
+        Unique GeoTIFF path in the HyperCoast cache directory.
+    """
+    cache_dir = generated_raster_cache_dir(project)
+    safe_name = sanitize_cache_name(layer_name)
+    safe_suffix = sanitize_cache_name(suffix)
+    token = uuid.uuid4().hex[:10]
+    return os.path.join(cache_dir, f"{safe_name}_{safe_suffix}_{token}.tif")

--- a/qgis_plugin/hypercoast_qgis/dialogs/band_combination_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/band_combination_dialog.py
@@ -6,8 +6,6 @@ SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
 SPDX-License-Identifier: MIT
 """
 
-import os
-import tempfile
 import numpy as np
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
 from qgis.PyQt.QtGui import QColor
@@ -40,6 +38,8 @@ from qgis.core import (
     QgsRasterShader,
     QgsSingleBandPseudoColorRenderer,
 )
+
+from ..cache_manager import create_generated_raster_path
 
 
 class BandExportWorker(QThread):
@@ -451,7 +451,7 @@ class BandCombinationDialog(QDockWidget):
         self.apply_btn.setEnabled(False)
 
         try:
-            dataset = data_info.get("dataset")
+            dataset = self.plugin.ensure_hyperspectral_dataset(layer_id)
             if dataset is None:
                 raise ValueError("Dataset not available")
 
@@ -600,19 +600,11 @@ class BandCombinationDialog(QDockWidget):
             suffix: Short output kind.
 
         Returns:
-            Path to a unique temporary GeoTIFF.
+            Path to a unique persistent cache GeoTIFF.
         """
-        safe_name = "".join(
-            c if c.isalnum() or c in ("-", "_") else "_" for c in layer_name
+        return create_generated_raster_path(
+            layer_name, suffix, project=QgsProject.instance()
         )
-        safe_name = safe_name.strip("_") or "hypercoast"
-        fd, path = tempfile.mkstemp(prefix=f"{safe_name}_{suffix}_", suffix=".tif")
-        os.close(fd)
-        try:
-            os.remove(path)
-        except OSError:
-            pass
-        return path
 
     def _set_layer_custom_properties(self, layer, data_info, wavelengths):
         """Persist HyperCoast metadata on a replacement layer.
@@ -624,6 +616,10 @@ class BandCombinationDialog(QDockWidget):
         """
         layer.setCustomProperty("hypercoast/source_path", data_info.get("filepath", ""))
         layer.setCustomProperty("hypercoast/data_type", data_info.get("data_type", ""))
+        if data_info.get("selected_variable"):
+            layer.setCustomProperty(
+                "hypercoast/selected_variable", data_info["selected_variable"]
+            )
         layer.setCustomProperty(
             "hypercoast/rgb_wavelengths", ",".join(str(v) for v in wavelengths)
         )

--- a/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
@@ -7,7 +7,6 @@ SPDX-License-Identifier: MIT
 """
 
 import os
-import tempfile
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
 from qgis.PyQt.QtWidgets import (
     QDockWidget,
@@ -46,6 +45,7 @@ from ..hyperspectral_provider import (
     DATA_TYPES,
     create_file_filter,
 )
+from ..cache_manager import create_generated_raster_path
 
 
 class DatasetPreviewWorker(QThread):
@@ -760,19 +760,11 @@ class LoadDataDialog(QDockWidget):
             suffix: Short output kind, such as ``"rgb"``.
 
         Returns:
-            Path to a unique temporary GeoTIFF.
+            Path to a unique persistent cache GeoTIFF.
         """
-        safe_name = "".join(
-            c if c.isalnum() or c in ("-", "_") else "_" for c in layer_name
+        return create_generated_raster_path(
+            layer_name, suffix, project=QgsProject.instance()
         )
-        safe_name = safe_name.strip("_") or "hypercoast"
-        fd, path = tempfile.mkstemp(prefix=f"{safe_name}_{suffix}_", suffix=".tif")
-        os.close(fd)
-        try:
-            os.remove(path)
-        except OSError:
-            pass
-        return path
 
     def _set_layer_custom_properties(
         self, raster_layer, filepath, wavelengths, selected_variable=None

--- a/qgis_plugin/hypercoast_qgis/dialogs/spectral_inspector_tool.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/spectral_inspector_tool.py
@@ -104,7 +104,11 @@ class SpectralInspectorTool(QgsMapToolEmitPoint):
         self._add_point_marker(point)
 
         # Extract from each layer
+        selected_layer_id = self._selected_layer_id()
         for layer_id, data_info in hyper_layers.items():
+            if selected_layer_id and layer_id != selected_layer_id:
+                continue
+
             layer = QgsProject.instance().mapLayer(layer_id)
             if not layer:
                 continue
@@ -213,6 +217,18 @@ class SpectralInspectorTool(QgsMapToolEmitPoint):
             except Exception:
                 pass
         return "EPSG:4326"
+
+    def _selected_layer_id(self):
+        """Return the spectral plot's selected layer ID.
+
+        Returns:
+            QGIS layer ID, or None to sample all HyperCoast layers.
+        """
+        plot_dialog = getattr(self.plugin, "spectral_plot_dialog", None)
+        selected_layer_id = getattr(plot_dialog, "selected_layer_id", None)
+        if callable(selected_layer_id):
+            return selected_layer_id()
+        return None
 
     def clear_points(self):
         """Clear all extracted points and markers."""

--- a/qgis_plugin/hypercoast_qgis/dialogs/spectral_inspector_tool.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/spectral_inspector_tool.py
@@ -109,7 +109,7 @@ class SpectralInspectorTool(QgsMapToolEmitPoint):
             if not layer:
                 continue
 
-            dataset = data_info.get("dataset")
+            dataset = self.plugin.ensure_hyperspectral_dataset(layer_id)
             if dataset is None:
                 continue
 
@@ -132,7 +132,14 @@ class SpectralInspectorTool(QgsMapToolEmitPoint):
 
             try:
                 # Extract spectral signature
-                wavelengths, values = dataset.extract_spectral_signature(lon, lat)
+                layer_crs_authid = self._crs_authid(layer_crs)
+                wavelengths, values = dataset.extract_spectral_signature(
+                    layer_point.x(),
+                    layer_point.y(),
+                    crs=layer_crs_authid,
+                    lon=lon,
+                    lat=lat,
+                )
 
                 if wavelengths is not None and values is not None:
                     # Emit signal for plot update
@@ -187,6 +194,25 @@ class SpectralInspectorTool(QgsMapToolEmitPoint):
         rb.addPoint(point, True)
 
         self.rubber_bands.append(rb)
+
+    def _crs_authid(self, crs):
+        """Return a CRS auth ID for a QGIS CRS object.
+
+        Args:
+            crs: QgsCoordinateReferenceSystem-like object.
+
+        Returns:
+            CRS auth ID, or EPSG:4326 when unavailable.
+        """
+        authid = getattr(crs, "authid", None)
+        if callable(authid):
+            try:
+                value = authid()
+                if value:
+                    return value
+            except Exception:
+                pass
+        return "EPSG:4326"
 
     def clear_points(self):
         """Clear all extracted points and markers."""

--- a/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
@@ -23,6 +23,7 @@ from qgis.PyQt.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QHeaderView,
+    QSizePolicy,
     QFileDialog,
     QMessageBox,
     QSplitter,
@@ -65,8 +66,8 @@ class SpectralPlotDialog(QDockWidget):
 
         self.setWindowTitle("Spectral Plot")
         self.setObjectName("HyperCoastSpectralPlotDock")
-        self.setMinimumWidth(800)
-        self.setMinimumHeight(600)
+        self.setMinimumWidth(560)
+        self.setMinimumHeight(480)
 
         # Store spectra
         self.spectra = []
@@ -117,7 +118,34 @@ class SpectralPlotDialog(QDockWidget):
 
         # Tab 1: Plot options
         options_tab = QWidget()
-        options_layout = QHBoxLayout(options_tab)
+        options_layout = QVBoxLayout(options_tab)
+        policy = getattr(QSizePolicy, "Policy", QSizePolicy)
+
+        # Sampling options
+        sampling_group = QGroupBox("Sampling")
+        sampling_group.setSizePolicy(policy.Expanding, policy.Maximum)
+        sampling_layout = QHBoxLayout()
+        sampling_layout.setContentsMargins(8, 6, 8, 6)
+        sampling_layout.setSpacing(6)
+
+        self.layer_combo = QComboBox()
+        self.layer_combo.setMinimumWidth(180)
+        self.layer_combo.setSizeAdjustPolicy(
+            QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+        )
+        self.layer_combo.setSizePolicy(policy.Expanding, policy.Fixed)
+        sampling_layout.addWidget(QLabel("Layer:"))
+        sampling_layout.addWidget(self.layer_combo, 1)
+
+        refresh_layers_btn = QPushButton("Refresh Layers")
+        refresh_layers_btn.clicked.connect(self.refresh_layer_combo)
+        sampling_layout.addWidget(refresh_layers_btn)
+
+        sampling_group.setLayout(sampling_layout)
+        sampling_group.setMaximumHeight(sampling_group.sizeHint().height())
+        options_layout.addWidget(sampling_group)
+
+        option_groups_layout = QHBoxLayout()
 
         # Plot options
         options_group = QGroupBox("Plot Options")
@@ -139,7 +167,7 @@ class SpectralPlotDialog(QDockWidget):
         options_form.addRow("", self.grid_check)
 
         options_group.setLayout(options_form)
-        options_layout.addWidget(options_group)
+        option_groups_layout.addWidget(options_group, 1)
 
         # Axis options
         axis_group = QGroupBox("Axis Range")
@@ -181,7 +209,7 @@ class SpectralPlotDialog(QDockWidget):
         axis_form.addRow("", apply_range_btn)
 
         axis_group.setLayout(axis_form)
-        options_layout.addWidget(axis_group)
+        option_groups_layout.addWidget(axis_group, 2)
 
         # Labels
         labels_group = QGroupBox("Labels")
@@ -208,7 +236,8 @@ class SpectralPlotDialog(QDockWidget):
         labels_form.addRow("Y Label:", self.ylabel_combo)
 
         labels_group.setLayout(labels_form)
-        options_layout.addWidget(labels_group)
+        option_groups_layout.addWidget(labels_group, 2)
+        options_layout.addLayout(option_groups_layout)
 
         tab_widget.addTab(options_tab, "Options")
 
@@ -269,8 +298,58 @@ class SpectralPlotDialog(QDockWidget):
 
         layout.addWidget(splitter)
 
+        self.refresh_layer_combo()
+
         # Defer the first draw until Qt has assigned the dock/canvas geometry.
         QTimer.singleShot(0, self.update_plot)
+
+    def refresh_layer_combo(self):
+        """Refresh the spectral sampling layer selector."""
+        if not hasattr(self, "layer_combo"):
+            return
+
+        current_layer_id = self.selected_layer_id()
+        self.layer_combo.blockSignals(True)
+        self.layer_combo.clear()
+        self.layer_combo.addItem("All HyperCoast layers", None)
+
+        for layer_id in self.plugin.get_all_hyperspectral_layers():
+            layer = self._project_layer(layer_id)
+            if layer is not None:
+                self.layer_combo.addItem(layer.name(), layer_id)
+
+        if current_layer_id:
+            index = self.layer_combo.findData(current_layer_id)
+            if index >= 0:
+                self.layer_combo.setCurrentIndex(index)
+
+        self.layer_combo.blockSignals(False)
+
+    def selected_layer_id(self):
+        """Return the selected sampling layer ID.
+
+        Returns:
+            QGIS layer ID, or None to sample every HyperCoast layer.
+        """
+        if not hasattr(self, "layer_combo"):
+            return None
+        return self.layer_combo.currentData()
+
+    def _project_layer(self, layer_id):
+        """Return a QGIS project layer by ID.
+
+        Args:
+            layer_id: QGIS layer ID.
+
+        Returns:
+            QGIS layer object, or None.
+        """
+        try:
+            from qgis.core import QgsProject
+
+            return QgsProject.instance().mapLayer(layer_id)
+        except Exception:
+            return None
 
     def add_spectrum(self, lat, lon, wavelengths, values, layer_name):
         """Add a new spectrum to the plot.

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -430,10 +430,12 @@ class HyperCoastPlugin:
                 pass  # nosec B110
 
         # Remove the toolbar
-        try:
-            self._remove_toolbar(self.toolbar)
-        except RuntimeError:
-            pass  # nosec B110
+        toolbar = getattr(self, "toolbar", None)
+        if toolbar is not None:
+            try:
+                self._remove_toolbar(toolbar)
+            except Exception:
+                pass  # nosec B110
         self.toolbar = None
 
         self._remove_processing_provider()
@@ -753,6 +755,7 @@ class HyperCoastPlugin:
             "spectral_plot_dialog",
             lambda: SpectralPlotDialog(self.iface, self, self.iface.mainWindow()),
             self.spectral_action,
+            before_show=lambda dock: dock.refresh_layer_combo(),
         )
 
     def _show_deps_required_warning(self):
@@ -814,6 +817,8 @@ class HyperCoastPlugin:
         :param data_info: Dictionary containing dataset info.
         """
         self.hyperspectral_data[layer_id] = data_info
+        if self.spectral_plot_dialog is not None:
+            self.spectral_plot_dialog.refresh_layer_combo()
 
     def rehydrate_hyperspectral_layers(self):
         """Restore HyperCoast layer registrations from QGIS custom properties."""

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -211,6 +211,17 @@ class HyperCoastPlugin:
 
         # Auto-check dependencies after GUI is initialized
         QTimer.singleShot(1000, self._check_dependencies_on_startup)
+        self._connect_project_signals()
+
+    def _connect_project_signals(self):
+        """Connect project lifecycle signals used for layer rehydration."""
+        try:
+            project = QgsProject.instance()
+            signal = getattr(project, "readProject", None)
+            if signal is not None and hasattr(signal, "connect"):
+                signal.connect(self.rehydrate_hyperspectral_layers)
+        except Exception:
+            pass  # nosec B110
 
     def _remove_toolbar(self, toolbar):
         """Detach and schedule deletion of a plugin toolbar widget."""
@@ -409,11 +420,21 @@ class HyperCoastPlugin:
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""
         for action in self.actions:
-            self.iface.removePluginRasterMenu(self.tr("&HyperCoast"), action)
-            self.iface.removeToolBarIcon(action)
+            try:
+                self.iface.removePluginRasterMenu(self.tr("&HyperCoast"), action)
+            except RuntimeError:
+                pass  # nosec B110
+            try:
+                self.iface.removeToolBarIcon(action)
+            except RuntimeError:
+                pass  # nosec B110
 
         # Remove the toolbar
-        del self.toolbar
+        try:
+            self._remove_toolbar(self.toolbar)
+        except RuntimeError:
+            pass  # nosec B110
+        self.toolbar = None
 
         self._remove_processing_provider()
 
@@ -565,6 +586,7 @@ class HyperCoastPlugin:
             self._deps_available = True
             self._set_data_actions_enabled(True)
             self._ensure_processing_provider()
+            self.rehydrate_hyperspectral_layers()
             QgsMessageLog.logMessage(
                 "All data features enabled",
                 "HyperCoast",
@@ -792,6 +814,161 @@ class HyperCoastPlugin:
         :param data_info: Dictionary containing dataset info.
         """
         self.hyperspectral_data[layer_id] = data_info
+
+    def rehydrate_hyperspectral_layers(self):
+        """Restore HyperCoast layer registrations from QGIS custom properties."""
+        try:
+            project = QgsProject.instance()
+            map_layers = getattr(project, "mapLayers", None)
+            layers = map_layers() if callable(map_layers) else {}
+        except Exception as exc:
+            QgsMessageLog.logMessage(
+                f"Could not scan project layers for HyperCoast metadata: {exc}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+            return
+
+        for layer_id, layer in getattr(layers, "items", lambda: [])():
+            source_path = self._layer_custom_property(
+                layer, "hypercoast/source_path", ""
+            )
+            if not source_path:
+                continue
+            if not os.path.exists(source_path):
+                QgsMessageLog.logMessage(
+                    f"Skipping HyperCoast layer with missing source file: {source_path}",
+                    "HyperCoast",
+                    Qgis.MessageLevel.Warning,
+                )
+                continue
+
+            existing = self.hyperspectral_data.get(layer_id, {})
+            data_info = {
+                "dataset": existing.get("dataset"),
+                "filepath": source_path,
+                "data_type": self._layer_custom_property(
+                    layer, "hypercoast/data_type", "auto"
+                ),
+                "wavelengths": existing.get("wavelengths"),
+                "rgb_wavelengths": self._parse_wavelengths(
+                    self._layer_custom_property(layer, "hypercoast/rgb_wavelengths", "")
+                ),
+                "selected_variable": self._layer_custom_property(
+                    layer, "hypercoast/selected_variable", None
+                ),
+                "bounds": existing.get("bounds"),
+                "crs": self._layer_custom_property(layer, "hypercoast/crs", None),
+            }
+            self.hyperspectral_data[layer_id] = data_info
+
+    def ensure_hyperspectral_dataset(self, layer_id):
+        """Return a loaded dataset for a registered HyperCoast layer.
+
+        Args:
+            layer_id: QGIS layer ID.
+
+        Returns:
+            Loaded HyperspectralDataset, or None when the dataset cannot be
+            loaded.
+        """
+        data_info = self.get_hyperspectral_data(layer_id)
+        if not data_info:
+            return None
+
+        dataset = data_info.get("dataset")
+        if dataset is not None and getattr(dataset, "dataset", None) is not None:
+            return dataset
+
+        filepath = data_info.get("filepath", "")
+        if not filepath or not os.path.exists(filepath):
+            QgsMessageLog.logMessage(
+                f"Cannot load HyperCoast source file: {filepath}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+            return None
+
+        try:
+            from .hyperspectral_provider import HyperspectralDataset
+
+            dataset = HyperspectralDataset(filepath, data_info.get("data_type", "auto"))
+            dataset.set_selected_variable(data_info.get("selected_variable"))
+            if not dataset.load():
+                QgsMessageLog.logMessage(
+                    dataset.last_error or f"Failed to load {filepath}",
+                    "HyperCoast",
+                    Qgis.MessageLevel.Warning,
+                )
+                return None
+
+            data_info.update(
+                {
+                    "dataset": dataset,
+                    "data_type": dataset.data_type,
+                    "wavelengths": dataset.wavelengths,
+                    "bounds": dataset.bounds,
+                    "crs": dataset.crs,
+                }
+            )
+            return dataset
+        except Exception as exc:
+            QgsMessageLog.logMessage(
+                f"Could not load HyperCoast dataset for layer {layer_id}: {exc}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+            return None
+
+    def _layer_custom_property(self, layer, key, default=None):
+        """Read a QGIS layer custom property as a plain Python value.
+
+        Args:
+            layer: QGIS layer-like object.
+            key: Custom property key.
+            default: Value returned when the property is missing.
+
+        Returns:
+            Custom property value or ``default``.
+        """
+        custom_property = getattr(layer, "customProperty", None)
+        if not callable(custom_property):
+            return default
+        try:
+            value = custom_property(key, default)
+        except TypeError:
+            try:
+                value = custom_property(key)
+            except Exception:
+                return default
+        except Exception:
+            return default
+        if value in ("", None):
+            return default
+        return value
+
+    def _parse_wavelengths(self, value):
+        """Parse a comma-separated wavelength custom property.
+
+        Args:
+            value: Custom property value.
+
+        Returns:
+            List of wavelength values.
+        """
+        if not value:
+            return []
+        if isinstance(value, (list, tuple)):
+            candidates = value
+        else:
+            candidates = str(value).split(",")
+        wavelengths = []
+        for candidate in candidates:
+            try:
+                wavelengths.append(float(candidate))
+            except (TypeError, ValueError):
+                pass
+        return wavelengths
 
     def get_hyperspectral_data(self, layer_id):
         """Get hyperspectral data for a layer.

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -38,7 +38,13 @@ except ImportError:
     HAS_H5PY = False
 
 try:
-    from qgis.core import QgsMessageLog, Qgis
+    from qgis.core import (
+        QgsCoordinateReferenceSystem,
+        QgsCoordinateTransform,
+        QgsMessageLog,
+        QgsProject,
+        Qgis,
+    )
 
     HAS_QGIS = True
     LOG_INFO = Qgis.MessageLevel.Info
@@ -1241,32 +1247,42 @@ class HyperspectralDataset:
         """
         return getattr(data_var, "ndim", 0) >= 2
 
-    def extract_spectral_signature(self, x, y, crs="EPSG:4326"):
+    def extract_spectral_signature(self, x, y, crs="EPSG:4326", lon=None, lat=None):
         """Extract spectral signature at a given location.
 
-        :param x: X coordinate (longitude)
-        :param y: Y coordinate (latitude)
-        :param crs: Coordinate reference system
-        :returns: Tuple of (wavelengths, values) or (None, None)
+        Args:
+            x: X coordinate in the CRS supplied by ``crs``.
+            y: Y coordinate in the CRS supplied by ``crs``.
+            crs: Coordinate reference system for ``x`` and ``y``.
+            lon: Optional longitude in EPSG:4326.
+            lat: Optional latitude in EPSG:4326.
+
+        Returns:
+            Tuple of wavelength and value arrays, or ``(None, None)``.
         """
         if self.dataset is None or self.wavelengths is None:
             return None, None
 
         try:
-            # Use hypercoast extraction functions if available
-            if HAS_HYPERCOAST:
-                return self._extract_with_hypercoast(x, y)
-
-            # Fallback extraction
             data_var = self.get_data_variable()
             if data_var is None:
                 return None, None
 
+            # Use HyperCoast's sensor-specific extractors when they accept
+            # geographic coordinates. Generic rectilinear rasters are handled
+            # below so projected x/y coordinates remain correct.
+            if HAS_HYPERCOAST and self.data_type in {"EMIT", "PACE", "DESIS", "NEON"}:
+                lon_value, lat_value = self._as_lon_lat(x, y, crs, lon, lat)
+                return self._extract_with_hypercoast(lon_value, lat_value)
+
             if "latitude" in data_var.dims and "longitude" in data_var.dims:
-                values = data_var.sel(latitude=y, longitude=x, method="nearest").values
+                lon_value, lat_value = self._as_lon_lat(x, y, crs, lon, lat)
+                values = data_var.sel(
+                    latitude=lat_value, longitude=lon_value, method="nearest"
+                ).values
             elif "y" in data_var.dims and "x" in data_var.dims:
-                # May need coordinate transformation
-                values = data_var.sel(y=y, x=x, method="nearest").values
+                x_value, y_value = self._as_dataset_xy(x, y, crs)
+                values = data_var.sel(y=y_value, x=x_value, method="nearest").values
             else:
                 return None, None
 
@@ -1275,6 +1291,98 @@ class HyperspectralDataset:
         except Exception as e:
             _log(f"Error extracting spectral signature: {e}", LOG_WARNING)
             return None, None
+
+    def _as_lon_lat(self, x, y, crs, lon=None, lat=None):
+        """Return coordinates in EPSG:4326.
+
+        Args:
+            x: X coordinate in ``crs``.
+            y: Y coordinate in ``crs``.
+            crs: Source coordinate reference system.
+            lon: Optional precomputed longitude.
+            lat: Optional precomputed latitude.
+
+        Returns:
+            Tuple of ``(lon, lat)``.
+        """
+        if lon is not None and lat is not None:
+            return lon, lat
+        return self._transform_xy(x, y, crs, "EPSG:4326")
+
+    def _as_dataset_xy(self, x, y, crs):
+        """Return coordinates in the dataset's raster CRS.
+
+        Args:
+            x: X coordinate in ``crs``.
+            y: Y coordinate in ``crs``.
+            crs: Source coordinate reference system.
+
+        Returns:
+            Tuple of transformed ``(x, y)`` coordinates.
+        """
+        target_crs = self.crs or crs
+        return self._transform_xy(x, y, crs, target_crs)
+
+    def _transform_xy(self, x, y, source_crs, target_crs):
+        """Transform coordinates between two CRS values when possible.
+
+        Args:
+            x: Source x coordinate.
+            y: Source y coordinate.
+            source_crs: Source CRS string or QGIS CRS object.
+            target_crs: Target CRS string or QGIS CRS object.
+
+        Returns:
+            Tuple of transformed coordinates, or the original coordinates if
+            transformation is unavailable.
+        """
+        if self._crs_equal(source_crs, target_crs):
+            return x, y
+        if not HAS_QGIS:
+            return x, y
+
+        try:
+            src = QgsCoordinateReferenceSystem(str(source_crs))
+            dst = QgsCoordinateReferenceSystem(str(target_crs))
+            transform = QgsCoordinateTransform(src, dst, QgsProject.instance())
+            point = transform.transform(float(x), float(y))
+            return point.x(), point.y()
+        except Exception as exc:
+            _log(f"Could not transform spectral point coordinates: {exc}", LOG_WARNING)
+            return x, y
+
+    def _crs_equal(self, source_crs, target_crs):
+        """Return whether two CRS values represent the same CRS.
+
+        Args:
+            source_crs: Source CRS value.
+            target_crs: Target CRS value.
+
+        Returns:
+            True if the CRS strings or auth IDs match.
+        """
+        return self._crs_text(source_crs).lower() == self._crs_text(target_crs).lower()
+
+    def _crs_text(self, crs):
+        """Return a comparable CRS text value.
+
+        Args:
+            crs: CRS string or QGIS CRS object.
+
+        Returns:
+            CRS text suitable for equality checks.
+        """
+        if crs is None:
+            return ""
+        authid = getattr(crs, "authid", None)
+        if callable(authid):
+            try:
+                value = authid()
+                if value:
+                    return str(value)
+            except Exception:
+                pass
+        return str(crs)
 
     def _extract_with_hypercoast(self, lon, lat):
         """Extract spectral signature using hypercoast."""
@@ -1440,6 +1548,13 @@ class HyperspectralDataset:
             if result:
                 return result
 
+        if self._requires_geolocation_export():
+            raise ValueError(
+                f"{self.data_type} uses per-pixel geolocation and cannot be "
+                "safely exported with the generic bounding-box writer. Install "
+                "or activate HyperCoast dependencies, then reload the dataset."
+            )
+
         return self._export_fallback(output_path, wavelengths, bands)
 
     def _export_with_hypercoast(self, output_path, wavelengths):
@@ -1462,6 +1577,11 @@ class HyperspectralDataset:
                     result = self._export_pace_bgc_with_hypercoast(output_path)
                     if result:
                         return result
+                    if self._requires_geolocation_export():
+                        raise ValueError(
+                            "PACE BGC export requires successful HyperCoast "
+                            "geolocation gridding."
+                        )
                     return self._export_fallback(output_path, wavelengths, None)
 
                 # PACE AOP needs gridding first
@@ -1481,6 +1601,10 @@ class HyperspectralDataset:
                 )
 
             else:
+                if self._requires_geolocation_export():
+                    raise ValueError(
+                        f"{self.data_type} requires a geolocation-aware export path."
+                    )
                 return self._export_fallback(output_path, wavelengths, None)
 
             # Save the image to the output path
@@ -1506,7 +1630,30 @@ class HyperspectralDataset:
                     except Exception:
                         pass  # nosec B110
             _log(f"Error in hypercoast export: {e}", LOG_WARNING)
+            if self._requires_geolocation_export():
+                raise
             return self._export_fallback(output_path, wavelengths, None)
+
+    def _requires_geolocation_export(self):
+        """Return whether generic bounding-box export would misplace the raster.
+
+        Returns:
+            True for swath or per-pixel geolocated datasets.
+        """
+        if self._is_swath:
+            return True
+        if self.dataset is None:
+            return False
+
+        for name in ("latitude", "longitude"):
+            if name not in self.dataset:
+                return False
+        try:
+            lat = self.dataset["latitude"]
+            lon = self.dataset["longitude"]
+            return getattr(lat, "ndim", 0) == 2 or getattr(lon, "ndim", 0) == 2
+        except Exception:
+            return False
 
     def _export_pace_bgc_with_hypercoast(self, output_path, method="linear"):
         """Export a PACE BGC 2D product after gridding swath coordinates.
@@ -1648,7 +1795,7 @@ class HyperspectralDataset:
                 wavelengths=wavelengths,
                 output=output_path,
             )
-            if result and os.path.isfile(output_path):
+            if os.path.isfile(output_path) and os.path.getsize(output_path) > 0:
                 _log(f"HyperCoast EMIT export succeeded: {output_path}", LOG_INFO)
                 return output_path
         except Exception as exc:

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -1247,6 +1247,22 @@ class HyperspectralDataset:
         """
         return getattr(data_var, "ndim", 0) >= 2
 
+    def is_exportable_variable(self, name):
+        """Return whether a named data variable exists and is raster-like.
+
+        Args:
+            name: Data variable name.
+
+        Returns:
+            True when the dataset is loaded, contains ``name``, and the
+            variable has at least two dimensions.
+        """
+        if not name or self.dataset is None:
+            return False
+        if name not in self.dataset.data_vars:
+            return False
+        return self._is_exportable_data_variable(self.dataset[name])
+
     def extract_spectral_signature(self, x, y, crs="EPSG:4326", lon=None, lat=None):
         """Extract spectral signature at a given location.
 
@@ -1549,11 +1565,13 @@ class HyperspectralDataset:
                 return result
 
         if self._requires_geolocation_export():
-            raise ValueError(
+            self.last_error = (
                 f"{self.data_type} uses per-pixel geolocation and cannot be "
                 "safely exported with the generic bounding-box writer. Install "
                 "or activate HyperCoast dependencies, then reload the dataset."
             )
+            _log(self.last_error, LOG_WARNING)
+            return None
 
         return self._export_fallback(output_path, wavelengths, bands)
 
@@ -1578,10 +1596,12 @@ class HyperspectralDataset:
                     if result:
                         return result
                     if self._requires_geolocation_export():
-                        raise ValueError(
+                        self.last_error = (
                             "PACE BGC export requires successful HyperCoast "
                             "geolocation gridding."
                         )
+                        _log(self.last_error, LOG_WARNING)
+                        return None
                     return self._export_fallback(output_path, wavelengths, None)
 
                 # PACE AOP needs gridding first
@@ -1790,11 +1810,24 @@ class HyperspectralDataset:
                 from ._hypercoast_lib import get_hypercoast
 
                 hc = get_hypercoast()
-            result = hc.emit_to_image(
+            # Remove any stale file so we can use a fresh-write check below.
+            try:
+                if os.path.isfile(output_path):
+                    os.remove(output_path)
+            except OSError as exc:
+                _log(
+                    f"Could not clear stale EMIT output {output_path}: {exc}",
+                    LOG_WARNING,
+                )
+                return None
+            hc.emit_to_image(
                 self.filepath,
                 wavelengths=wavelengths,
                 output=output_path,
             )
+            # The stale file was removed above, so a fresh non-empty file at
+            # ``output_path`` is the explicit success signal even when the
+            # HyperCoast writer returns ``None``.
             if os.path.isfile(output_path) and os.path.getsize(output_path) > 0:
                 _log(f"HyperCoast EMIT export succeeded: {output_path}", LOG_INFO)
                 return output_path

--- a/qgis_plugin/hypercoast_qgis/processing_provider.py
+++ b/qgis_plugin/hypercoast_qgis/processing_provider.py
@@ -17,6 +17,7 @@ from qgis.core import (
     QgsProcessingParameterFile,
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterString,
     QgsProcessingProvider,
 )
 
@@ -90,6 +91,7 @@ class BaseHyperCoastAlgorithm(QgsProcessingAlgorithm):
 
     INPUT = "INPUT"
     DATA_TYPE = "DATA_TYPE"
+    VARIABLE = "VARIABLE"
     OUTPUT = "OUTPUT"
 
     def group(self):
@@ -117,6 +119,14 @@ class BaseHyperCoastAlgorithm(QgsProcessingAlgorithm):
                 defaultValue=0,
             )
         )
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.VARIABLE,
+                "Data variable (optional)",
+                defaultValue="",
+                optional=True,
+            )
+        )
 
     def _load_dataset(self, parameters, context):
         """Load the requested HyperCoast dataset.
@@ -135,9 +145,49 @@ class BaseHyperCoastAlgorithm(QgsProcessingAlgorithm):
         data_type_index = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
         data_type = DATA_TYPE_OPTIONS[data_type_index]
         dataset = HyperspectralDataset(input_path, data_type)
+        dataset.set_selected_variable(self._selected_variable(parameters, context))
         if not dataset.load():
             raise QgsProcessingException(dataset.last_error or "Failed to load dataset")
+        self._validate_selected_variable(dataset)
         return dataset
+
+    def _selected_variable(self, parameters, context):
+        """Return the optional Processing data variable parameter.
+
+        Args:
+            parameters: Processing parameter dict.
+            context: Processing context.
+
+        Returns:
+            Selected variable name, or None.
+        """
+        try:
+            value = self.parameterAsString(parameters, self.VARIABLE, context)
+        except Exception:
+            value = parameters.get(self.VARIABLE, "") if parameters else ""
+        value = str(value).strip() if value is not None else ""
+        return value or None
+
+    def _validate_selected_variable(self, dataset):
+        """Validate the explicitly selected data variable.
+
+        Args:
+            dataset: Loaded HyperspectralDataset.
+
+        Raises:
+            QgsProcessingException: If the requested variable cannot be used
+                as raster data.
+        """
+        variable = dataset.selected_variable
+        if not variable:
+            return
+        if dataset.dataset is None or variable not in dataset.dataset.data_vars:
+            raise QgsProcessingException(f"Data variable not found: {variable}")
+        data_var = dataset.dataset[variable]
+        if not dataset._is_exportable_data_variable(data_var):
+            raise QgsProcessingException(
+                f"Data variable is not raster-like: {variable}"
+            )
 
     def _data_cube(self, dataset):
         """Return a data cube arranged as bands, rows, columns.
@@ -261,17 +311,14 @@ class RGBCompositeAlgorithm(BaseHyperCoastAlgorithm):
 
     def processAlgorithm(self, parameters, context, feedback):
         """Run RGB composite export."""
-        input_path = self.parameterAsFile(parameters, self.INPUT, context)
-        data_type_index = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
-        data_type = DATA_TYPE_OPTIONS[data_type_index]
         wavelengths = [
             self.parameterAsDouble(parameters, self.RED, context),
             self.parameterAsDouble(parameters, self.GREEN, context),
             self.parameterAsDouble(parameters, self.BLUE, context),
         ]
         output_path = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
-        dataset = HyperspectralDataset(input_path, data_type)
-        result = dataset.load_and_export(output_path, wavelengths=wavelengths)
+        dataset = self._load_dataset(parameters, context)
+        result = dataset.export_to_geotiff(output_path, wavelengths=wavelengths)
         if result is None:
             raise QgsProcessingException(dataset.last_error or "Failed to export RGB")
         return {self.OUTPUT: result}
@@ -465,9 +512,38 @@ class PCAAlgorithm(BaseHyperCoastAlgorithm):
         dataset = self._load_dataset(parameters, context)
         output_path = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         n_components = self.parameterAsInt(parameters, self.COMPONENTS, context)
+        data_var = dataset.get_data_variable()
+        if data_var is None:
+            raise QgsProcessingException("No data variable found")
+        if data_var.ndim != 3:
+            raise QgsProcessingException(
+                f"Expected a 3D hyperspectral cube, got shape {data_var.shape}"
+            )
+        dims = list(data_var.dims)
+        spatial_axes = [
+            i
+            for i, dim in enumerate(dims)
+            if dim in ("x", "y", "latitude", "longitude")
+        ]
+        if len(spatial_axes) < 2:
+            raise QgsProcessingException("Could not identify spatial dimensions")
+        height, width = [data_var.shape[i] for i in spatial_axes[:2]]
+        total_pixels = height * width
+        max_total_pixels = 50_000_000
+        if total_pixels > max_total_pixels:
+            raise QgsProcessingException(
+                f"Raster has {total_pixels:,} pixels which exceeds the "
+                f"PCA limit of {max_total_pixels:,}. Crop or downsample the "
+                "input before running PCA."
+            )
+        if feedback and feedback.isCanceled():
+            return {self.OUTPUT: output_path}
+
         arr, height, width = self._data_cube(dataset)
         bands, _, _ = arr.shape
         n_components = min(n_components, bands)
+        if feedback:
+            feedback.setProgress(20)
 
         pixels = arr.reshape(bands, height * width).T
         valid = np.all(np.isfinite(pixels), axis=1)
@@ -477,20 +553,16 @@ class PCAAlgorithm(BaseHyperCoastAlgorithm):
 
         # Cap fitting set to keep memory bounded; project full cube in chunks.
         max_fit_pixels = 500_000
-        max_total_pixels = 50_000_000
-        if pixels.shape[0] > max_total_pixels:
-            raise QgsProcessingException(
-                f"Raster has {pixels.shape[0]:,} pixels which exceeds the "
-                f"PCA limit of {max_total_pixels:,}. Crop or downsample the "
-                "input before running PCA."
-            )
-
         valid_indices = np.flatnonzero(valid)
         if n_valid > max_fit_pixels:
             rng = np.random.default_rng(0)
             fit_indices = rng.choice(valid_indices, size=max_fit_pixels, replace=False)
         else:
             fit_indices = valid_indices
+        if feedback and feedback.isCanceled():
+            return {self.OUTPUT: output_path}
+        if feedback:
+            feedback.setProgress(40)
 
         fit_pixels = pixels[fit_indices].astype(np.float64, copy=False)
         mean = fit_pixels.mean(axis=0)
@@ -506,6 +578,8 @@ class PCAAlgorithm(BaseHyperCoastAlgorithm):
         scores = np.zeros((pixels.shape[0], n_components), dtype="float32")
         chunk = 200_000
         for start in range(0, valid_indices.size, chunk):
+            if feedback and feedback.isCanceled():
+                return {self.OUTPUT: output_path}
             stop = min(start + chunk, valid_indices.size)
             idx = valid_indices[start:stop]
             block = (
@@ -515,9 +589,14 @@ class PCAAlgorithm(BaseHyperCoastAlgorithm):
                 if scale > 0:
                     block[:, i] /= scale
             scores[idx] = block.astype("float32")
+            if feedback:
+                progress = 50 + int(40 * stop / max(valid_indices.size, 1))
+                feedback.setProgress(progress)
 
         components = scores.T.reshape(n_components, height, width)
         self._write_raster(dataset, output_path, components)
+        if feedback:
+            feedback.setProgress(100)
         return {self.OUTPUT: output_path}
 
     def createInstance(self):

--- a/qgis_plugin/hypercoast_qgis/processing_provider.py
+++ b/qgis_plugin/hypercoast_qgis/processing_provider.py
@@ -183,8 +183,7 @@ class BaseHyperCoastAlgorithm(QgsProcessingAlgorithm):
             return
         if dataset.dataset is None or variable not in dataset.dataset.data_vars:
             raise QgsProcessingException(f"Data variable not found: {variable}")
-        data_var = dataset.dataset[variable]
-        if not dataset._is_exportable_data_variable(data_var):
+        if not dataset.is_exportable_variable(variable):
             raise QgsProcessingException(
                 f"Data variable is not raster-like: {variable}"
             )
@@ -537,7 +536,7 @@ class PCAAlgorithm(BaseHyperCoastAlgorithm):
                 "input before running PCA."
             )
         if feedback and feedback.isCanceled():
-            return {self.OUTPUT: output_path}
+            raise QgsProcessingException("PCA cancelled by user")
 
         arr, height, width = self._data_cube(dataset)
         bands, _, _ = arr.shape
@@ -560,7 +559,7 @@ class PCAAlgorithm(BaseHyperCoastAlgorithm):
         else:
             fit_indices = valid_indices
         if feedback and feedback.isCanceled():
-            return {self.OUTPUT: output_path}
+            raise QgsProcessingException("PCA cancelled by user")
         if feedback:
             feedback.setProgress(40)
 

--- a/qgis_plugin/install_plugin.py
+++ b/qgis_plugin/install_plugin.py
@@ -30,7 +30,7 @@ def get_script_dir():
 def get_version_from_metadata():
     """Read the version from metadata.txt."""
     script_dir = get_script_dir()
-    metadata_path = script_dir / "hypercoast_qgis/metadata.txt"
+    metadata_path = script_dir / PLUGIN_NAME / "metadata.txt"
     with open(metadata_path, encoding="utf-8") as f:
         for line in f:
             if line.strip().lower().startswith("version"):

--- a/qgis_plugin/qt6_tests/conftest.py
+++ b/qgis_plugin/qt6_tests/conftest.py
@@ -62,5 +62,103 @@ def _install_qgis_stub() -> None:
         sys.modules[f"qgis.{name}"] = stub
         setattr(qgis, name, stub)
 
+    core = sys.modules["qgis.core"]
+
+    class QgsProcessingException(Exception):
+        """Minimal Processing exception stub."""
+
+    class QgsProcessingAlgorithm:
+        """Minimal Processing algorithm stub."""
+
+        def __init__(self) -> None:
+            """Initialize stored parameters."""
+            self.parameters = []
+
+        def addParameter(self, parameter) -> None:
+            """Store an algorithm parameter.
+
+            Args:
+                parameter: Parameter object.
+            """
+            self.parameters.append(parameter)
+
+        def parameterAsFile(self, parameters, name, context):
+            """Return a file parameter value."""
+            return parameters.get(name, "")
+
+        def parameterAsEnum(self, parameters, name, context):
+            """Return an enum parameter value."""
+            return int(parameters.get(name, 0))
+
+        def parameterAsString(self, parameters, name, context):
+            """Return a string parameter value."""
+            return parameters.get(name, "")
+
+        def parameterAsDouble(self, parameters, name, context):
+            """Return a double parameter value."""
+            return float(parameters.get(name, 0.0))
+
+        def parameterAsInt(self, parameters, name, context):
+            """Return an integer parameter value."""
+            return int(parameters.get(name, 0))
+
+        def parameterAsOutputLayer(self, parameters, name, context):
+            """Return an output layer parameter value."""
+            return parameters.get(name, "")
+
+    class QgsProcessingProvider:
+        """Minimal Processing provider stub."""
+
+        def __init__(self) -> None:
+            """Initialize stored algorithms."""
+            self.algorithms = []
+
+        def addAlgorithm(self, algorithm) -> None:
+            """Store a provider algorithm.
+
+            Args:
+                algorithm: Algorithm instance.
+            """
+            self.algorithms.append(algorithm)
+
+    class _Parameter:
+        """Minimal Processing parameter stub."""
+
+        def __init__(self, *args, **kwargs) -> None:
+            """Store parameter construction arguments."""
+            self.args = args
+            self.kwargs = kwargs
+
+    class QgsProcessingParameterFile(_Parameter):
+        """Minimal file parameter stub."""
+
+        File = 0
+
+        class Behavior:
+            """Minimal file behavior enum."""
+
+            File = 0
+
+    class QgsProcessingParameterNumber(_Parameter):
+        """Minimal number parameter stub."""
+
+        Double = 0
+        Integer = 1
+
+        class Type:
+            """Minimal number type enum."""
+
+            Double = 0
+            Integer = 1
+
+    core.QgsProcessingException = QgsProcessingException
+    core.QgsProcessingAlgorithm = QgsProcessingAlgorithm
+    core.QgsProcessingProvider = QgsProcessingProvider
+    core.QgsProcessingParameterEnum = _Parameter
+    core.QgsProcessingParameterFile = QgsProcessingParameterFile
+    core.QgsProcessingParameterNumber = QgsProcessingParameterNumber
+    core.QgsProcessingParameterRasterDestination = _Parameter
+    core.QgsProcessingParameterString = _Parameter
+
 
 _install_qgis_stub()

--- a/qgis_plugin/qt6_tests/test_cache_manager.py
+++ b/qgis_plugin/qt6_tests/test_cache_manager.py
@@ -1,0 +1,50 @@
+"""Tests for generated raster cache path helpers."""
+
+import os
+
+from hypercoast_qgis.cache_manager import (
+    create_generated_raster_path,
+    generated_raster_cache_dir,
+)
+
+
+class _Project:
+    """Tiny QgsProject-like object for cache path tests."""
+
+    def __init__(self, filename):
+        """Initialize the fake project.
+
+        Args:
+            filename: Project filename returned by ``fileName``.
+        """
+        self._filename = filename
+
+    def fileName(self):
+        """Return the fake project filename."""
+        return self._filename
+
+
+def test_saved_project_uses_user_cache_directory(tmp_path, monkeypatch):
+    """Saved projects should use the user-level HyperCoast cache."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    project_path = tmp_path / "example.qgz"
+    project_path.write_text("", encoding="utf-8")
+    project = _Project(str(project_path))
+
+    cache_dir = generated_raster_cache_dir(project)
+    raster_path = create_generated_raster_path("Layer One", "rgb", project)
+
+    assert cache_dir == str(tmp_path / ".qgis_hypercoast" / "cache")
+    assert os.path.isdir(cache_dir)
+    assert os.path.dirname(raster_path) == cache_dir
+    assert os.path.basename(raster_path).startswith("Layer_One_rgb_")
+
+
+def test_unsaved_project_uses_user_cache_directory(tmp_path, monkeypatch):
+    """Unsaved projects should use the user-level HyperCoast cache."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    cache_dir = generated_raster_cache_dir(_Project(""))
+
+    assert cache_dir == str(tmp_path / ".qgis_hypercoast" / "cache")
+    assert os.path.isdir(cache_dir)

--- a/qgis_plugin/qt6_tests/test_hyperspectral_provider.py
+++ b/qgis_plugin/qt6_tests/test_hyperspectral_provider.py
@@ -91,3 +91,130 @@ def test_north_up_orientation_flips_ascending_latitude():
     oriented = provider._orient_array_north_up(data, y_values, y_axis=0)
 
     np.testing.assert_array_equal(oriented, np.array([[3, 4], [1, 2]]))
+
+
+def test_projected_xy_spectral_extraction_uses_dataset_crs(monkeypatch):
+    """Projected x/y datasets should use projected click coordinates."""
+    import hypercoast_qgis.hyperspectral_provider as provider_module
+
+    monkeypatch.setattr(provider_module, "HAS_HYPERCOAST", False)
+    dataset = xr.Dataset(
+        {
+            "reflectance": (
+                ("wavelength", "y", "x"),
+                np.array(
+                    [
+                        [[1.0, 2.0], [3.0, 4.0]],
+                        [[10.0, 20.0], [30.0, 40.0]],
+                    ],
+                    dtype="float32",
+                ),
+            )
+        },
+        coords={
+            "wavelength": np.array([500.0, 600.0]),
+            "y": np.array([0.0, 100.0]),
+            "x": np.array([0.0, 1000.0]),
+        },
+    )
+    provider = HyperspectralDataset("generic.tif", "Generic")
+    provider.dataset = dataset
+    provider.wavelengths = dataset.coords["wavelength"].values
+    provider.crs = "EPSG:32618"
+
+    wavelengths, values = provider.extract_spectral_signature(
+        510.0, 90.0, crs="EPSG:32618"
+    )
+
+    np.testing.assert_array_equal(wavelengths, np.array([500.0, 600.0]))
+    np.testing.assert_array_equal(values, np.array([4.0, 40.0], dtype="float32"))
+
+
+def test_lat_lon_spectral_extraction_uses_geographic_coordinates(monkeypatch):
+    """Latitude/longitude datasets should still extract with EPSG:4326 input."""
+    import hypercoast_qgis.hyperspectral_provider as provider_module
+
+    monkeypatch.setattr(provider_module, "HAS_HYPERCOAST", False)
+    dataset = xr.Dataset(
+        {
+            "reflectance": (
+                ("wavelength", "latitude", "longitude"),
+                np.array(
+                    [
+                        [[1.0, 2.0], [3.0, 4.0]],
+                        [[10.0, 20.0], [30.0, 40.0]],
+                    ],
+                    dtype="float32",
+                ),
+            )
+        },
+        coords={
+            "wavelength": np.array([500.0, 600.0]),
+            "latitude": np.array([30.0, 31.0]),
+            "longitude": np.array([-91.0, -90.0]),
+        },
+    )
+    provider = HyperspectralDataset("generic.nc", "Generic")
+    provider.dataset = dataset
+    provider.wavelengths = dataset.coords["wavelength"].values
+    provider.crs = "EPSG:4326"
+
+    wavelengths, values = provider.extract_spectral_signature(
+        -90.9, 30.1, crs="EPSG:4326"
+    )
+
+    np.testing.assert_array_equal(wavelengths, np.array([500.0, 600.0]))
+    np.testing.assert_array_equal(values, np.array([1.0, 10.0], dtype="float32"))
+
+
+def test_emit_runtime_export_accepts_written_file_when_return_is_none(
+    tmp_path, monkeypatch
+):
+    """HyperCoast writers may signal success by writing the requested file."""
+    import hypercoast_qgis.hyperspectral_provider as provider_module
+
+    output_path = tmp_path / "emit.tif"
+
+    class _HyperCoast:
+        """Fake HyperCoast module."""
+
+        def emit_to_image(self, filepath, wavelengths, output):
+            """Write the output file and return None."""
+            with open(output, "wb") as fp:
+                fp.write(b"fake geotiff")
+            return None
+
+    monkeypatch.setattr(provider_module, "HAS_HYPERCOAST", True)
+    monkeypatch.setattr(provider_module, "hypercoast", _HyperCoast(), raising=False)
+    provider = HyperspectralDataset("EMIT_test.nc", "EMIT")
+
+    result = provider._export_emit_with_runtime_hypercoast(
+        str(output_path), [650, 550, 450]
+    )
+
+    assert result == str(output_path)
+
+
+def test_per_pixel_geolocation_requires_geolocation_export():
+    """Datasets with 2D lat/lon coordinates should not use bbox fallback."""
+    dataset = xr.Dataset(
+        {
+            "reflectance": (
+                ("wavelength", "downtrack", "crosstrack"),
+                np.ones((2, 2, 2), dtype="float32"),
+            ),
+            "latitude": (
+                ("downtrack", "crosstrack"),
+                np.array([[30.0, 30.1], [31.0, 31.1]]),
+            ),
+            "longitude": (
+                ("downtrack", "crosstrack"),
+                np.array([[-91.0, -90.9], [-91.1, -90.8]]),
+            ),
+        },
+        coords={"wavelength": np.array([500.0, 600.0])},
+    )
+    provider = HyperspectralDataset("EMIT_test.nc", "EMIT")
+    provider.dataset = dataset
+
+    assert provider._requires_geolocation_export()

--- a/qgis_plugin/qt6_tests/test_layer_registry.py
+++ b/qgis_plugin/qt6_tests/test_layer_registry.py
@@ -1,0 +1,135 @@
+"""Tests for HyperCoast layer metadata rehydration."""
+
+from hypercoast_qgis.hypercoast_plugin import HyperCoastPlugin
+
+
+class _Layer:
+    """Small QGIS layer-like object with custom properties."""
+
+    def __init__(self, properties):
+        """Initialize the fake layer.
+
+        Args:
+            properties: Custom property mapping.
+        """
+        self._properties = properties
+
+    def customProperty(self, key, default=None):
+        """Return a fake custom property."""
+        return self._properties.get(key, default)
+
+
+class _Project:
+    """Small QGIS project-like object."""
+
+    def __init__(self, layers):
+        """Initialize the fake project.
+
+        Args:
+            layers: Mapping of layer IDs to layer-like objects.
+        """
+        self._layers = layers
+
+    def mapLayers(self):
+        """Return fake project layers."""
+        return self._layers
+
+
+def _plugin():
+    """Return a HyperCoastPlugin instance without constructing QGIS UI."""
+    plugin = HyperCoastPlugin.__new__(HyperCoastPlugin)
+    plugin.hyperspectral_data = {}
+    return plugin
+
+
+def test_rehydrate_parses_custom_properties(tmp_path, monkeypatch):
+    """Custom properties should rebuild HyperCoast layer metadata."""
+    source = tmp_path / "source.nc"
+    source.write_text("", encoding="utf-8")
+    layer = _Layer(
+        {
+            "hypercoast/source_path": str(source),
+            "hypercoast/data_type": "PACE",
+            "hypercoast/selected_variable": "chlor_a",
+            "hypercoast/rgb_wavelengths": "650,550,450",
+            "hypercoast/crs": "EPSG:4326",
+        }
+    )
+    project = _Project({"layer-1": layer})
+    import hypercoast_qgis.hypercoast_plugin as plugin_module
+
+    monkeypatch.setattr(
+        plugin_module.QgsProject, "instance", staticmethod(lambda: project)
+    )
+    plugin = _plugin()
+
+    plugin.rehydrate_hyperspectral_layers()
+
+    data_info = plugin.hyperspectral_data["layer-1"]
+    assert data_info["dataset"] is None
+    assert data_info["filepath"] == str(source)
+    assert data_info["data_type"] == "PACE"
+    assert data_info["selected_variable"] == "chlor_a"
+    assert data_info["rgb_wavelengths"] == [650.0, 550.0, 450.0]
+    assert data_info["crs"] == "EPSG:4326"
+
+
+def test_rehydrate_skips_missing_source_files(monkeypatch):
+    """Missing source files should not crash project metadata scanning."""
+    layer = _Layer({"hypercoast/source_path": "/missing/source.nc"})
+    project = _Project({"layer-1": layer})
+    import hypercoast_qgis.hypercoast_plugin as plugin_module
+
+    monkeypatch.setattr(
+        plugin_module.QgsProject, "instance", staticmethod(lambda: project)
+    )
+    plugin = _plugin()
+
+    plugin.rehydrate_hyperspectral_layers()
+
+    assert plugin.hyperspectral_data == {}
+
+
+def test_lazy_load_preserves_selected_variable(tmp_path, monkeypatch):
+    """Lazy loading should pass the rehydrated selected variable to the provider."""
+    source = tmp_path / "source.nc"
+    source.write_text("", encoding="utf-8")
+    plugin = _plugin()
+    plugin.hyperspectral_data["layer-1"] = {
+        "dataset": None,
+        "filepath": str(source),
+        "data_type": "PACE",
+        "selected_variable": "chlor_a",
+    }
+    selected_variables = []
+
+    class _Dataset:
+        """Fake HyperspectralDataset that records selected variables."""
+
+        def __init__(self, filepath, data_type):
+            """Initialize fake dataset metadata."""
+            self.filepath = filepath
+            self.data_type = data_type
+            self.dataset = object()
+            self.wavelengths = [1, 2, 3]
+            self.bounds = (0, 0, 1, 1)
+            self.crs = "EPSG:4326"
+            self.last_error = None
+
+        def set_selected_variable(self, variable_name):
+            """Record the selected variable."""
+            selected_variables.append(variable_name)
+
+        def load(self):
+            """Pretend the dataset loaded successfully."""
+            return True
+
+    import hypercoast_qgis.hyperspectral_provider as provider_module
+
+    monkeypatch.setattr(provider_module, "HyperspectralDataset", _Dataset)
+
+    dataset = plugin.ensure_hyperspectral_dataset("layer-1")
+
+    assert dataset is not None
+    assert selected_variables == ["chlor_a"]
+    assert plugin.hyperspectral_data["layer-1"]["dataset"] is dataset

--- a/qgis_plugin/qt6_tests/test_processing_provider.py
+++ b/qgis_plugin/qt6_tests/test_processing_provider.py
@@ -1,0 +1,70 @@
+"""Tests for HyperCoast Processing helper behavior."""
+
+import numpy as np
+import pytest
+
+xr = pytest.importorskip("xarray")
+
+from hypercoast_qgis.processing_provider import (
+    BaseHyperCoastAlgorithm,
+    QgsProcessingException,
+    RGBCompositeAlgorithm,
+)
+from hypercoast_qgis.hyperspectral_provider import HyperspectralDataset
+
+
+def _loaded_dataset():
+    """Return a loaded provider with multiple candidate variables."""
+    dataset = xr.Dataset(
+        {
+            "reflectance": (
+                ("wavelength", "y", "x"),
+                np.ones((2, 2, 2), dtype="float32"),
+            ),
+            "quality": (("y", "x"), np.ones((2, 2), dtype="float32")),
+            "metadata": (("record",), np.ones(2, dtype="float32")),
+        },
+        coords={
+            "wavelength": np.array([500.0, 600.0]),
+            "y": np.array([0.0, 1.0]),
+            "x": np.array([0.0, 1.0]),
+        },
+    )
+    provider = HyperspectralDataset("generic.nc", "Generic")
+    provider.dataset = dataset
+    return provider
+
+
+def test_blank_processing_variable_uses_default_selection():
+    """Blank Processing variable input should behave like no override."""
+    algorithm = RGBCompositeAlgorithm()
+
+    assert (
+        algorithm._selected_variable({BaseHyperCoastAlgorithm.VARIABLE: ""}, None)
+        is None
+    )
+
+
+def test_valid_processing_variable_is_accepted():
+    """A raster-like selected variable should pass validation."""
+    algorithm = RGBCompositeAlgorithm()
+    dataset = _loaded_dataset()
+    dataset.set_selected_variable("quality")
+
+    algorithm._validate_selected_variable(dataset)
+
+    assert dataset.get_data_variable().name == "quality"
+
+
+def test_invalid_processing_variable_raises_clear_exception():
+    """Missing or non-raster variables should raise Processing exceptions."""
+    algorithm = RGBCompositeAlgorithm()
+    dataset = _loaded_dataset()
+    dataset.set_selected_variable("missing")
+
+    with pytest.raises(QgsProcessingException, match="Data variable not found"):
+        algorithm._validate_selected_variable(dataset)
+
+    dataset.set_selected_variable("metadata")
+    with pytest.raises(QgsProcessingException, match="not raster-like"):
+        algorithm._validate_selected_variable(dataset)


### PR DESCRIPTION
## Summary
- Rehydrate HyperCoast layer state from QGIS custom properties on project load and lazily reload datasets on demand, with safer plugin unload that survives already-deleted toolbar widgets.
- Make spectral signature extraction CRS-aware (transform between map, raster, and EPSG:4326), restrict HyperCoast sensor extractors to sensors that expect lon/lat, and add an optional data variable parameter plus PCA pixel-count and dimensionality guards in the Processing algorithms.
- Move the generated raster cache to a stable user-level directory and add Qt6 tests for the cache manager, layer registry, processing provider, and hyperspectral provider.

## Test plan
- [ ] `python -m pytest qgis_plugin/qt6_tests/`
- [ ] Open a saved QGIS project containing HyperCoast hyperspectral layers and confirm the spectral inspector and band combination dialogs work without re-loading the source manually.
- [ ] Run the RGB Composite and PCA Processing algorithms on a sample EMIT/PACE file with and without an explicit data variable.