### PR TITLE
fix: install QGIS plugin as hypercoast folder

### DIFF
--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -61,7 +61,7 @@ When QGIS is launched from this Conda environment, the plugin automatically dete
 
 ### Manual Installation
 
-1. Copy the `hypercoast_qgis` folder to your QGIS plugins directory:
+1. Copy the `hypercoast_qgis` source folder to your QGIS plugins directory and name the copied folder `hypercoast`:
 
     - **Linux**: `~/.local/share/QGIS/QGIS3/profiles/default/python/plugins/`
     - **Windows**: `%APPDATA%\QGIS\QGIS3\profiles\default\python\plugins\`
@@ -125,7 +125,7 @@ The recommended way to package and install the plugin:
 ```bash
 cd qgis_plugin
 
-# Package the plugin (creates dist/hypercoast_qgis_0.8.0.zip)
+# Package the plugin (creates dist/hypercoast_0.8.0.zip)
 python install_plugin.py
 
 # Package and install directly to QGIS
@@ -152,11 +152,11 @@ cd qgis_plugin
 
 ### Manual Packaging
 
-To create a distributable ZIP file manually:
+To create a distributable ZIP file manually, keep `hypercoast` as the top-level folder in the archive:
 
 ```bash
 cd qgis_plugin
-zip -r hypercoast_qgis.zip hypercoast_qgis -x "*.pyc" -x "__pycache__/*"
+python package_plugin.py
 ```
 
 ### Running Tests

--- a/qgis_plugin/install_plugin.py
+++ b/qgis_plugin/install_plugin.py
@@ -19,7 +19,9 @@ import platform
 from pathlib import Path
 
 # Plugin configuration
-PLUGIN_NAME = "hypercoast_qgis"
+SOURCE_PLUGIN_NAME = "hypercoast_qgis"
+QGIS_PLUGIN_NAME = "hypercoast"
+PLUGIN_NAME = QGIS_PLUGIN_NAME
 
 
 def get_script_dir():
@@ -30,7 +32,7 @@ def get_script_dir():
 def get_version_from_metadata():
     """Read the version from metadata.txt."""
     script_dir = get_script_dir()
-    metadata_path = script_dir / PLUGIN_NAME / "metadata.txt"
+    metadata_path = script_dir / SOURCE_PLUGIN_NAME / "metadata.txt"
     with open(metadata_path, encoding="utf-8") as f:
         for line in f:
             if line.strip().lower().startswith("version"):
@@ -88,7 +90,8 @@ def get_qgis_plugins_dir():
             )
 
     elif system == "Darwin":
-        # macOS: ~/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins
+        # macOS: ~/Library/Application Support/QGIS/QGIS3/profiles/default/
+        # python/plugins
         return (
             home
             / "Library"
@@ -131,6 +134,18 @@ def should_exclude(path, patterns):
     return False
 
 
+def prompt_response(message):
+    """Read a normalized response from standard input.
+
+    Args:
+        message: Prompt shown to the user.
+
+    Returns:
+        Lowercase stripped response text.
+    """
+    return input(message).strip().lower()
+
+
 def copy_plugin_files(src_dir, dst_dir, exclude_patterns):
     """Copy plugin files to destination, excluding certain patterns."""
     if dst_dir.exists():
@@ -154,8 +169,11 @@ def create_zip_package(source_dir, output_path, plugin_name):
     """Create a ZIP package of the plugin."""
     with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
         for root, dirs, files in os.walk(source_dir):
-            # Filter out excluded directories
-            dirs[:] = [d for d in dirs if not should_exclude(Path(d), EXCLUDE_PATTERNS)]
+            filtered_dirs = []
+            for directory in dirs:
+                if not should_exclude(Path(directory), EXCLUDE_PATTERNS):
+                    filtered_dirs.append(directory)
+            dirs[:] = filtered_dirs
 
             for file in files:
                 if should_exclude(Path(file), EXCLUDE_PATTERNS):
@@ -163,8 +181,9 @@ def create_zip_package(source_dir, output_path, plugin_name):
 
                 file_path = Path(root) / file
                 # Create archive path with plugin name as root
-                rel_path = file_path.relative_to(source_dir.parent)
-                zipf.write(file_path, rel_path)
+                rel_path = file_path.relative_to(source_dir)
+                archive_path = Path(plugin_name) / rel_path
+                zipf.write(file_path, archive_path)
 
     return output_path
 
@@ -173,13 +192,14 @@ def package_plugin(output_dir=None):
     """Package the plugin into a ZIP file.
 
     Args:
-        output_dir: Optional output directory. Defaults to 'dist' in script directory.
+        output_dir: Optional output directory. Defaults to 'dist' in script
+            directory.
 
     Returns:
         Path to the created ZIP file.
     """
     script_dir = get_script_dir()
-    plugin_dir = script_dir / PLUGIN_NAME
+    plugin_dir = script_dir / SOURCE_PLUGIN_NAME
 
     if not plugin_dir.exists():
         raise FileNotFoundError(f"Plugin directory not found: {plugin_dir}")
@@ -194,18 +214,18 @@ def package_plugin(output_dir=None):
 
     # Create temporary directory for clean copy
     with tempfile.TemporaryDirectory() as temp_dir:
-        temp_plugin_dir = Path(temp_dir) / PLUGIN_NAME
+        temp_plugin_dir = Path(temp_dir) / QGIS_PLUGIN_NAME
 
         # Copy files
-        print(f"Copying plugin files...")
+        print("Copying plugin files...")
         copy_plugin_files(plugin_dir, temp_plugin_dir, EXCLUDE_PATTERNS)
 
         # Create ZIP archive
-        zip_name = f"{PLUGIN_NAME}_{VERSION}.zip"
+        zip_name = f"{QGIS_PLUGIN_NAME}_{VERSION}.zip"
         zip_path = output_dir / zip_name
 
-        print(f"Creating ZIP archive...")
-        create_zip_package(temp_plugin_dir, zip_path, PLUGIN_NAME)
+        print("Creating ZIP archive...")
+        create_zip_package(temp_plugin_dir, zip_path, QGIS_PLUGIN_NAME)
 
     print(f"\nPlugin packaged successfully: {zip_path}")
     return zip_path
@@ -234,11 +254,13 @@ def install_plugin(zip_path=None, force=False):
 
     # Check if plugins directory exists
     if not plugins_dir.parent.exists():
-        print(f"\nWarning: QGIS profile directory not found: {plugins_dir.parent}")
-        print("Please ensure QGIS is installed and has been run at least once.")
+        print("\nWarning: QGIS profile directory not found:")
+        print(f"  {plugins_dir.parent}")
+        print("Please ensure QGIS is installed.")
+        print("Run QGIS at least once before installing the plugin.")
         while True:
             try:
-                create = input("Create directory anyway? [y/N]: ").strip().lower()
+                create = prompt_response("Create directory anyway? [y/N]: ")
             except EOFError:
                 create = ""
             if create in ("y", "n", ""):
@@ -256,14 +278,13 @@ def install_plugin(zip_path=None, force=False):
     if install_path.exists():
         if not force:
             print(f"\nPlugin already installed at: {install_path}")
-            overwrite = (
-                input("Overwrite existing installation? [y/N]: ").strip().lower()
-            )
+            prompt = "Overwrite existing installation? [y/N]: "
+            overwrite = prompt_response(prompt)
             if overwrite != "y":
                 print("Installation cancelled.")
                 return None
 
-        print(f"Removing existing installation...")
+        print("Removing existing installation...")
         shutil.rmtree(install_path)
 
     # Extract ZIP to plugins directory
@@ -272,12 +293,12 @@ def install_plugin(zip_path=None, force=False):
     with zipfile.ZipFile(zip_path, "r") as zipf:
         zipf.extractall(plugins_dir)
 
-    print(f"\nPlugin installed successfully!")
-    print(f"\nTo enable the plugin:")
-    print(f"  1. Open QGIS")
-    print(f"  2. Go to Plugins -> Manage and Install Plugins")
-    print(f"  3. Find 'HyperCoast' in the list")
-    print(f"  4. Check the box to enable it")
+    print("\nPlugin installed successfully!")
+    print("\nTo enable the plugin:")
+    print("  1. Open QGIS")
+    print("  2. Go to Plugins -> Manage and Install Plugins")
+    print("  3. Find 'HyperCoast' in the list")
+    print("  4. Check the box to enable it")
 
     return install_path
 
@@ -291,7 +312,8 @@ def uninstall_plugin():
         print(f"Plugin not found at: {install_path}")
         return False
 
-    confirm = input(f"Remove plugin from {install_path}? [y/N]: ").strip().lower()
+    prompt = f"Remove plugin from {install_path}? [y/N]: "
+    confirm = prompt_response(prompt)
     if confirm != "y":
         print("Uninstallation cancelled.")
         return False
@@ -308,24 +330,25 @@ def show_info():
     install_path = plugins_dir / PLUGIN_NAME
 
     print(f"\n{'=' * 60}")
-    print(f"HyperCoast QGIS Plugin Information")
+    print("HyperCoast QGIS Plugin Information")
     print(f"{'=' * 60}")
-    print(f"Plugin Name:     {PLUGIN_NAME}")
+    print(f"Plugin Name:     {QGIS_PLUGIN_NAME}")
+    print(f"Source Folder:   {SOURCE_PLUGIN_NAME}")
     print(f"Version:         {VERSION}")
     print(f"Script Location: {script_dir}")
     print(f"{'=' * 60}")
     print(f"System:          {platform.system()} {platform.release()}")
     print(f"Python:          {sys.version.split()[0]}")
     print(f"{'=' * 60}")
-    print(f"QGIS Plugins Directory:")
+    print("QGIS Plugins Directory:")
     print(f"  {plugins_dir}")
     print(f"  Exists: {plugins_dir.exists()}")
     print(f"{'=' * 60}")
-    print(f"Installation Status:")
+    print("Installation Status:")
     if install_path.exists():
         print(f"  Installed at: {install_path}")
     else:
-        print(f"  Not installed")
+        print("  Not installed")
     print(f"{'=' * 60}\n")
 
 
@@ -352,7 +375,10 @@ Examples:
     )
 
     parser.add_argument(
-        "--uninstall", "-u", action="store_true", help="Uninstall the plugin from QGIS"
+        "--uninstall",
+        "-u",
+        action="store_true",
+        help="Uninstall the plugin from QGIS",
     )
 
     parser.add_argument(
@@ -371,7 +397,9 @@ Examples:
     )
 
     parser.add_argument(
-        "--info", action="store_true", help="Show plugin and system information"
+        "--info",
+        action="store_true",
+        help="Show plugin and system information",
     )
 
     args = parser.parse_args()
@@ -389,14 +417,14 @@ Examples:
             install_plugin(force=args.force)
         else:
             zip_path = package_plugin(args.output)
-            print(f"\nTo install the plugin:")
+            print("\nTo install the plugin:")
             print(f"  python {Path(__file__).name} --install")
-            print(f"\nOr manually:")
-            print(f"  1. Open QGIS")
-            print(f"  2. Go to Plugins -> Manage and Install Plugins")
-            print(f"  3. Click 'Install from ZIP'")
+            print("\nOr manually:")
+            print("  1. Open QGIS")
+            print("  2. Go to Plugins -> Manage and Install Plugins")
+            print("  3. Click 'Install from ZIP'")
             print(f"  4. Select: {zip_path}")
-            print(f"  5. Click 'Install Plugin'")
+            print("  5. Click 'Install Plugin'")
 
         return 0
 

--- a/qgis_plugin/install_plugin.py
+++ b/qgis_plugin/install_plugin.py
@@ -141,9 +141,14 @@ def prompt_response(message):
         message: Prompt shown to the user.
 
     Returns:
-        Lowercase stripped response text.
+        Lowercase stripped response text. Returns an empty string when
+        standard input is closed (for example, during non-interactive runs)
+        so callers do not need to guard against ``EOFError``.
     """
-    return input(message).strip().lower()
+    try:
+        return input(message).strip().lower()
+    except EOFError:
+        return ""
 
 
 def copy_plugin_files(src_dir, dst_dir, exclude_patterns):
@@ -259,10 +264,7 @@ def install_plugin(zip_path=None, force=False):
         print("Please ensure QGIS is installed.")
         print("Run QGIS at least once before installing the plugin.")
         while True:
-            try:
-                create = prompt_response("Create directory anyway? [y/N]: ")
-            except EOFError:
-                create = ""
+            create = prompt_response("Create directory anyway? [y/N]: ")
             if create in ("y", "n", ""):
                 break
             print("Please enter 'y' to create the directory or 'n' to cancel.")

--- a/qgis_plugin/install_plugin.sh
+++ b/qgis_plugin/install_plugin.sh
@@ -1,13 +1,31 @@
 #!/bin/bash
-# Script to package the HyperCoast QGIS Plugin for distribution
+# Script to package the HyperCoast QGIS Plugin for distribution.
+#
+# Produces ``dist/hypercoast_<version>.zip`` with ``hypercoast`` as the
+# top-level archive folder, matching the official QGIS plugin name. The
+# source folder in this repository is ``hypercoast_qgis``.
+
+set -euo pipefail
 
 # Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Plugin name
-PLUGIN_NAME="hypercoast_qgis"
-VERSION="0.3.0"
+# Plugin names: source folder vs. installed/published name
+SOURCE_PLUGIN_NAME="hypercoast_qgis"
+QGIS_PLUGIN_NAME="hypercoast"
+
+# Read version from metadata.txt so it stays in sync with the plugin
+METADATA_FILE="$SOURCE_PLUGIN_NAME/metadata.txt"
+if [[ ! -f "$METADATA_FILE" ]]; then
+    echo "Error: metadata file not found: $METADATA_FILE" >&2
+    exit 1
+fi
+VERSION="$(awk -F '=' '/^[[:space:]]*version[[:space:]]*=/ {gsub(/[[:space:]]/, "", $2); print $2; exit}' "$METADATA_FILE")"
+if [[ -z "$VERSION" ]]; then
+    echo "Error: could not determine version from $METADATA_FILE" >&2
+    exit 1
+fi
 
 # Create output directory
 OUTPUT_DIR="dist"
@@ -15,10 +33,11 @@ mkdir -p "$OUTPUT_DIR"
 
 # Create temporary directory for clean copy
 TEMP_DIR=$(mktemp -d)
-mkdir -p "$TEMP_DIR/$PLUGIN_NAME"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+mkdir -p "$TEMP_DIR/$QGIS_PLUGIN_NAME"
 
-# Copy plugin files
-cp -r "$PLUGIN_NAME"/* "$TEMP_DIR/$PLUGIN_NAME/"
+# Copy plugin files from the source folder to the published folder name
+cp -r "$SOURCE_PLUGIN_NAME"/* "$TEMP_DIR/$QGIS_PLUGIN_NAME/"
 
 # Remove unnecessary files
 find "$TEMP_DIR" -type f -name "*.pyc" -delete
@@ -27,12 +46,9 @@ find "$TEMP_DIR" -type f -name "*.py.bak" -delete
 find "$TEMP_DIR" -type f -name ".DS_Store" -delete
 
 # Create ZIP archive
-ZIP_NAME="${PLUGIN_NAME}_${VERSION}.zip"
+ZIP_NAME="${QGIS_PLUGIN_NAME}_${VERSION}.zip"
 cd "$TEMP_DIR"
-zip -r "$SCRIPT_DIR/$OUTPUT_DIR/$ZIP_NAME" "$PLUGIN_NAME"
-
-# Cleanup
-rm -rf "$TEMP_DIR"
+zip -r "$SCRIPT_DIR/$OUTPUT_DIR/$ZIP_NAME" "$QGIS_PLUGIN_NAME"
 
 echo "Plugin packaged: $OUTPUT_DIR/$ZIP_NAME"
 echo ""
@@ -42,4 +58,3 @@ echo "2. Go to Plugins -> Manage and Install Plugins"
 echo "3. Click 'Install from ZIP'"
 echo "4. Select: $OUTPUT_DIR/$ZIP_NAME"
 echo "5. Click 'Install Plugin'"
-

--- a/qgis_plugin/qt6_tests/test_install_plugin_packaging.py
+++ b/qgis_plugin/qt6_tests/test_install_plugin_packaging.py
@@ -4,9 +4,9 @@ import sys
 import zipfile
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
 
 import install_plugin  # noqa: E402
 
@@ -45,7 +45,7 @@ def test_install_plugin_installs_to_hypercoast_folder(tmp_path, monkeypatch):
 
 def test_readme_advertises_hypercoast_install_folder():
     """README should document hypercoast as the QGIS plugin folder name."""
-    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    readme = (PLUGIN_ROOT / "README.md").read_text(encoding="utf-8")
 
     assert "name the copied folder `hypercoast`" in readme
     assert "Copy the `hypercoast_qgis` folder" not in readme

--- a/qgis_plugin/qt6_tests/test_install_plugin_packaging.py
+++ b/qgis_plugin/qt6_tests/test_install_plugin_packaging.py
@@ -1,0 +1,51 @@
+"""Tests for QGIS plugin packaging and install folder conventions."""
+
+import sys
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import install_plugin  # noqa: E402
+
+
+def test_install_plugin_zip_uses_hypercoast_root(tmp_path):
+    """Package files under the official folder name."""
+    zip_path = install_plugin.package_plugin(tmp_path)
+
+    assert zip_path.name == f"hypercoast_{install_plugin.VERSION}.zip"
+
+    with zipfile.ZipFile(zip_path) as zip_file:
+        names = zip_file.namelist()
+
+    top_level = {name.split("/", 1)[0] for name in names if name}
+    assert top_level == {"hypercoast"}
+    assert "hypercoast/metadata.txt" in names
+    assert not any(name.startswith("hypercoast_qgis/") for name in names)
+
+
+def test_install_plugin_installs_to_hypercoast_folder(tmp_path, monkeypatch):
+    """Local installation should create a hypercoast plugin folder."""
+    zip_path = install_plugin.package_plugin(tmp_path / "dist")
+    plugins_dir = tmp_path / "plugins"
+    monkeypatch.setattr(
+        install_plugin,
+        "get_qgis_plugins_dir",
+        lambda: plugins_dir,
+    )
+
+    install_path = install_plugin.install_plugin(zip_path=zip_path, force=True)
+
+    assert install_path == plugins_dir / "hypercoast"
+    assert (install_path / "metadata.txt").is_file()
+    assert not (plugins_dir / "hypercoast_qgis").exists()
+
+
+def test_readme_advertises_hypercoast_install_folder():
+    """README should document hypercoast as the QGIS plugin folder name."""
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "name the copied folder `hypercoast`" in readme
+    assert "Copy the `hypercoast_qgis` folder" not in readme


### PR DESCRIPTION
## Summary
- Package and install the QGIS plugin under the official `hypercoast` folder name (matching the plugin metadata identifier) while keeping `hypercoast_qgis` as the source directory in this repo.
- Update `qgis_plugin/README.md` to document the new folder convention and ZIP naming.
- Add packaging tests that lock in the archive layout, install destination, and README guidance.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest qgis_plugin/qt6_tests/test_install_plugin_packaging.py`
- [ ] `python qgis_plugin/install_plugin.py` produces `dist/hypercoast_<version>.zip` with `hypercoast/` as the top-level folder
- [ ] Manual install into a QGIS profile creates a `hypercoast/` plugin directory