### PR TITLE
feat: add Planet Tanager STAC search and visualization

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.10", "3.11", "3.12", "3.13"]
+                python-version: ["3.10", "3.11", "3.12"]
 
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.9", "3.10", "3.11", "3.12"]
+                python-version: ["3.10", "3.11", "3.12", "3.13"]
 
         steps:
             - uses: actions/checkout@v6

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -15,3 +15,4 @@
 -   [Visualize PACE OCI L1 data products](https://hypercoast.org/examples/pace_oci_l1)
 -   [Visualize PACE OCI L2 data products](https://hypercoast.org/examples/pace_oci_l2)
 -   [Visualize Multispectral data interactively](https://hypercoast.org/examples/multispectral)
+-   [Search and visualize Planet Tanager STAC data](https://hypercoast.org/examples/tanager_stac)

--- a/docs/examples/tanager_stac.ipynb
+++ b/docs/examples/tanager_stac.ipynb
@@ -51,30 +51,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "m = hypercoast.Map()\n",
-    "m"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if m.user_roi_bounds():\n",
-    "    bbox = m.user_roi_bounds()\n",
-    "else:\n",
-    "    bbox = [-123.0, 37.0, -122.0, 38.1]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "7",
    "metadata": {},
@@ -82,6 +58,60 @@
     "## Search Tanager STAC items\n",
     "\n",
     "The Tanager catalog is organized into thematic collections. The example below searches the Coastal and Water Bodies collection near San Francisco Bay."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a",
+   "metadata": {},
+   "source": [
+    "## Display Tanager footprints\n",
+    "\n",
+    "Use `tanager_footprints()` to collect STAC item footprints as a GeoDataFrame. By default, duplicate scenes that appear in multiple thematic collections are merged and their collection names are preserved in the `collections` and `collection_titles` columns.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "footprints = hypercoast.tanager_footprints()\n",
+    "len(footprints), footprints[[\"id\", \"collection_titles\", \"datetime\"]].head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m.add_tanager_footprints(info_mode=\"on_click\")\n",
+    "m\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fb5963c",
+   "metadata": {},
+   "source": [
+    "Draw a rectangle on the map. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab71e861",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if m.user_roi_bounds():\n",
+    "    bbox = m.user_roi_bounds()\n",
+    "else:\n",
+    "    bbox = [-123.0, 37.0, -122.0, 38.1]"
    ]
   },
   {
@@ -140,6 +170,7 @@
    "source": [
     "m = hypercoast.Map()\n",
     "m.add_cog_layer(visual_url, name=\"Tanager ortho visual\")\n",
+    "m.zoom = 10\n",
     "m"
    ]
   },
@@ -163,6 +194,7 @@
     "m = hypercoast.Map()\n",
     "m.add_tanager(item, layer_name=\"Tanager\")\n",
     "m.add(\"spectral\")\n",
+    "m.zoom = 10\n",
     "m"
    ]
   },

--- a/docs/examples/tanager_stac.ipynb
+++ b/docs/examples/tanager_stac.ipynb
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Search Tanager STAC items\n",
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Display Tanager footprints\n",
@@ -73,29 +73,29 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
     "footprints = hypercoast.tanager_footprints()\n",
-    "len(footprints), footprints[[\"id\", \"collection_titles\", \"datetime\"]].head()\n"
+    "len(footprints), footprints[[\"id\", \"collection_titles\", \"datetime\"]].head()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
     "m = hypercoast.Map()\n",
     "m.add_tanager_footprints(info_mode=\"on_click\")\n",
-    "m\n"
+    "m"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6fb5963c",
+   "id": "9",
    "metadata": {},
    "source": [
     "Draw a rectangle on the map. "
@@ -104,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab71e861",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Visualize the ortho visual COG\n",
@@ -153,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "16",
    "metadata": {},
    "source": [
     "## Add a STAC item with spectral signatures\n",
@@ -187,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Download and read the spectral HDF5 asset\n",
@@ -211,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/examples/tanager_stac.ipynb
+++ b/docs/examples/tanager_stac.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Searching and Visualizing Planet Tanager STAC Data\n",
+    "\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/HyperCoast/blob/main/docs/examples/tanager_stac.ipynb)\n",
+    "\n",
+    "This notebook demonstrates how to search the [Planet Tanager STAC catalog](https://www.planet.com/data/stac/browser/tanager-core-imagery/catalog.json), visualize the `ortho_visual` Cloud-Optimized GeoTIFF directly, and use the `ortho_radiance_hdf5` asset for spectral signatures."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Install packages\n",
+    "\n",
+    "Uncomment the following line to install the packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install hypercoast"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hypercoast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if m.user_roi_bounds():\n",
+    "    bbox = m.user_roi_bounds()\n",
+    "else:\n",
+    "    bbox = [-123.0, 37.0, -122.0, 38.1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Search Tanager STAC items\n",
+    "\n",
+    "The Tanager catalog is organized into thematic collections. The example below searches the Coastal and Water Bodies collection near San Francisco Bay."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "items = hypercoast.search_tanager(\n",
+    "    collections=\"coastal-water-bodies\",\n",
+    "    bbox=bbox,\n",
+    "    count=5,\n",
+    ")\n",
+    "len(items), items[0][\"id\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "item = items[0]\n",
+    "item[\"properties\"][\"datetime\"], item[\"properties\"].get(\"location_description\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "## Visualize the ortho visual COG\n",
+    "\n",
+    "Each Tanager STAC item includes an `ortho_visual` asset. It is a Cloud-Optimized GeoTIFF and can be displayed directly with `add_cog_layer()` without downloading the HDF5 spectral product.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "visual_url = hypercoast.get_tanager_asset_url(item, asset=\"ortho_visual\")\n",
+    "visual_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m.add_cog_layer(visual_url, name=\"Tanager ortho visual\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "## Add a STAC item with spectral signatures\n",
+    "\n",
+    "`Map.add_tanager()` accepts a STAC item dictionary or item URL. For STAC inputs, HyperCoast displays the `ortho_visual` COG on the map and downloads `ortho_radiance_hdf5` for the spectral dataset used by the spectral plotting tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = hypercoast.Map()\n",
+    "m.add_tanager(item, layer_name=\"Tanager\")\n",
+    "m.add(\"spectral\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "## Download and read the spectral HDF5 asset\n",
+    "\n",
+    "You can also download and read the `ortho_radiance_hdf5` asset explicitly. The reader uses STAC band metadata when the HDF5 file does not contain wavelength metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = hypercoast.read_tanager_stac(\n",
+    "    item,\n",
+    "    asset=\"ortho_radiance_hdf5\",\n",
+    "    out_dir=\"data\",\n",
+    ")\n",
+    "dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hypercoast.extract_tanager(\n",
+    "    dataset,\n",
+    "    latitude=37.9,\n",
+    "    longitude=-122.3,\n",
+    "    delta=0.01,\n",
+    "    return_plot=True,\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hyper",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -43,6 +43,7 @@ from .tanager import (
     read_tanager,
     read_tanager_stac,
     search_tanager,
+    tanager_footprints,
     download_tanager,
     get_tanager_asset_url,
     tanager_to_image,
@@ -1193,6 +1194,129 @@ class Map(leafmap.Map):
             self._update_band_names(layer_name, selected_wavelengths)
         except Exception as e:
             print(e)
+
+    def add_tanager_footprints(
+        self,
+        bbox=None,
+        temporal=None,
+        collections=None,
+        count=-1,
+        query=None,
+        cloud_percent=None,
+        catalog_url=None,
+        output=None,
+        crs="EPSG:4326",
+        unique=True,
+        timeout=30,
+        layer_name="Tanager footprints",
+        style=None,
+        hover_style=None,
+        style_callback=None,
+        fill_colors=None,
+        info_mode="on_hover",
+        zoom_to_layer=True,
+        **kwargs,
+    ):
+        """Add Tanager STAC item footprints to the map.
+
+        Args:
+            bbox (list, optional): Bounding box ``[xmin, ymin, xmax, ymax]`` in
+                EPSG:4326.
+            temporal (str or tuple, optional): Date/time range as
+                ``"start/end"``, ``"start,end"``, or ``(start, end)``.
+            collections (str or list, optional): Tanager collection ids or
+                titles. Defaults to all collections.
+            count (int, optional): Maximum number of matching STAC item records
+                to inspect. ``-1`` means all. Defaults to ``-1``.
+            query (str, optional): Case-insensitive text search against item id,
+                title, description, and location description.
+            cloud_percent (float, optional): Maximum item ``cloud_percent``.
+            catalog_url (str, optional): Tanager STAC catalog URL.
+            output (str, optional): File path to save the footprint
+                GeoDataFrame.
+            crs (str, optional): CRS for the returned GeoDataFrame. Defaults to
+                ``"EPSG:4326"``.
+            unique (bool, optional): Deduplicate scenes that appear in multiple
+                thematic collections. Defaults to True.
+            timeout (int, optional): HTTP request timeout in seconds. Defaults
+                to 30.
+            layer_name (str, optional): Map layer name. Defaults to
+                ``"Tanager footprints"``.
+            style (dict, optional): Polygon style dictionary.
+            hover_style (dict, optional): Polygon hover style dictionary.
+            style_callback (callable, optional): Per-feature style callback.
+            fill_colors (list, optional): Random fill colors passed to leafmap.
+            info_mode (str, optional): ``"on_hover"`` or ``"on_click"``.
+                Defaults to ``"on_hover"``.
+            zoom_to_layer (bool, optional): Whether to zoom to the footprints.
+                Defaults to True.
+            **kwargs: Additional exact-match STAC property filters and keyword
+                arguments passed to ``leafmap.Map.add_gdf``.
+
+        Returns:
+            geopandas.GeoDataFrame: The footprint GeoDataFrame added to the map.
+        """
+        if style is None:
+            style = {
+                "color": "#00A6D6",
+                "weight": 2,
+                "fillColor": "#00A6D6",
+                "fillOpacity": 0.08,
+            }
+        if hover_style is None:
+            hover_style = {"weight": 4, "fillOpacity": 0.18}
+
+        search_kwargs = {}
+        add_gdf_kwargs = {}
+        add_gdf_keys = {"encoding", "marker", "marker_cluster"}
+        for key, value in kwargs.items():
+            if key in add_gdf_keys:
+                add_gdf_kwargs[key] = value
+            else:
+                search_kwargs[key] = value
+
+        if catalog_url is None:
+            gdf = tanager_footprints(
+                bbox=bbox,
+                temporal=temporal,
+                collections=collections,
+                count=count,
+                query=query,
+                cloud_percent=cloud_percent,
+                output=output,
+                crs=crs,
+                unique=unique,
+                timeout=timeout,
+                **search_kwargs,
+            )
+        else:
+            gdf = tanager_footprints(
+                bbox=bbox,
+                temporal=temporal,
+                collections=collections,
+                count=count,
+                query=query,
+                cloud_percent=cloud_percent,
+                catalog_url=catalog_url,
+                output=output,
+                crs=crs,
+                unique=unique,
+                timeout=timeout,
+                **search_kwargs,
+            )
+
+        self.add_gdf(
+            gdf,
+            layer_name=layer_name,
+            style=style,
+            hover_style=hover_style,
+            style_callback=style_callback,
+            fill_colors=fill_colors,
+            info_mode=info_mode,
+            zoom_to_layer=zoom_to_layer,
+            **add_gdf_kwargs,
+        )
+        return gdf
 
     def add_hyper(self, xds, dtype, wvl_indexes=None, **kwargs):
         """Add a hyperspectral dataset to the map.

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -39,7 +39,16 @@ from .pace import (
     pace_to_image,
     pace_chla_to_image,
 )
-from .tanager import read_tanager, tanager_to_image, extract_tanager, grid_tanager
+from .tanager import (
+    read_tanager,
+    read_tanager_stac,
+    search_tanager,
+    download_tanager,
+    get_tanager_asset_url,
+    tanager_to_image,
+    extract_tanager,
+    grid_tanager,
+)
 from .wyvern import read_wyvern, wyvern_to_image, extract_wyvern, filter_wyvern
 from .cesl import (
     search_cesl,
@@ -1059,6 +1068,8 @@ class Map(leafmap.Map):
         zoom_to_layer=True,
         visible=True,
         method="nearest",
+        asset="ortho_radiance_hdf5",
+        visual_asset="ortho_visual",
         array_args=None,
         **kwargs,
     ):
@@ -1074,8 +1085,15 @@ class Map(leafmap.Map):
             os.environ['LOCALTILESERVER_CLIENT_PREFIX'] = 'proxy/{port}'
 
         Args:
-            source (str): The path to the GeoTIFF file or the URL of the Cloud
-                Optimized GeoTIFF.
+            source (str or dict): The path to a Tanager HDF5 file, a Tanager
+                STAC item URL, a Planet STAC browser item URL, a STAC item
+                dictionary, or an xarray.Dataset.
+            asset (str, optional): HDF5 STAC asset key to download when
+                ``source`` is a STAC item. Defaults to
+                ``"ortho_radiance_hdf5"``.
+            visual_asset (str, optional): STAC COG asset key used for the map
+                layer when ``source`` is a STAC item. Defaults to
+                ``"ortho_visual"``. Set to None to render from the HDF5 data.
             bands (list, optional): The band indices to select. Defaults to None.
             wavelengths (list, optional): The wavelength values to select. Takes priority over bands. Defaults to None.
             colormap (str, optional): The name of the colormap from `matplotlib`
@@ -1101,8 +1119,16 @@ class Map(leafmap.Map):
         if array_args is None:
             array_args = {}
 
-        if isinstance(source, str):
-
+        stac_source = None
+        if isinstance(source, dict) or (
+            isinstance(source, str)
+            and source.startswith("http")
+            and "/data/stac/" in source
+            and ".json" in source
+        ):
+            stac_source = source
+            source = read_tanager_stac(source, asset=asset)
+        elif isinstance(source, str):
             source = read_tanager(source)
 
         selected_wavelengths = []
@@ -1123,28 +1149,42 @@ class Map(leafmap.Map):
 
         else:
             selected_wavelengths = [876.3, 675.88, 625.83]
+
+        if isinstance(selected_wavelengths, list) and len(selected_wavelengths) > 1:
+            colormap = None
+
         try:
-            image = tanager_to_image(
-                source, wavelengths=selected_wavelengths, method=method
-            )
-
-            if isinstance(selected_wavelengths, list) and len(selected_wavelengths) > 1:
-                colormap = None
-
-            self.add_raster(
-                image,
-                indexes=indexes,
-                colormap=colormap,
-                vmin=vmin,
-                vmax=vmax,
-                nodata=nodata,
-                attribution=attribution,
-                layer_name=layer_name,
-                zoom_to_layer=zoom_to_layer,
-                visible=visible,
-                array_args=array_args,
-                **kwargs,
-            )
+            if stac_source is not None and visual_asset is not None:
+                image = get_tanager_asset_url(stac_source, asset=visual_asset)
+                cog_kwargs = kwargs.copy()
+                if indexes is not None:
+                    cog_kwargs["bidx"] = indexes
+                self.add_cog_layer(
+                    image,
+                    name=layer_name,
+                    attribution=attribution or "",
+                    shown=visible,
+                    zoom_to_layer=zoom_to_layer,
+                    **cog_kwargs,
+                )
+            else:
+                image = tanager_to_image(
+                    source, wavelengths=selected_wavelengths, method=method
+                )
+                self.add_raster(
+                    image,
+                    indexes=indexes,
+                    colormap=colormap,
+                    vmin=vmin,
+                    vmax=vmax,
+                    nodata=nodata,
+                    attribution=attribution,
+                    layer_name=layer_name,
+                    zoom_to_layer=zoom_to_layer,
+                    visible=visible,
+                    array_args=array_args,
+                    **kwargs,
+                )
 
             self.cog_layer_dict[layer_name]["xds"] = source
             self.cog_layer_dict[layer_name]["vmax"] = vmax

--- a/hypercoast/tanager.py
+++ b/hypercoast/tanager.py
@@ -209,7 +209,71 @@ def _stac_items_to_gdf(items, crs="EPSG:4326"):
     """Convert STAC items to a GeoDataFrame."""
     import geopandas as gpd
 
-    return gpd.GeoDataFrame.from_features(items, crs=crs)
+    features = []
+    for item in items:
+        props = dict(item.get("properties", {}))
+        props["id"] = item.get("id")
+        props["stac_url"] = _get_stac_item_url(item)
+        if item.get("_collection_title"):
+            props["collection_title"] = item["_collection_title"]
+        if item.get("_collection_url"):
+            props["collection_url"] = item["_collection_url"]
+        if item.get("collection"):
+            props["collection"] = item["collection"]
+
+        collection_ids = item.get("_collection_ids")
+        collection_titles = item.get("_collection_titles")
+        if collection_ids:
+            props["collections"] = ", ".join(collection_ids)
+        if collection_titles:
+            props["collection_titles"] = ", ".join(collection_titles)
+
+        assets = item.get("assets", {})
+        for asset_key in (
+            "ortho_visual",
+            "ortho_radiance_hdf5",
+            "basic_radiance_hdf5",
+            "ortho_sr_hdf5",
+            "basic_sr_hdf5",
+        ):
+            if asset_key in assets:
+                props[f"{asset_key}_url"] = assets[asset_key].get("href")
+
+        features.append(
+            {
+                "type": "Feature",
+                "id": item.get("id"),
+                "geometry": item.get("geometry"),
+                "properties": props,
+            }
+        )
+
+    return gpd.GeoDataFrame.from_features(features, crs=crs)
+
+
+def _dedupe_tanager_items(items):
+    """Deduplicate STAC items and track all matching Tanager collections."""
+    deduped = {}
+    for item in items:
+        key = item.get("id") or _get_stac_item_url(item)
+        if key not in deduped:
+            copy = dict(item)
+            copy["_collection_ids"] = []
+            copy["_collection_titles"] = []
+            deduped[key] = copy
+
+        target = deduped[key]
+        collection_id = item.get("collection")
+        if not collection_id and item.get("_collection_url"):
+            collection_id = item["_collection_url"].rstrip("/").split("/")[-2]
+        collection_title = item.get("_collection_title")
+
+        if collection_id and collection_id not in target["_collection_ids"]:
+            target["_collection_ids"].append(collection_id)
+        if collection_title and collection_title not in target["_collection_titles"]:
+            target["_collection_titles"].append(collection_title)
+
+    return list(deduped.values())
 
 
 def _spectral_bands_from_asset(asset):
@@ -415,6 +479,75 @@ def search_tanager(
             gdf.to_file(output)
         return results, gdf
     return results
+
+
+def tanager_footprints(
+    bbox: Optional[List[float]] = None,
+    temporal: Optional[Union[str, Tuple[str, str]]] = None,
+    collections: Optional[Union[str, List[str]]] = None,
+    count: int = -1,
+    query: Optional[str] = None,
+    cloud_percent: Optional[float] = None,
+    catalog_url: str = TANAGER_STAC_CATALOG_URL,
+    output: Optional[str] = None,
+    crs: str = "EPSG:4326",
+    unique: bool = True,
+    return_items: bool = False,
+    timeout: int = 30,
+    **kwargs,
+):
+    """Return Tanager STAC item footprints as a GeoDataFrame.
+
+    Args:
+        bbox (list, optional): Bounding box ``[xmin, ymin, xmax, ymax]`` in
+            EPSG:4326.
+        temporal (str or tuple, optional): Date/time range as
+            ``"start/end"``, ``"start,end"``, or ``(start, end)``.
+        collections (str or list, optional): Tanager collection ids or titles.
+            Defaults to all collections in the Tanager STAC catalog.
+        count (int, optional): Maximum number of matching STAC item records to
+            inspect. ``-1`` means all. Defaults to ``-1``.
+        query (str, optional): Case-insensitive text search against item id,
+            title, description, and location description.
+        cloud_percent (float, optional): Maximum item ``cloud_percent``.
+        catalog_url (str, optional): Tanager STAC catalog URL. Planet browser
+            URLs are accepted and normalized to raw JSON URLs.
+        output (str, optional): File path to save the GeoDataFrame.
+        crs (str, optional): CRS for GeoDataFrame output. Defaults to
+            ``"EPSG:4326"``.
+        unique (bool, optional): Deduplicate scenes that appear in more than
+            one thematic collection. Defaults to True.
+        return_items (bool, optional): Return ``(items, gdf)`` instead of only
+            the GeoDataFrame. Defaults to False.
+        timeout (int, optional): HTTP request timeout in seconds.
+        **kwargs: Additional exact-match filters against STAC item properties.
+
+    Returns:
+        geopandas.GeoDataFrame or tuple: Footprint GeoDataFrame, or
+            ``(items, gdf)`` when ``return_items=True``.
+    """
+    items = search_tanager(
+        bbox=bbox,
+        temporal=temporal,
+        collections=collections,
+        count=count,
+        query=query,
+        cloud_percent=cloud_percent,
+        catalog_url=catalog_url,
+        return_gdf=False,
+        timeout=timeout,
+        **kwargs,
+    )
+    if unique:
+        items = _dedupe_tanager_items(items)
+
+    gdf = _stac_items_to_gdf(items, crs=crs)
+    if output is not None:
+        gdf.to_file(output)
+
+    if return_items:
+        return items, gdf
+    return gdf
 
 
 def download_tanager(

--- a/hypercoast/tanager.py
+++ b/hypercoast/tanager.py
@@ -8,14 +8,21 @@ caller-supplied STAC URL only when necessary.
 """
 
 import warnings
+import os
+import re
+from datetime import datetime, timezone
 
 import h5py
 import xarray as xr
 import numpy as np
 import requests
 import matplotlib.pyplot as plt
-from typing import List, Tuple, Union, Optional, Any, Callable
+from typing import List, Tuple, Union, Optional
 from .common import download_file
+
+TANAGER_STAC_CATALOG_URL = (
+    "https://www.planet.com/data/stac/tanager-core-imagery/catalog.json"
+)
 
 # Recognized Planet Tanager products and their canonical output var names.
 _PRODUCT_VAR_NAME = {
@@ -31,6 +38,501 @@ _PRODUCT_STAC_ASSET = {
     "basic_sr": "basic_sr_hdf5",
     "ortho_sr": "ortho_sr_hdf5",
 }
+
+_STAC_ASSET_PRODUCT = {v: k for k, v in _PRODUCT_STAC_ASSET.items()}
+
+
+def _normalize_stac_url(url):
+    """Convert a Planet STAC browser URL to the raw JSON URL."""
+    if isinstance(url, str):
+        url = url.replace("/data/stac/browser/", "/data/stac/")
+        if ".json?" in url or ".json#" in url:
+            url = url.split(".json", 1)[0] + ".json"
+        return url
+    return url
+
+
+def _fetch_json(url, timeout=30):
+    """Fetch JSON from a URL and raise for HTTP errors when available."""
+    response = requests.get(_normalize_stac_url(url), timeout=timeout)
+    if hasattr(response, "raise_for_status"):
+        response.raise_for_status()
+    return response.json()
+
+
+def _stac_links(obj, rel):
+    """Return all STAC links matching a relation."""
+    return [link for link in obj.get("links", []) if link.get("rel") == rel]
+
+
+def _get_stac_item_url(item):
+    """Return a known URL for a STAC item if one is available."""
+    if isinstance(item, str):
+        return _normalize_stac_url(item)
+    for key in ("_stac_url", "stac_url"):
+        if item.get(key):
+            return _normalize_stac_url(item[key])
+    for link in item.get("links", []):
+        if link.get("rel") == "self" and link.get("href"):
+            return _normalize_stac_url(link["href"])
+    return None
+
+
+def _load_stac_item(item):
+    """Load a STAC item from a dict or URL."""
+    if isinstance(item, str):
+        url = _normalize_stac_url(item)
+        loaded = _fetch_json(url)
+        loaded["_stac_url"] = url
+        return loaded
+    if isinstance(item, dict):
+        return item
+    raise TypeError("Expected a STAC item dictionary or item URL.")
+
+
+def _as_list(value):
+    """Return ``value`` as a list, preserving ``None``."""
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _bbox_intersects(a, b):
+    """Return True when bbox ``a`` intersects bbox ``b``."""
+    if len(a) != 4 or len(b) != 4:
+        return False
+    return not (a[2] < b[0] or a[0] > b[2] or a[3] < b[1] or a[1] > b[3])
+
+
+def _parse_datetime(value):
+    """Parse common STAC datetime strings."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    value = str(value).strip()
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    if len(value) == 10:
+        value = value + "T00:00:00+00:00"
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _parse_temporal(temporal):
+    """Parse temporal filters accepted by ``search_tanager``."""
+    if temporal is None:
+        return None, None
+    if isinstance(temporal, str):
+        sep = "/" if "/" in temporal else ","
+        parts = [part.strip() for part in temporal.split(sep, 1)]
+    else:
+        parts = list(temporal)
+    if len(parts) != 2:
+        raise ValueError("temporal must be a string or pair of start/end datetimes.")
+    return _parse_datetime(parts[0]), _parse_datetime(parts[1])
+
+
+def _item_datetime(item):
+    """Return an item's acquisition datetime."""
+    dt = item.get("properties", {}).get("datetime")
+    return _parse_datetime(dt)
+
+
+def _item_matches_filters(
+    item,
+    bbox=None,
+    temporal=None,
+    query=None,
+    cloud_percent=None,
+    **property_filters,
+):
+    """Return True when a STAC item satisfies search filters."""
+    if bbox is not None and not _bbox_intersects(item.get("bbox", []), bbox):
+        return False
+
+    start, end = _parse_temporal(temporal)
+    if start is not None or end is not None:
+        dt = _item_datetime(item)
+        if dt is None:
+            return False
+        if start is not None and dt < start:
+            return False
+        if end is not None and dt > end:
+            return False
+
+    props = item.get("properties", {})
+    if cloud_percent is not None:
+        item_cloud = props.get("cloud_percent")
+        if item_cloud is None or item_cloud > cloud_percent:
+            return False
+
+    if query:
+        haystack = " ".join(
+            str(value)
+            for value in (
+                item.get("id", ""),
+                props.get("title", ""),
+                props.get("description", ""),
+                props.get("location_description", ""),
+            )
+        ).lower()
+        if str(query).lower() not in haystack:
+            return False
+
+    for key, expected in property_filters.items():
+        if expected is None:
+            continue
+        value = props.get(key)
+        expected_values = _as_list(expected)
+        if value not in expected_values:
+            return False
+
+    return True
+
+
+def _coerce_tanager_items(items):
+    """Return STAC item dictionaries from a single item/URL or a sequence."""
+    if isinstance(items, (str, dict)):
+        return [_load_stac_item(items)]
+    return [_load_stac_item(item) for item in items]
+
+
+def _stac_items_to_gdf(items, crs="EPSG:4326"):
+    """Convert STAC items to a GeoDataFrame."""
+    import geopandas as gpd
+
+    return gpd.GeoDataFrame.from_features(items, crs=crs)
+
+
+def _spectral_bands_from_asset(asset):
+    """Return only spectral ``eo:bands`` entries from a STAC asset."""
+    return [band for band in asset.get("eo:bands", []) if "center_wavelength" in band]
+
+
+def _read_wavelengths_from_stac_item(stac_item, asset_key):
+    """Read wavelength and FWHM arrays from a loaded STAC item."""
+    assets = stac_item.get("assets", {})
+    if asset_key not in assets:
+        available = sorted(assets.keys())
+        raise KeyError(
+            f"STAC item has no asset '{asset_key}'. Available assets: {available}"
+        )
+    bands_meta = _spectral_bands_from_asset(assets[asset_key])
+    if not bands_meta:
+        raise KeyError(f"STAC item asset '{asset_key}' has no spectral eo:bands.")
+    wl = np.array([b["center_wavelength"] for b in bands_meta], dtype=float)
+    fwhm = np.array(
+        [b.get("full_width_half_max", np.nan) for b in bands_meta], dtype=float
+    )
+    return _ensure_nm(wl), _ensure_fwhm_nm(fwhm)
+
+
+def _parse_hdfeos_grid_metadata(h5_file):
+    """Parse HDFEOS GRID projection metadata from StructMetadata.0."""
+    path = "HDFEOS INFORMATION/StructMetadata.0"
+    if path not in h5_file:
+        return {}
+
+    raw = h5_file[path][()]
+    if isinstance(raw, bytes):
+        text = raw.decode("utf-8", "ignore")
+    else:
+        text = str(raw)
+
+    def _number(name, cast=float):
+        match = re.search(rf"{name}=(-?\d+(?:\.\d+)?)", text)
+        return cast(match.group(1)) if match else None
+
+    def _point(name):
+        match = re.search(rf"{name}=\((-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)\)", text)
+        if match:
+            return float(match.group(1)), float(match.group(2))
+        return None
+
+    return {
+        "xdim": _number("XDim", int),
+        "ydim": _number("YDim", int),
+        "upper_left": _point("UpperLeftPointMtrs"),
+        "lower_right": _point("LowerRightMtrs"),
+        "projection": "HE5_GCTP_UTM" if "Projection=HE5_GCTP_UTM" in text else None,
+        "zone_code": _number("ZoneCode", int),
+    }
+
+
+def _grid_latlon(h5_file, layout):
+    """Build latitude/longitude arrays for an HDFEOS GRID product."""
+    grid_root = layout.get("grid_root")
+    grid_info = layout.get("grid_info") or {}
+    if not grid_root:
+        return None, None
+
+    attrs = h5_file[grid_root].attrs if grid_root in h5_file else {}
+    epsg = attrs.get("epsg_code")
+    if epsg is not None:
+        epsg = int(epsg)
+    elif grid_info.get("projection") == "HE5_GCTP_UTM" and grid_info.get("zone_code"):
+        zone = int(grid_info["zone_code"])
+        epsg = 32600 + zone if zone > 0 else 32700 + abs(zone)
+
+    upper_left = grid_info.get("upper_left")
+    lower_right = grid_info.get("lower_right")
+    if epsg is None or upper_left is None or lower_right is None:
+        return None, None
+
+    cube = h5_file[layout["data_path"]]
+    if layout["band_axis"] == 0:
+        y_size, x_size = cube.shape[1], cube.shape[2]
+    else:
+        axes = [axis for axis in range(cube.ndim) if axis != layout["band_axis"]]
+        y_size, x_size = cube.shape[axes[0]], cube.shape[axes[1]]
+
+    left, top = upper_left
+    right, bottom = lower_right
+    x_res = (right - left) / x_size
+    y_res = (top - bottom) / y_size
+    x = np.linspace(left + x_res / 2, right - x_res / 2, x_size)
+    y = np.linspace(top - y_res / 2, bottom + y_res / 2, y_size)
+    x2d, y2d = np.meshgrid(x, y)
+
+    try:
+        from pyproj import Transformer
+    except ImportError as exc:
+        raise ImportError(
+            "Reading orthorectified Tanager GRID products requires pyproj. "
+            "Install pyproj or geopandas to generate latitude/longitude coordinates."
+        ) from exc
+
+    transformer = Transformer.from_crs(f"EPSG:{epsg}", "EPSG:4326", always_xy=True)
+    lon, lat = transformer.transform(x2d, y2d)
+    return lat, lon
+
+
+def search_tanager(
+    bbox: Optional[List[float]] = None,
+    temporal: Optional[Union[str, Tuple[str, str]]] = None,
+    collections: Optional[Union[str, List[str]]] = None,
+    count: int = -1,
+    query: Optional[str] = None,
+    cloud_percent: Optional[float] = None,
+    catalog_url: str = TANAGER_STAC_CATALOG_URL,
+    output: Optional[str] = None,
+    crs: str = "EPSG:4326",
+    return_gdf: bool = False,
+    timeout: int = 30,
+    **kwargs,
+) -> Union[List[dict], tuple]:
+    """Search Planet Tanager STAC sample imagery.
+
+    Args:
+        bbox (list, optional): Bounding box ``[xmin, ymin, xmax, ymax]`` in
+            EPSG:4326.
+        temporal (str or tuple, optional): Date/time range as
+            ``"start/end"``, ``"start,end"``, or ``(start, end)``.
+        collections (str or list, optional): Tanager collection ids or titles,
+            such as ``"coastal-water-bodies"`` or ``"GHG Plumes"``.
+        count (int, optional): Maximum number of items to return. ``-1`` means
+            all matching items. Defaults to ``-1``.
+        query (str, optional): Case-insensitive text search against item id,
+            title, description, and location description.
+        cloud_percent (float, optional): Maximum item ``cloud_percent``.
+        catalog_url (str, optional): Tanager STAC catalog URL. Planet browser
+            URLs are accepted and normalized to raw JSON URLs.
+        output (str, optional): File path to save a GeoDataFrame when
+            ``return_gdf`` is True.
+        crs (str, optional): CRS for GeoDataFrame output. Defaults to
+            ``"EPSG:4326"``.
+        return_gdf (bool, optional): Return ``(items, gdf)`` instead of only
+            the item list. Defaults to False.
+        timeout (int, optional): HTTP request timeout in seconds.
+        **kwargs: Additional exact-match filters against STAC item properties,
+            for example ``quality_category="test"``.
+
+    Returns:
+        list or tuple: STAC item dictionaries, or ``(items, gdf)`` when
+            ``return_gdf=True``.
+    """
+    catalog_url = _normalize_stac_url(catalog_url)
+    bbox = list(bbox) if bbox is not None else None
+    selected_collections = _as_list(collections)
+    if selected_collections is not None:
+        selected_collections = {str(value).lower() for value in selected_collections}
+
+    catalog = _fetch_json(catalog_url, timeout=timeout)
+    results = []
+
+    for link in _stac_links(catalog, "child"):
+        collection_url = _normalize_stac_url(link["href"])
+        collection = _fetch_json(collection_url, timeout=timeout)
+        collection_id = str(collection.get("id", "")).lower()
+        collection_title = str(collection.get("title", "")).lower()
+        if selected_collections is not None and not (
+            collection_id in selected_collections
+            or collection_title in selected_collections
+        ):
+            continue
+
+        for item_link in _stac_links(collection, "item"):
+            item_url = _normalize_stac_url(item_link["href"])
+            item = _fetch_json(item_url, timeout=timeout)
+            item["_stac_url"] = item_url
+            item["_collection_url"] = collection_url
+            item["_collection_title"] = collection.get("title", "")
+            if _item_matches_filters(
+                item,
+                bbox=bbox,
+                temporal=temporal,
+                query=query,
+                cloud_percent=cloud_percent,
+                **kwargs,
+            ):
+                results.append(item)
+                if count is not None and count > -1 and len(results) >= count:
+                    break
+        if count is not None and count > -1 and len(results) >= count:
+            break
+
+    if return_gdf:
+        gdf = _stac_items_to_gdf(results, crs=crs)
+        if output is not None:
+            gdf.to_file(output)
+        return results, gdf
+    return results
+
+
+def download_tanager(
+    items,
+    asset: str = "ortho_radiance_hdf5",
+    out_dir: Optional[str] = None,
+    quiet: bool = True,
+    overwrite: bool = False,
+    **kwargs,
+) -> List[str]:
+    """Download a Tanager asset from one or more STAC items.
+
+    Args:
+        items (dict, str, or list): STAC item dictionary, STAC item URL, or a
+            sequence of either.
+        asset (str, optional): STAC asset key to download. Defaults to
+            ``"ortho_radiance_hdf5"``.
+        out_dir (str, optional): Output directory. Defaults to the current
+            directory.
+        quiet (bool, optional): Suppress download output. Defaults to True.
+        overwrite (bool, optional): Overwrite existing files. Defaults to False.
+        **kwargs: Extra keyword arguments passed to :func:`download_file`.
+
+    Returns:
+        list: Local file paths for the downloaded assets.
+    """
+    paths = []
+    for item in _coerce_tanager_items(items):
+        assets = item.get("assets", {})
+        if asset not in assets:
+            available = sorted(assets.keys())
+            raise KeyError(
+                f"STAC item has no asset '{asset}'. Available assets: {available}"
+            )
+        href = assets[asset].get("href")
+        if not href:
+            raise ValueError(f"STAC item asset '{asset}' has no href.")
+        output = None
+        if out_dir is not None:
+            output = os.path.join(out_dir, os.path.basename(href))
+        paths.append(
+            download_file(
+                href,
+                output=output,
+                quiet=quiet,
+                overwrite=overwrite,
+                unzip=False,
+                **kwargs,
+            )
+        )
+    return paths
+
+
+def get_tanager_asset_url(stac_item, asset: str = "ortho_visual") -> str:
+    """Return an asset URL from a Tanager STAC item.
+
+    Args:
+        stac_item (dict or str): STAC item dictionary or item JSON URL.
+        asset (str, optional): STAC asset key. Defaults to ``"ortho_visual"``.
+
+    Returns:
+        str: The asset href.
+    """
+    item = _load_stac_item(stac_item)
+    assets = item.get("assets", {})
+    if asset not in assets:
+        available = sorted(assets.keys())
+        raise KeyError(
+            f"STAC item has no asset '{asset}'. Available assets: {available}"
+        )
+    href = assets[asset].get("href")
+    if not href:
+        raise ValueError(f"STAC item asset '{asset}' has no href.")
+    return href
+
+
+def read_tanager_stac(
+    stac_item,
+    asset: str = "ortho_radiance_hdf5",
+    out_dir: Optional[str] = None,
+    bands=None,
+    wavelengths=None,
+    product: Optional[str] = None,
+    quiet: bool = True,
+    overwrite: bool = False,
+    **kwargs,
+):
+    """Download and read a Tanager HDF5 asset from a STAC item.
+
+    Args:
+        stac_item (dict or str): STAC item dictionary or item JSON URL.
+        asset (str, optional): HDF5 STAC asset key. Defaults to
+            ``"ortho_radiance_hdf5"``.
+        out_dir (str, optional): Directory for the downloaded HDF5 file.
+        bands (array-like, optional): Spectral band indices to keep.
+        wavelengths (array-like, optional): Explicit wavelength values in nm.
+        product (str, optional): Force a Tanager product variant.
+        quiet (bool, optional): Suppress download output. Defaults to True.
+        overwrite (bool, optional): Overwrite existing files. Defaults to False.
+        **kwargs: Extra keyword arguments passed to :func:`read_tanager`.
+
+    Returns:
+        xarray.Dataset: Tanager dataset read from the selected STAC asset.
+    """
+    item = _load_stac_item(stac_item)
+    stac_url = _get_stac_item_url(item)
+    paths = download_tanager(
+        item,
+        asset=asset,
+        out_dir=out_dir,
+        quiet=quiet,
+        overwrite=overwrite,
+    )
+    if wavelengths is None:
+        wavelengths, _ = _read_wavelengths_from_stac_item(item, asset)
+    ds = read_tanager(
+        paths[0],
+        bands=bands,
+        stac_url=stac_url,
+        wavelengths=wavelengths,
+        product=product,
+        **kwargs,
+    )
+    if product is None and asset in _STAC_ASSET_PRODUCT:
+        ds.attrs["product"] = _STAC_ASSET_PRODUCT[asset]
+    ds.attrs["stac_asset"] = asset
+    ds.attrs["stac_item"] = stac_url or ds.attrs.get("stac_item", "")
+    return ds
 
 
 def _ensure_nm(values):
@@ -50,6 +552,19 @@ def _ensure_nm(values):
     arr = np.asarray(values, dtype=float)
     if arr.size and np.nanmax(arr) < 10:
         arr = arr * 1000.0
+    return arr
+
+
+def _ensure_fwhm_nm(values, units=None):
+    """Return a FWHM array in nanometers."""
+    arr = np.asarray(values, dtype=float)
+    units = str(units or "").lower()
+    if "nm" in units or "nanometer" in units:
+        return arr
+    if "um" in units or "µm" in units or "micrometer" in units or "micron" in units:
+        return arr * 1000.0
+    if arr.size and np.nanmax(arr) < 1:
+        return arr * 1000.0
     return arr
 
 
@@ -103,12 +618,11 @@ def _discover_tanager_layout(h5_file, product=None):
     Raises:
         ValueError: If no 3-D data cube can be located in the file.
     """
-    hdfeos_root = "HDFEOS/SWATHS/HYP"
-    df_root = f"{hdfeos_root}/Data Fields"
-    gf_root = f"{hdfeos_root}/Geolocation Fields"
+    hdfeos_roots = ["HDFEOS/SWATHS/HYP", "HDFEOS/GRIDS/HYP"]
 
     data_path = None
     cube_name = None
+    hdfeos_root = None
 
     candidate_names_by_product = {
         "basic_radiance": ["toa_radiance"],
@@ -123,30 +637,44 @@ def _discover_tanager_layout(h5_file, product=None):
                 f"Unknown Tanager product '{product}'. Expected one of "
                 f"{sorted(_PRODUCT_VAR_NAME)}."
             )
-        for candidate in candidate_names_by_product[product]:
-            path = f"{df_root}/{candidate}"
-            if path in h5_file:
-                data_path = path
-                cube_name = candidate
+        for root in hdfeos_roots:
+            df_root = f"{root}/Data Fields"
+            for candidate in candidate_names_by_product[product]:
+                path = f"{df_root}/{candidate}"
+                if path in h5_file:
+                    data_path = path
+                    cube_name = candidate
+                    hdfeos_root = root
+                    break
+            if data_path is not None:
                 break
         if data_path is None:
-            expected = [f"{df_root}/{c}" for c in candidate_names_by_product[product]]
+            expected = [
+                f"{root}/Data Fields/{c}"
+                for root in hdfeos_roots
+                for c in candidate_names_by_product[product]
+            ]
             raise ValueError(
                 f"Forced product '{product}' requires one of {expected} "
                 f"in the HDF5 file but none were found."
             )
 
     if data_path is None:
-        for candidate in (
-            "toa_radiance",
-            "surface_reflectance",
-            "ortho_radiance",
-            "ortho_surface_reflectance",
-        ):
-            path = f"{df_root}/{candidate}"
-            if path in h5_file:
-                data_path = path
-                cube_name = candidate
+        for root in hdfeos_roots:
+            df_root = f"{root}/Data Fields"
+            for candidate in (
+                "toa_radiance",
+                "surface_reflectance",
+                "ortho_radiance",
+                "ortho_surface_reflectance",
+            ):
+                path = f"{df_root}/{candidate}"
+                if path in h5_file:
+                    data_path = path
+                    cube_name = candidate
+                    hdfeos_root = root
+                    break
+            if data_path is not None:
                 break
 
     if data_path is None:
@@ -174,21 +702,37 @@ def _discover_tanager_layout(h5_file, product=None):
             )
         data_path = best["path"]
         cube_name = best["name"]
+        for root in hdfeos_roots:
+            if data_path.startswith(f"{root}/"):
+                hdfeos_root = root
+                break
 
     if product is None:
         product = _cube_name_to_product(cube_name) or "basic_radiance"
+        if hdfeos_root and "/GRIDS/" in hdfeos_root:
+            if product == "basic_radiance":
+                product = "ortho_radiance"
+            elif product == "basic_sr":
+                product = "ortho_sr"
 
     data_var_name = _PRODUCT_VAR_NAME[product]
 
     cube = h5_file[data_path]
-    if data_path.startswith(f"{hdfeos_root}/"):
-        # HDFEOS SWATHS products store cubes in (band, y, x) order.
+    if hdfeos_root is not None and data_path.startswith(f"{hdfeos_root}/"):
+        # HDFEOS SWATHS/GRIDS products store cubes in (band, y, x) order.
         band_axis = 0
     else:
         band_axis = int(np.argmin(cube.shape))
 
-    lat_path = f"{gf_root}/Latitude" if f"{gf_root}/Latitude" in h5_file else None
-    lon_path = f"{gf_root}/Longitude" if f"{gf_root}/Longitude" in h5_file else None
+    gf_root = f"{hdfeos_root}/Geolocation Fields" if hdfeos_root else None
+    lat_path = (
+        f"{gf_root}/Latitude" if gf_root and f"{gf_root}/Latitude" in h5_file else None
+    )
+    lon_path = (
+        f"{gf_root}/Longitude"
+        if gf_root and f"{gf_root}/Longitude" in h5_file
+        else None
+    )
     if lat_path is None or lon_path is None:
         found_lat = []
         found_lon = []
@@ -208,25 +752,26 @@ def _discover_tanager_layout(h5_file, product=None):
 
     wl_path = None
     fwhm_path = None
+    df_root = f"{hdfeos_root}/Data Fields" if hdfeos_root else None
     for candidate in (
-        f"{df_root}/Wavelength",
-        f"{df_root}/Wavelengths",
-        f"{df_root}/wavelength",
-        f"{df_root}/wavelengths",
-        f"{hdfeos_root}/Wavelength",
+        f"{df_root}/Wavelength" if df_root else None,
+        f"{df_root}/Wavelengths" if df_root else None,
+        f"{df_root}/wavelength" if df_root else None,
+        f"{df_root}/wavelengths" if df_root else None,
+        f"{hdfeos_root}/Wavelength" if hdfeos_root else None,
         "Wavelengths",
         "Wavelength",
     ):
-        if candidate in h5_file:
+        if candidate and candidate in h5_file:
             wl_path = candidate
             break
     for candidate in (
-        f"{df_root}/FWHM",
-        f"{df_root}/fwhm",
-        f"{hdfeos_root}/FWHM",
+        f"{df_root}/FWHM" if df_root else None,
+        f"{df_root}/fwhm" if df_root else None,
+        f"{hdfeos_root}/FWHM" if hdfeos_root else None,
         "FWHM",
     ):
-        if candidate in h5_file:
+        if candidate and candidate in h5_file:
             fwhm_path = candidate
             break
 
@@ -258,6 +803,13 @@ def _discover_tanager_layout(h5_file, product=None):
         "fill_value": fill_value,
         "band_axis": band_axis,
         "stac_asset_key": _PRODUCT_STAC_ASSET[product],
+        "hdfeos_root": hdfeos_root,
+        "grid_root": hdfeos_root if hdfeos_root and "/GRIDS/" in hdfeos_root else None,
+        "grid_info": (
+            _parse_hdfeos_grid_metadata(h5_file)
+            if hdfeos_root and "/GRIDS/" in hdfeos_root
+            else {}
+        ),
     }
 
 
@@ -299,14 +851,23 @@ def _read_wavelengths_from_hdf5(h5_file, layout, n_bands):
     if fwhm_path and fwhm_path in h5_file:
         vals = np.asarray(h5_file[fwhm_path][()], dtype=float).ravel()
         if vals.size == n_bands:
-            fwhm_nm = _ensure_nm(vals)
+            fwhm_nm = _ensure_fwhm_nm(
+                vals,
+                h5_file[fwhm_path].attrs.get("units")
+                or h5_file[fwhm_path].attrs.get("Units"),
+            )
     if fwhm_nm is None:
         cube = h5_file[layout["data_path"]]
         for attr_name in ("fwhm", "full_width_half_max"):
             if attr_name in cube.attrs:
                 vals = np.asarray(cube.attrs[attr_name], dtype=float).ravel()
                 if vals.size == n_bands:
-                    fwhm_nm = _ensure_nm(vals)
+                    fwhm_nm = _ensure_fwhm_nm(
+                        vals,
+                        cube.attrs.get("fwhm_units")
+                        or cube.attrs.get("fwhm_unit")
+                        or cube.attrs.get("units"),
+                    )
                     break
 
     return wl_nm, fwhm_nm
@@ -326,19 +887,8 @@ def _read_wavelengths_from_stac(stac_url, asset_key):
     Raises:
         KeyError: If the asset key or ``eo:bands`` block is absent.
     """
-    stac_item = requests.get(stac_url, timeout=10).json()
-    assets = stac_item.get("assets", {})
-    if asset_key not in assets:
-        available = sorted(assets.keys())
-        raise KeyError(
-            f"STAC item has no asset '{asset_key}'. Available assets: {available}"
-        )
-    bands_meta = assets[asset_key]["eo:bands"]
-    wl = np.array([b["center_wavelength"] for b in bands_meta], dtype=float)
-    fwhm = np.array(
-        [b.get("full_width_half_max", np.nan) for b in bands_meta], dtype=float
-    )
-    return _ensure_nm(wl), _ensure_nm(fwhm)
+    stac_item = _fetch_json(stac_url, timeout=10)
+    return _read_wavelengths_from_stac_item(stac_item, asset_key)
 
 
 def read_tanager(
@@ -418,12 +968,15 @@ def read_tanager(
 
         lat_path = layout["lat_path"]
         lon_path = layout["lon_path"]
-        if lat_path is None or lon_path is None:
+        if lat_path is not None and lon_path is not None:
+            lat = f[lat_path][()]
+            lon = f[lon_path][()]
+        else:
+            lat, lon = _grid_latlon(f, layout)
+        if lat is None or lon is None:
             raise ValueError(
                 "Could not locate Latitude/Longitude datasets in the Tanager HDF5 file."
             )
-        lat = f[lat_path][()]
-        lon = f[lon_path][()]
 
         wl_nm_full, fwhm_nm_full = _read_wavelengths_from_hdf5(f, layout, n_bands_total)
 

--- a/hypercoast/tanager.py
+++ b/hypercoast/tanager.py
@@ -365,10 +365,22 @@ def search_tanager(
     if selected_collections is not None:
         selected_collections = {str(value).lower() for value in selected_collections}
 
-    catalog = _fetch_json(catalog_url, timeout=timeout)
+    has_limit = count is not None and count > -1
     results = []
 
+    if has_limit and count == 0:
+        if return_gdf:
+            gdf = _stac_items_to_gdf(results, crs=crs)
+            if output is not None:
+                gdf.to_file(output)
+            return results, gdf
+        return results
+
+    catalog = _fetch_json(catalog_url, timeout=timeout)
+
     for link in _stac_links(catalog, "child"):
+        if has_limit and len(results) >= count:
+            break
         collection_url = _normalize_stac_url(link["href"])
         collection = _fetch_json(collection_url, timeout=timeout)
         collection_id = str(collection.get("id", "")).lower()
@@ -380,6 +392,8 @@ def search_tanager(
             continue
 
         for item_link in _stac_links(collection, "item"):
+            if has_limit and len(results) >= count:
+                break
             item_url = _normalize_stac_url(item_link["href"])
             item = _fetch_json(item_url, timeout=timeout)
             item["_stac_url"] = item_url
@@ -394,10 +408,6 @@ def search_tanager(
                 **kwargs,
             ):
                 results.append(item)
-                if count is not None and count > -1 and len(results) >= count:
-                    break
-        if count is not None and count > -1 and len(results) >= count:
-            break
 
     if return_gdf:
         gdf = _stac_items_to_gdf(results, crs=crs)
@@ -487,6 +497,7 @@ def read_tanager_stac(
     out_dir: Optional[str] = None,
     bands=None,
     wavelengths=None,
+    fwhm=None,
     product: Optional[str] = None,
     quiet: bool = True,
     overwrite: bool = False,
@@ -501,6 +512,7 @@ def read_tanager_stac(
         out_dir (str, optional): Directory for the downloaded HDF5 file.
         bands (array-like, optional): Spectral band indices to keep.
         wavelengths (array-like, optional): Explicit wavelength values in nm.
+        fwhm (array-like, optional): Explicit FWHM values in nm.
         product (str, optional): Force a Tanager product variant.
         quiet (bool, optional): Suppress download output. Defaults to True.
         overwrite (bool, optional): Overwrite existing files. Defaults to False.
@@ -518,13 +530,18 @@ def read_tanager_stac(
         quiet=quiet,
         overwrite=overwrite,
     )
-    if wavelengths is None:
-        wavelengths, _ = _read_wavelengths_from_stac_item(item, asset)
+    if wavelengths is None or fwhm is None:
+        stac_wl, stac_fwhm = _read_wavelengths_from_stac_item(item, asset)
+        if wavelengths is None:
+            wavelengths = stac_wl
+        if fwhm is None:
+            fwhm = stac_fwhm
     ds = read_tanager(
         paths[0],
         bands=bands,
         stac_url=stac_url,
         wavelengths=wavelengths,
+        fwhm=fwhm,
         product=product,
         **kwargs,
     )
@@ -896,6 +913,7 @@ def read_tanager(
     bands=None,
     stac_url=None,
     wavelengths=None,
+    fwhm=None,
     product=None,
     **kwargs,
 ):
@@ -923,6 +941,8 @@ def read_tanager(
         wavelengths (array-like, optional): Wavelengths in nanometers to use
             directly. Must have either the full cube band count or, when
             ``bands`` is also supplied, the number of selected bands.
+        fwhm (array-like, optional): Full width at half maximum in nanometers
+            to use directly. Same length rules as ``wavelengths``.
         product (str, optional): Force a specific product variant. One of
             ``basic_radiance``, ``ortho_radiance``, ``basic_sr``, ``ortho_sr``.
         **kwargs: Extra keyword arguments forwarded to ``xr.Dataset``.
@@ -1017,6 +1037,17 @@ def read_tanager(
                 f"`wavelengths` has length {wl_nm.size} but {n_bands_selected} "
                 f"bands are being read."
             )
+
+    if fwhm is not None:
+        fwhm_arr = np.asarray(fwhm, dtype=float).ravel()
+        if fwhm_arr.size == n_bands_total and bands is not None:
+            fwhm_arr = fwhm_arr[bands]
+        if fwhm_arr.size != n_bands_selected:
+            raise ValueError(
+                f"`fwhm` has length {fwhm_arr.size} but {n_bands_selected} "
+                f"bands are being read."
+            )
+        fwhm_nm = fwhm_arr
 
     if wl_nm is None and stac_url is not None:
         wl_stac, fwhm_stac = _read_wavelengths_from_stac(

--- a/hypercoast/tanager.py
+++ b/hypercoast/tanager.py
@@ -459,7 +459,7 @@ def search_tanager(
             if has_limit and len(results) >= count:
                 break
             item_url = _normalize_stac_url(item_link["href"])
-            item = _fetch_json(item_url, timeout=timeout)
+            item = dict(_fetch_json(item_url, timeout=timeout))
             item["_stac_url"] = item_url
             item["_collection_url"] = collection_url
             item["_collection_title"] = collection.get("title", "")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
           - examples/field_data.ipynb
           - examples/hypoxia.ipynb
           - examples/tanager.ipynb
+          - examples/tanager_stac.ipynb
           - examples/tanager_3d.ipynb
           - examples/prisma.ipynb
           - examples/enmap.ipynb

--- a/tests/test_tanager.py
+++ b/tests/test_tanager.py
@@ -14,6 +14,7 @@ from unittest import mock
 
 import h5py
 import numpy as np
+import pytest
 
 import hypercoast
 
@@ -151,6 +152,228 @@ class TestReadTanager(unittest.TestCase):
 
         mocked_get.assert_not_called()
         np.testing.assert_allclose(ds.coords["wavelength"].values, supplied)
+
+    def test_fwhm_attribute_in_nm_is_not_scaled(self):
+        path = os.path.join(self.tmpdir, "fwhm_attr.h5")
+        _write_hdfeos_cube(path, "toa_radiance", n_bands=100, include_wavelength=True)
+        with h5py.File(path, "a") as f:
+            cube = f["HDFEOS/SWATHS/HYP/Data Fields/toa_radiance"]
+            del f["HDFEOS/SWATHS/HYP/Data Fields/FWHM"]
+            cube.attrs["fwhm"] = np.full(100, 6.5, dtype=np.float32)
+            cube.attrs["fwhm_units"] = "nm"
+
+        ds = hypercoast.read_tanager(path)
+
+        np.testing.assert_allclose(ds.coords["fwhm"].values, np.full(100, 6.5))
+
+    def test_ortho_grid_product_builds_lat_lon(self):
+        pytest.importorskip("pyproj")
+
+        path = os.path.join(self.tmpdir, "ortho_grid.h5")
+        n_bands = 100
+        height = 4
+        width = 3
+        with h5py.File(path, "w") as f:
+            df = f.create_group("HDFEOS/GRIDS/HYP/Data Fields")
+            cube = df.create_dataset(
+                "toa_radiance",
+                data=np.ones((n_bands, height, width), dtype=np.float32),
+            )
+            cube.attrs["wavelengths"] = np.linspace(400, 900, n_bands)
+            cube.attrs["fwhm"] = np.full(n_bands, 6.0, dtype=np.float32)
+            cube.attrs["fwhm_units"] = "nm"
+            grid = f["HDFEOS/GRIDS/HYP"]
+            grid.attrs["epsg_code"] = 32610
+            info = f.create_group("HDFEOS INFORMATION")
+            info.create_dataset(
+                "StructMetadata.0",
+                data=(
+                    b"GROUP=GridStructure\n"
+                    b"GROUP=GRID_1\n"
+                    b"XDim=3\n"
+                    b"YDim=4\n"
+                    b"UpperLeftPointMtrs=(548580.00,4207350.00)\n"
+                    b"LowerRightMtrs=(574140.00,4181340.00)\n"
+                    b"Projection=HE5_GCTP_UTM\n"
+                    b"ZoneCode=10\n"
+                    b"END_GROUP=GRID_1\n"
+                    b"END_GROUP=GridStructure\n"
+                ),
+            )
+
+        ds = hypercoast.read_tanager(path, bands=[0, 1, 2])
+
+        self.assertEqual(ds.attrs["product"], "ortho_radiance")
+        self.assertEqual(ds.latitude.shape, (height, width))
+        self.assertEqual(ds.longitude.shape, (height, width))
+        self.assertTrue(np.isfinite(ds.latitude.values).all())
+        self.assertTrue(np.isfinite(ds.longitude.values).all())
+        np.testing.assert_allclose(ds.coords["fwhm"].values, np.full(3, 6.0))
+
+
+class _MockResponse:
+    """Minimal requests response for mocked STAC calls."""
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+class TestTanagerStac(unittest.TestCase):
+    """Exercise Tanager STAC search and download helpers without network I/O."""
+
+    def test_stac_wavelengths_ignore_non_spectral_bands(self):
+        item = {
+            "assets": {
+                "basic_radiance_hdf5": {
+                    "eo:bands": [
+                        {"name": "beta_cloud_mask"},
+                        {
+                            "name": "toa_radiance_B000",
+                            "center_wavelength": 0.4,
+                            "full_width_half_max": 0.006,
+                        },
+                        {
+                            "name": "toa_radiance_B001",
+                            "center_wavelength": 0.405,
+                            "full_width_half_max": 0.0061,
+                        },
+                        {"name": "Latitude"},
+                    ]
+                }
+            }
+        }
+
+        with mock.patch(
+            "hypercoast.tanager.requests.get", return_value=_MockResponse(item)
+        ):
+            wl, fwhm = hypercoast.tanager._read_wavelengths_from_stac(
+                "https://example.com/item.json", "basic_radiance_hdf5"
+            )
+
+        np.testing.assert_allclose(wl, [400.0, 405.0])
+        np.testing.assert_allclose(fwhm, [6.0, 6.1])
+
+    def test_search_tanager_filters_catalog_items(self):
+        catalog = {
+            "links": [
+                {
+                    "rel": "child",
+                    "href": "https://www.planet.com/data/stac/tanager-core-imagery/coastal-water-bodies/collection.json",
+                }
+            ]
+        }
+        collection = {
+            "id": "coastal-water-bodies",
+            "title": "Coastal and Water Bodies",
+            "links": [
+                {"rel": "item", "href": "https://example.com/item-1.json"},
+                {"rel": "item", "href": "https://example.com/item-2.json"},
+            ],
+        }
+        item_1 = {
+            "id": "item-1",
+            "bbox": [0, 0, 1, 1],
+            "properties": {
+                "datetime": "2025-01-15T00:00:00Z",
+                "title": "Cloudy Bay scene",
+                "cloud_percent": 80,
+            },
+        }
+        item_2 = {
+            "id": "item-2",
+            "bbox": [0, 0, 1, 1],
+            "properties": {
+                "datetime": "2025-01-20T00:00:00Z",
+                "title": "Clear Bay scene",
+                "cloud_percent": 5,
+            },
+        }
+
+        responses = [
+            _MockResponse(obj) for obj in (catalog, collection, item_1, item_2)
+        ]
+        with mock.patch("hypercoast.tanager.requests.get", side_effect=responses):
+            results = hypercoast.search_tanager(
+                bbox=[0.5, 0.5, 2, 2],
+                temporal=("2025-01-01", "2025-01-31"),
+                collections="coastal-water-bodies",
+                query="Bay",
+                cloud_percent=10,
+                count=1,
+            )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], "item-2")
+        self.assertEqual(results[0]["_stac_url"], "https://example.com/item-2.json")
+        self.assertEqual(results[0]["_collection_title"], "Coastal and Water Bodies")
+
+    def test_download_tanager_downloads_selected_asset(self):
+        item = {
+            "id": "item-1",
+            "assets": {
+                "ortho_radiance_hdf5": {
+                    "href": "https://example.com/20250101_ortho_radiance_hdf5.h5"
+                }
+            },
+        }
+
+        with mock.patch(
+            "hypercoast.tanager.download_file", return_value="/tmp/out.h5"
+        ) as mocked_download:
+            result = hypercoast.download_tanager(
+                item, out_dir="/tmp", quiet=True, overwrite=True
+            )
+
+        self.assertEqual(result, ["/tmp/out.h5"])
+        mocked_download.assert_called_once_with(
+            "https://example.com/20250101_ortho_radiance_hdf5.h5",
+            output="/tmp/20250101_ortho_radiance_hdf5.h5",
+            quiet=True,
+            overwrite=True,
+            unzip=False,
+        )
+
+    def test_read_tanager_stac_does_not_force_asset_product(self):
+        item = {
+            "id": "item-1",
+            "_stac_url": "https://example.com/item-1.json",
+            "assets": {
+                "ortho_radiance_hdf5": {
+                    "href": "https://example.com/ortho.h5",
+                    "eo:bands": [
+                        {
+                            "center_wavelength": 0.4,
+                            "full_width_half_max": 0.006,
+                            "name": "toa_radiance_B000",
+                        }
+                    ],
+                }
+            },
+        }
+        fake_ds = mock.MagicMock()
+        fake_ds.attrs = {}
+
+        with (
+            mock.patch(
+                "hypercoast.tanager.download_tanager", return_value=["/tmp/ortho.h5"]
+            ),
+            mock.patch(
+                "hypercoast.tanager.read_tanager", return_value=fake_ds
+            ) as mocked,
+        ):
+            result = hypercoast.read_tanager_stac(item)
+
+        self.assertIs(result, fake_ds)
+        _, kwargs = mocked.call_args
+        self.assertIsNone(kwargs["product"])
+        np.testing.assert_allclose(kwargs["wavelengths"], [400.0])
+        self.assertEqual(result.attrs["product"], "ortho_radiance")
 
 
 if __name__ == "__main__":

--- a/tests/test_tanager.py
+++ b/tests/test_tanager.py
@@ -339,6 +339,59 @@ class TestTanagerStac(unittest.TestCase):
             unzip=False,
         )
 
+    def test_tanager_footprints_deduplicates_collections(self):
+        pytest.importorskip("geopandas")
+        catalog = {
+            "links": [
+                {"rel": "child", "href": "https://example.com/a/collection.json"},
+                {"rel": "child", "href": "https://example.com/b/collection.json"},
+            ]
+        }
+        collection_a = {
+            "id": "a",
+            "title": "Collection A",
+            "links": [{"rel": "item", "href": "https://example.com/a/scene.json"}],
+        }
+        collection_b = {
+            "id": "b",
+            "title": "Collection B",
+            "links": [{"rel": "item", "href": "https://example.com/b/scene.json"}],
+        }
+        item = {
+            "id": "scene",
+            "type": "Feature",
+            "bbox": [0, 0, 1, 1],
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]],
+                ],
+            },
+            "properties": {
+                "datetime": "2025-01-15T00:00:00Z",
+                "title": "Shared scene",
+            },
+            "assets": {
+                "ortho_visual": {"href": "https://example.com/visual.tif"},
+                "ortho_radiance_hdf5": {"href": "https://example.com/rad.h5"},
+            },
+        }
+
+        responses = [
+            _MockResponse(obj)
+            for obj in (catalog, collection_a, item, collection_b, item)
+        ]
+        with mock.patch("hypercoast.tanager.requests.get", side_effect=responses):
+            gdf = hypercoast.tanager_footprints()
+
+        self.assertEqual(len(gdf), 1)
+        self.assertEqual(gdf.iloc[0]["id"], "scene")
+        self.assertEqual(gdf.iloc[0]["collections"], "a, b")
+        self.assertEqual(gdf.iloc[0]["collection_titles"], "Collection A, Collection B")
+        self.assertEqual(
+            gdf.iloc[0]["ortho_visual_url"], "https://example.com/visual.tif"
+        )
+
     def test_read_tanager_stac_does_not_force_asset_product(self):
         item = {
             "id": "item-1",

--- a/tests/test_tanager.py
+++ b/tests/test_tanager.py
@@ -373,7 +373,15 @@ class TestTanagerStac(unittest.TestCase):
         _, kwargs = mocked.call_args
         self.assertIsNone(kwargs["product"])
         np.testing.assert_allclose(kwargs["wavelengths"], [400.0])
+        np.testing.assert_allclose(kwargs["fwhm"], [6.0])
         self.assertEqual(result.attrs["product"], "ortho_radiance")
+
+    def test_search_tanager_with_count_zero_returns_empty(self):
+        with mock.patch("hypercoast.tanager.requests.get") as mocked_get:
+            results = hypercoast.search_tanager(count=0)
+
+        self.assertEqual(results, [])
+        mocked_get.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `search_tanager`, `download_tanager`, `get_tanager_asset_url`, and `read_tanager_stac` helpers for the Planet Tanager STAC catalog.
- Extend `Map.add_tanager` to accept STAC item URLs/dicts and render the `ortho_visual` COG, plus add HDFEOS GRID (orthorectified) support to `read_tanager`.
- Add an example notebook and matching tests for the new STAC workflow.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/test_tanager.py`
- [ ] Run `docs/examples/tanager_stac.ipynb` end to end