### PR TITLE
feat: add Tanager STAC search dialog to QGIS plugin

### DIFF
--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -12,6 +12,8 @@ Check out this [short video demo](https://youtu.be/EEUAC5BxqtM) and [full video 
 
 -   **Load Multiple Hyperspectral Formats**: Support for NASA EMIT, PACE, DESIS, NEON AOP, AVIRIS, PRISMA, EnMAP, Planet Tanager, Wyvern, and generic GeoTIFF/NetCDF hyperspectral data.
 
+-   **Tanager Search and Visualization**: Search Planet Tanager STAC scenes from QGIS, add footprint layers, open orthorectified visual imagery, and download orthorectified radiance HDF5 files for hyperspectral analysis.
+
 -   **Band Combination Visualization**: Easily change RGB band combinations using wavelength values. Includes presets for:
 
     -   True Color (RGB)
@@ -80,6 +82,14 @@ When QGIS is launched from this Conda environment, the plugin automatically dete
 3. Select the data type (or use auto-detect)
 4. Configure RGB wavelengths for visualization
 5. Click **Load Data**
+
+### Searching Tanager Data
+
+1. Click the **Search Tanager Data** button
+2. Use the current map extent or enter a bounding box
+3. Set optional date, collection, query, cloud, and count filters
+4. Click **Search**
+5. Add footprints, open the visual asset, or download the radiance HDF5 for analysis
 
 ### Changing Band Combinations
 

--- a/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
@@ -164,6 +164,10 @@ class LoadDataDialog(QDockWidget):
         self._preview_worker = None
         self._load_worker = None
         self._pending_load_context = None
+        # Track the last default the dialog applied to the value-range spinboxes
+        # so background callbacks can detect user edits and avoid overwriting
+        # them. Initialized to match the spinbox values set in setup_ui().
+        self._last_applied_value_range = (0.0, DEFAULT_VALUE_RANGE[1])
 
         self.setWindowTitle("Load Hyperspectral Data")
         self.setObjectName("HyperCoastLoadDataDock")
@@ -389,17 +393,33 @@ class LoadDataDialog(QDockWidget):
             return HyperspectralDataset(filepath, "auto").data_type
         return data_type
 
-    def _apply_data_type_value_range(self, data_type):
+    def _apply_data_type_value_range(self, data_type, preserve_user_edits=False):
         """Apply visualization range defaults for a data type.
 
         Args:
             data_type: Resolved HyperCoast data type.
+            preserve_user_edits: When True, skip updating the spinboxes if the
+                user has changed them since the last default was applied. Use
+                this from background callbacks (preview/load completion) so
+                custom min/max values entered before the callback fired are
+                not overwritten.
         """
         vmin, vmax = (
             TANAGER_VALUE_RANGE if data_type == "Tanager" else DEFAULT_VALUE_RANGE
         )
+        if preserve_user_edits:
+            last_vmin, last_vmax = self._last_applied_value_range
+            current_vmin = self.vmin_spin.value()
+            current_vmax = self.vmax_spin.value()
+            tolerance = 10 ** -self.vmin_spin.decimals()
+            if (
+                abs(current_vmin - last_vmin) > tolerance
+                or abs(current_vmax - last_vmax) > tolerance
+            ):
+                return
         self.vmin_spin.setValue(vmin)
         self.vmax_spin.setValue(vmax)
+        self._last_applied_value_range = (vmin, vmax)
 
     def preview_dataset(self):
         """Preview the selected dataset."""
@@ -436,7 +456,9 @@ class LoadDataDialog(QDockWidget):
         try:
             if dataset is not None:
                 self.dataset = dataset
-                self._apply_data_type_value_range(dataset.data_type)
+                self._apply_data_type_value_range(
+                    dataset.data_type, preserve_user_edits=True
+                )
                 self.progress_bar.setValue(80)
                 self.info_text.setText(self._format_dataset_info(dataset))
                 self._populate_variable_combo(dataset)
@@ -657,7 +679,9 @@ class LoadDataDialog(QDockWidget):
                 raise ValueError(f"Failed to load dataset. Details: {error_detail}")
 
             self.dataset = dataset
-            self._apply_data_type_value_range(self.dataset.data_type)
+            self._apply_data_type_value_range(
+                self.dataset.data_type, preserve_user_edits=True
+            )
             self.progress_bar.setValue(80)
             selected_data_var = self.dataset.get_data_variable()
             selected_variable = variable_name or getattr(

--- a/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
@@ -47,6 +47,9 @@ from ..hyperspectral_provider import (
 )
 from ..cache_manager import create_generated_raster_path
 
+DEFAULT_VALUE_RANGE = (0.0, 0.5)
+TANAGER_VALUE_RANGE = (0.0, 100.0)
+
 
 class DatasetPreviewWorker(QThread):
     """Worker thread for loading dataset metadata without blocking QGIS."""
@@ -253,7 +256,7 @@ class LoadDataDialog(QDockWidget):
 
         self.vmax_spin = QDoubleSpinBox()
         self.vmax_spin.setRange(-1000, 1000)
-        self.vmax_spin.setValue(0.5)
+        self.vmax_spin.setValue(DEFAULT_VALUE_RANGE[1])
         self.vmax_spin.setDecimals(4)
         range_layout.addWidget(QLabel("Max:"))
         range_layout.addWidget(self.vmax_spin)
@@ -358,12 +361,45 @@ class LoadDataDialog(QDockWidget):
             self.dataset = None
             self.info_text.clear()
             self._populate_variable_combo(None)
+            self._apply_data_type_value_range(
+                self._resolved_value_range_data_type(filepath)
+            )
 
     def _clear_dataset_preview(self, *args):
         """Clear loaded preview state after the requested data type changes."""
         self.dataset = None
         self.info_text.clear()
         self._populate_variable_combo(None)
+        self._apply_data_type_value_range(self._resolved_value_range_data_type())
+
+    def _resolved_value_range_data_type(self, filepath=None):
+        """Return the data type to use for visualization range defaults.
+
+        Args:
+            filepath: Optional data file path to inspect for auto-detection.
+
+        Returns:
+            Selected or auto-detected data type.
+        """
+        data_type = self.data_type_combo.currentData()
+        if data_type != "auto":
+            return data_type
+        filepath = filepath or self.file_path_edit.text()
+        if filepath and os.path.exists(filepath):
+            return HyperspectralDataset(filepath, "auto").data_type
+        return data_type
+
+    def _apply_data_type_value_range(self, data_type):
+        """Apply visualization range defaults for a data type.
+
+        Args:
+            data_type: Resolved HyperCoast data type.
+        """
+        vmin, vmax = (
+            TANAGER_VALUE_RANGE if data_type == "Tanager" else DEFAULT_VALUE_RANGE
+        )
+        self.vmin_spin.setValue(vmin)
+        self.vmax_spin.setValue(vmax)
 
     def preview_dataset(self):
         """Preview the selected dataset."""
@@ -400,6 +436,7 @@ class LoadDataDialog(QDockWidget):
         try:
             if dataset is not None:
                 self.dataset = dataset
+                self._apply_data_type_value_range(dataset.data_type)
                 self.progress_bar.setValue(80)
                 self.info_text.setText(self._format_dataset_info(dataset))
                 self._populate_variable_combo(dataset)
@@ -620,6 +657,7 @@ class LoadDataDialog(QDockWidget):
                 raise ValueError(f"Failed to load dataset. Details: {error_detail}")
 
             self.dataset = dataset
+            self._apply_data_type_value_range(self.dataset.data_type)
             self.progress_bar.setValue(80)
             selected_data_var = self.dataset.get_data_variable()
             selected_variable = variable_name or getattr(

--- a/qgis_plugin/hypercoast_qgis/dialogs/spectral_inspector_tool.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/spectral_inspector_tool.py
@@ -165,7 +165,12 @@ class SpectralInspectorTool(QgsMapToolEmitPoint):
                     # Update spectral plot dialog if open
                     if self.plugin.spectral_plot_dialog:
                         self.plugin.spectral_plot_dialog.add_spectrum(
-                            lat, lon, wavelengths, values, layer.name()
+                            lat,
+                            lon,
+                            wavelengths,
+                            values,
+                            layer.name(),
+                            data_info.get("data_type"),
                         )
 
                     QgsMessageLog.logMessage(

--- a/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
@@ -370,7 +370,7 @@ class SpectralPlotDialog(QDockWidget):
         Args:
             data_type: HyperCoast data type string.
         """
-        if data_type != "Tanager":
+        if not HAS_MATPLOTLIB or data_type != "Tanager":
             return
 
         index = self.ylabel_combo.findText("Radiance")

--- a/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
@@ -49,6 +49,9 @@ try:
 except ImportError:
     HAS_MATPLOTLIB = False
 
+DEFAULT_Y_RANGE = (0.0, 0.5)
+TANAGER_Y_RANGE = (0.0, 100.0)
+
 
 class SpectralPlotDialog(QDockWidget):
     """Dockable panel for displaying spectral plots."""
@@ -134,6 +137,7 @@ class SpectralPlotDialog(QDockWidget):
             QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
         )
         self.layer_combo.setSizePolicy(policy.Expanding, policy.Fixed)
+        self.layer_combo.currentIndexChanged.connect(self._on_selected_layer_changed)
         sampling_layout.addWidget(QLabel("Layer:"))
         sampling_layout.addWidget(self.layer_combo, 1)
 
@@ -188,14 +192,14 @@ class SpectralPlotDialog(QDockWidget):
 
         ylim_layout = QHBoxLayout()
         self.ymin_spin = QDoubleSpinBox()
-        self.ymin_spin.setRange(-1, 10)
-        self.ymin_spin.setValue(0)
+        self.ymin_spin.setRange(-1000, 10000)
+        self.ymin_spin.setValue(DEFAULT_Y_RANGE[0])
         self.ymin_spin.setDecimals(4)
         ylim_layout.addWidget(self.ymin_spin)
         ylim_layout.addWidget(QLabel("-"))
         self.ymax_spin = QDoubleSpinBox()
-        self.ymax_spin.setRange(-1, 10)
-        self.ymax_spin.setValue(0.5)
+        self.ymax_spin.setRange(-1000, 10000)
+        self.ymax_spin.setValue(DEFAULT_Y_RANGE[1])
         self.ymax_spin.setDecimals(4)
         ylim_layout.addWidget(self.ymax_spin)
         axis_form.addRow("Y Range:", ylim_layout)
@@ -324,6 +328,7 @@ class SpectralPlotDialog(QDockWidget):
                 self.layer_combo.setCurrentIndex(index)
 
         self.layer_combo.blockSignals(False)
+        self._apply_data_type_plot_defaults(self._selected_layer_data_type())
 
     def selected_layer_id(self):
         """Return the selected sampling layer ID.
@@ -334,6 +339,45 @@ class SpectralPlotDialog(QDockWidget):
         if not hasattr(self, "layer_combo"):
             return None
         return self.layer_combo.currentData()
+
+    def _on_selected_layer_changed(self, *args):
+        """Apply plot defaults when the selected sampling layer changes."""
+        self._apply_data_type_plot_defaults(self._selected_layer_data_type())
+
+    def _selected_layer_data_type(self):
+        """Return the data type represented by the selected sampling layer.
+
+        Returns:
+            HyperCoast data type string, or ``None`` for mixed/unknown layers.
+        """
+        layer_id = self.selected_layer_id()
+        if layer_id:
+            data_info = self.plugin.get_hyperspectral_data(layer_id) or {}
+            return data_info.get("data_type")
+
+        data_types = {
+            (self.plugin.get_hyperspectral_data(layer_id) or {}).get("data_type")
+            for layer_id in self.plugin.get_all_hyperspectral_layers()
+        }
+        data_types.discard(None)
+        if len(data_types) == 1:
+            return next(iter(data_types))
+        return None
+
+    def _apply_data_type_plot_defaults(self, data_type):
+        """Apply axis label and range defaults for a data type.
+
+        Args:
+            data_type: HyperCoast data type string.
+        """
+        if data_type != "Tanager":
+            return
+
+        index = self.ylabel_combo.findText("Radiance")
+        if index >= 0:
+            self.ylabel_combo.setCurrentIndex(index)
+        self.ymin_spin.setValue(TANAGER_Y_RANGE[0])
+        self.ymax_spin.setValue(TANAGER_Y_RANGE[1])
 
     def _project_layer(self, layer_id):
         """Return a QGIS project layer by ID.
@@ -351,7 +395,7 @@ class SpectralPlotDialog(QDockWidget):
         except Exception:
             return None
 
-    def add_spectrum(self, lat, lon, wavelengths, values, layer_name):
+    def add_spectrum(self, lat, lon, wavelengths, values, layer_name, data_type=None):
         """Add a new spectrum to the plot.
 
         :param lat: Latitude
@@ -359,7 +403,9 @@ class SpectralPlotDialog(QDockWidget):
         :param wavelengths: Array of wavelengths
         :param values: Array of spectral values
         :param layer_name: Name of the source layer
+        :param data_type: Optional HyperCoast data type.
         """
+        self._apply_data_type_plot_defaults(data_type)
         spectrum = {
             "lat": lat,
             "lon": lon,
@@ -367,6 +413,7 @@ class SpectralPlotDialog(QDockWidget):
             "values": np.array(values),
             "layer": layer_name,
             "label": f"({lat:.4f}, {lon:.4f})",
+            "data_type": data_type,
         }
 
         self.spectra.append(spectrum)

--- a/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
@@ -9,6 +9,7 @@ SPDX-License-Identifier: MIT
 import os
 import ast
 import json
+from urllib.parse import unquote, urlparse
 import urllib.request
 
 from qgis.PyQt.QtCore import Qt, QThread, QUrl, pyqtSignal
@@ -33,6 +34,7 @@ from qgis.PyQt.QtWidgets import (
     QDoubleSpinBox,
     QFileDialog,
     QFormLayout,
+    QGridLayout,
     QGroupBox,
     QHBoxLayout,
     QHeaderView,
@@ -48,7 +50,6 @@ from qgis.PyQt.QtWidgets import (
     QWidget,
 )
 from qgis.core import (
-    QgsContrastEnhancement,
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,
     QgsFeature,
@@ -56,16 +57,13 @@ from qgis.core import (
     QgsFillSymbol,
     QgsGeometry,
     QgsMessageLog,
-    QgsMultiBandColorRenderer,
     QgsProject,
     QgsRasterLayer,
-    QgsSingleBandGrayRenderer,
     QgsVectorLayer,
     Qgis,
 )
 
-from ..cache_manager import create_generated_raster_path, generated_raster_cache_dir
-from ..hyperspectral_provider import HyperspectralDataset
+from ..cache_manager import generated_raster_cache_dir
 
 TANAGER_HDF5_ASSET = "ortho_radiance_hdf5"
 TANAGER_HDF5_ASSETS = (
@@ -94,6 +92,21 @@ def _asset_url(item, asset_key):
     assets = item.get("assets", {}) if isinstance(item, dict) else {}
     asset = assets.get(asset_key, {})
     return asset.get("href", "") or ""
+
+
+def _asset_filename(url, fallback="tanager.h5"):
+    """Return a readable filename from an asset URL.
+
+    Args:
+        url: Asset URL.
+        fallback: Filename to use when the URL has no basename.
+
+    Returns:
+        Filename string.
+    """
+    path = urlparse(url).path if url else ""
+    filename = os.path.basename(unquote(path))
+    return filename or fallback
 
 
 def _item_title(item):
@@ -189,70 +202,47 @@ class TanagerSearchWorker(QThread):
             self.finished.emit([], None, str(exc))
 
 
-class TanagerDownloadLoadWorker(QThread):
-    """Worker thread for downloading and loading a Tanager HDF5 asset."""
+class TanagerDownloadWorker(QThread):
+    """Worker thread for downloading a Tanager HDF5 asset."""
 
     progress = pyqtSignal(int)
-    finished = pyqtSignal(object, str, str, str)
+    finished = pyqtSignal(str, str)
 
-    def __init__(
-        self,
-        item,
-        asset_key,
-        out_dir,
-        output_path,
-        wavelengths,
-        parent=None,
-    ):
+    def __init__(self, item, asset_key, output_path, parent=None):
         """Initialize the worker.
 
         Args:
             item: STAC item dictionary.
             asset_key: STAC asset key to download.
-            out_dir: Download directory.
-            output_path: GeoTIFF output path.
-            wavelengths: RGB wavelengths.
+            output_path: Destination HDF5 path.
             parent: Optional parent QObject.
         """
         super().__init__(parent)
         self.item = item
         self.asset_key = asset_key
-        self.out_dir = out_dir
         self.output_path = output_path
-        self.wavelengths = wavelengths
 
     def run(self):
-        """Download the HDF5 asset and export an RGB raster."""
+        """Download the HDF5 asset."""
         try:
             from .._hypercoast_lib import get_hypercoast
 
-            self.progress.emit(15)
+            self.progress.emit(20)
             hypercoast = get_hypercoast()
-            paths = hypercoast.download_tanager(
-                self.item,
-                asset=self.asset_key,
-                out_dir=self.out_dir,
+            url = _asset_url(self.item, self.asset_key)
+            if not url:
+                raise ValueError(f"The selected asset '{self.asset_key}' has no URL.")
+            filepath = hypercoast.download_file(
+                url,
+                output=self.output_path,
                 quiet=True,
-                overwrite=False,
+                overwrite=True,
+                unzip=False,
             )
-            if not paths:
-                raise ValueError("Tanager download produced no file.")
-
-            filepath = paths[0]
-            self.progress.emit(45)
-            dataset = HyperspectralDataset(filepath, "Tanager")
-            result = dataset.load_and_export(
-                self.output_path, wavelengths=self.wavelengths
-            )
-            if result is None:
-                detail = getattr(dataset, "last_error", None) or "Unknown error"
-                self.finished.emit(None, filepath, "", detail)
-                return
-
             self.progress.emit(90)
-            self.finished.emit(dataset, filepath, self.output_path, "")
+            self.finished.emit(filepath, "")
         except Exception as exc:
-            self.finished.emit(None, "", "", str(exc))
+            self.finished.emit("", str(exc))
 
 
 class TanagerSearchDialog(QDockWidget):
@@ -278,7 +268,7 @@ class TanagerSearchDialog(QDockWidget):
 
         self.setWindowTitle("Search Tanager Data")
         self.setObjectName("HyperCoastTanagerSearchDock")
-        self.setMinimumWidth(680)
+        self.setMinimumWidth(520)
         self.setMinimumHeight(560)
 
         self.setup_ui()
@@ -394,36 +384,36 @@ class TanagerSearchDialog(QDockWidget):
         self.progress_bar.setVisible(False)
         layout.addWidget(self.progress_bar)
 
-        button_layout = QHBoxLayout()
+        button_layout = QGridLayout()
         self.search_btn = QPushButton("Search")
         self.search_btn.clicked.connect(self.search)
-        button_layout.addWidget(self.search_btn)
+        button_layout.addWidget(self.search_btn, 0, 0)
 
         self.selected_footprints_btn = QPushButton("Use Selected Footprints")
         self.selected_footprints_btn.clicked.connect(
             self.populate_from_selected_footprints
         )
-        button_layout.addWidget(self.selected_footprints_btn)
+        button_layout.addWidget(self.selected_footprints_btn, 0, 1)
 
         self.footprints_btn = QPushButton("Add Footprints")
         self.footprints_btn.clicked.connect(self.add_footprints_layer)
-        button_layout.addWidget(self.footprints_btn)
+        button_layout.addWidget(self.footprints_btn, 0, 2)
 
         self.visual_btn = QPushButton("Open Visual")
         self.visual_btn.clicked.connect(self.open_visual_layer)
-        button_layout.addWidget(self.visual_btn)
+        button_layout.addWidget(self.visual_btn, 1, 0)
 
         self.stac_btn = QPushButton("Open STAC")
         self.stac_btn.clicked.connect(self.open_stac_item)
-        button_layout.addWidget(self.stac_btn)
+        button_layout.addWidget(self.stac_btn, 1, 1)
 
         self.download_btn = QPushButton("Download HDF5")
         self.download_btn.clicked.connect(self.download_hdf5)
-        button_layout.addWidget(self.download_btn)
+        button_layout.addWidget(self.download_btn, 1, 2)
 
         close_btn = QPushButton("Close")
         close_btn.clicked.connect(self.close)
-        button_layout.addWidget(close_btn)
+        button_layout.addWidget(close_btn, 1, 3)
         layout.addLayout(button_layout)
         self._sync_button_state()
 
@@ -1108,7 +1098,7 @@ class TanagerSearchDialog(QDockWidget):
         QDesktopServices.openUrl(QUrl(browser_url))
 
     def download_hdf5(self):
-        """Download and load the selected Tanager radiance HDF5 asset."""
+        """Download the selected Tanager HDF5 asset."""
         item = self.hydrated_selected_item()
         if item is None:
             return
@@ -1131,153 +1121,69 @@ class TanagerSearchDialog(QDockWidget):
             return
 
         try:
-            out_dir = self.download_dir_edit.text().strip()
-            if not out_dir:
-                raise ValueError("Please select a download folder.")
-            os.makedirs(out_dir, exist_ok=True)
-            asset_label = self.asset_combo.currentText() or asset_key
-            layer_name = f"Tanager {asset_label} - {_item_title(item)}"
-            output_path = create_generated_raster_path(
-                layer_name, "rgb", project=QgsProject.instance()
+            asset_url = _asset_url(item, asset_key)
+            out_dir = self.download_dir_edit.text().strip() or tanager_download_dir(
+                QgsProject.instance()
             )
-            wavelengths = [650, 550, 450]
-            self._pending_load_context = {
-                "layer_name": layer_name,
-                "wavelengths": wavelengths,
-                "stac_url": item.get("_stac_url", ""),
-            }
+            os.makedirs(out_dir, exist_ok=True)
+            default_path = os.path.join(
+                out_dir,
+                _asset_filename(asset_url, fallback=f"{_item_title(item)}.h5"),
+            )
+            output_path, _ = QFileDialog.getSaveFileName(
+                self,
+                "Save Tanager HDF5",
+                default_path,
+                "HDF5 files (*.h5 *.hdf5);;All files (*)",
+            )
+            if not output_path:
+                return
+            if not os.path.splitext(output_path)[1]:
+                output_path = f"{output_path}.h5"
+            output_dir = os.path.dirname(os.path.abspath(output_path))
+            os.makedirs(output_dir, exist_ok=True)
+            self.download_dir_edit.setText(output_dir)
+
             self._set_busy(True)
             self.progress_bar.setRange(0, 100)
             self.progress_bar.setValue(20)
             self.status_label.setText("Downloading Tanager HDF5...")
-            self._load_worker = TanagerDownloadLoadWorker(
+            self._load_worker = TanagerDownloadWorker(
                 item,
                 asset_key,
-                out_dir,
                 output_path,
-                wavelengths,
                 parent=self,
             )
             self._load_worker.progress.connect(self.progress_bar.setValue)
-            self._load_worker.finished.connect(self._on_download_load_finished)
+            self._load_worker.finished.connect(self._on_download_finished)
             self._load_worker.start()
         except Exception as exc:
-            self._pending_load_context = None
             self._set_busy(False)
             QMessageBox.warning(self, "Tanager HDF5", str(exc))
 
-    def _on_download_load_finished(self, dataset, filepath, temp_path, error_detail):
-        """Handle Tanager download and load worker completion.
+    def _on_download_finished(self, filepath, error_detail):
+        """Handle Tanager download completion.
 
         Args:
-            dataset: Loaded HyperspectralDataset, or None on failure.
             filepath: Downloaded HDF5 path.
-            temp_path: Exported GeoTIFF path.
-            error_detail: Error message when loading failed.
-        """
-        if self._pending_load_context is not None and filepath:
-            self._pending_load_context["filepath"] = filepath
-        self._on_load_finished(dataset, temp_path, error_detail)
-
-    def _on_load_finished(self, dataset, temp_path, error_detail):
-        """Add the loaded Tanager HDF5 raster to QGIS.
-
-        Args:
-            dataset: Loaded HyperspectralDataset, or None on failure.
-            temp_path: Exported GeoTIFF path.
-            error_detail: Error message when loading failed.
+            error_detail: Error message when downloading failed.
         """
         try:
-            context = self._pending_load_context or {}
-            if dataset is None:
-                raise ValueError(error_detail or "Failed to load Tanager HDF5.")
-
-            layer_name = context.get("layer_name", "Tanager Radiance")
-            raster_layer = QgsRasterLayer(temp_path, layer_name)
-            if not raster_layer.isValid():
-                raise ValueError("Created Tanager raster layer is not valid.")
-
-            if (not raster_layer.crs().isValid()) and dataset.crs:
-                known_crs = QgsCoordinateReferenceSystem(str(dataset.crs))
-                if known_crs.isValid():
-                    raster_layer.setCrs(known_crs)
-
-            self._style_raster_layer(raster_layer)
-            self._set_hyperspectral_properties(raster_layer, dataset, context)
-            QgsProject.instance().addMapLayer(raster_layer)
-
-            selected_data_var = dataset.get_data_variable()
-            selected_variable = getattr(selected_data_var, "name", None)
-            self.plugin.register_hyperspectral_layer(
-                raster_layer.id(),
-                {
-                    "dataset": dataset,
-                    "filepath": context.get("filepath", ""),
-                    "data_type": dataset.data_type,
-                    "wavelengths": dataset.wavelengths,
-                    "rgb_wavelengths": context.get("wavelengths", []),
-                    "selected_variable": selected_variable,
-                    "bounds": dataset.bounds,
-                    "crs": dataset.crs,
-                },
-            )
-            spectral_plot = getattr(self.plugin, "spectral_plot_dialog", None)
-            if spectral_plot is not None:
-                spectral_plot.clear_all_spectra()
-
-            self.iface.setActiveLayer(raster_layer)
-            self._zoom_to_layer(raster_layer)
+            if error_detail:
+                raise ValueError(error_detail)
             self.progress_bar.setValue(100)
-            self.status_label.setText("Tanager HDF5 loaded")
+            self.status_label.setText(
+                f"Tanager HDF5 saved: {os.path.basename(filepath)}"
+            )
         except Exception as exc:
             QMessageBox.warning(self, "Tanager HDF5", str(exc))
             QgsMessageLog.logMessage(
-                f"Error loading Tanager HDF5: {exc}",
+                f"Error downloading Tanager HDF5: {exc}",
                 "HyperCoast",
                 Qgis.MessageLevel.Warning,
             )
         finally:
-            self._pending_load_context = None
             self._set_busy(False)
-
-    def _style_raster_layer(self, raster_layer):
-        """Apply a default renderer to a generated Tanager raster.
-
-        Args:
-            raster_layer: QGIS raster layer.
-        """
-        provider = raster_layer.dataProvider()
-        if provider is None:
-            return
-        for band_idx in range(1, raster_layer.bandCount() + 1):
-            try:
-                provider.setNoDataValue(band_idx, -9999.0)
-            except Exception:
-                pass  # nosec B110
-
-        if raster_layer.bandCount() >= 3:
-            renderer = QgsMultiBandColorRenderer(provider, 1, 2, 3)
-            renderer_bands = [1, 2, 3]
-        else:
-            renderer = QgsSingleBandGrayRenderer(provider, 1)
-            renderer_bands = [1]
-
-        for band_idx in renderer_bands:
-            ce = QgsContrastEnhancement(provider.dataType(band_idx))
-            ce.setContrastEnhancementAlgorithm(
-                QgsContrastEnhancement.StretchToMinimumMaximum
-            )
-            ce.setMinimumValue(0)
-            ce.setMaximumValue(0.5)
-            if raster_layer.bandCount() < 3:
-                renderer.setContrastEnhancement(ce)
-            elif band_idx == 1:
-                renderer.setRedContrastEnhancement(ce)
-            elif band_idx == 2:
-                renderer.setGreenContrastEnhancement(ce)
-            else:
-                renderer.setBlueContrastEnhancement(ce)
-        raster_layer.setRenderer(renderer)
 
     def _style_footprint_layer(self, layer):
         """Apply the default Tanager footprint style.
@@ -1297,28 +1203,6 @@ class TanagerSearchDialog(QDockWidget):
             layer.triggerRepaint()
         except Exception:
             pass  # nosec B110
-
-    def _set_hyperspectral_properties(self, raster_layer, dataset, context):
-        """Persist HyperCoast metadata on a Tanager raster layer.
-
-        Args:
-            raster_layer: Layer receiving custom properties.
-            dataset: Loaded Tanager dataset provider.
-            context: Pending load context.
-        """
-        raster_layer.setCustomProperty(
-            "hypercoast/source_path", context.get("filepath", "")
-        )
-        raster_layer.setCustomProperty("hypercoast/data_type", dataset.data_type)
-        raster_layer.setCustomProperty(
-            "hypercoast/rgb_wavelengths",
-            ",".join(str(value) for value in context.get("wavelengths", [])),
-        )
-        raster_layer.setCustomProperty(
-            "hypercoast/tanager_stac_url", context.get("stac_url", "")
-        )
-        if dataset.crs:
-            raster_layer.setCustomProperty("hypercoast/crs", str(dataset.crs))
 
     def _zoom_to_layer(self, layer):
         """Zoom the map canvas to a layer extent.

--- a/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
@@ -57,6 +57,7 @@ from qgis.core import (
     QgsFillSymbol,
     QgsGeometry,
     QgsMessageLog,
+    QgsPointXY,
     QgsProject,
     QgsRasterLayer,
     QgsVectorLayer,
@@ -193,11 +194,11 @@ class TanagerSearchWorker(QThread):
             self.progress.emit(20)
             hypercoast = get_hypercoast()
             params = dict(self.search_params)
-            params["return_gdf"] = True
+            params["return_gdf"] = False
             self.progress.emit(50)
-            items, gdf = hypercoast.search_tanager(**params)
+            items = hypercoast.search_tanager(**params)
             self.progress.emit(90)
-            self.finished.emit(items, gdf, "")
+            self.finished.emit(items, None, "")
         except Exception as exc:
             self.finished.emit([], None, str(exc))
 
@@ -265,6 +266,7 @@ class TanagerSearchDialog(QDockWidget):
         self._load_worker = None
         self._pending_load_context = None
         self._connected_global_footprint_layers = set()
+        self._result_footprints_layer = None
 
         self.setWindowTitle("Search Tanager Data")
         self.setObjectName("HyperCoastTanagerSearchDock")
@@ -391,12 +393,12 @@ class TanagerSearchDialog(QDockWidget):
 
         self.selected_footprints_btn = QPushButton("Use Selected Footprints")
         self.selected_footprints_btn.clicked.connect(
-            self.populate_from_selected_footprints
+            lambda: self.populate_from_selected_footprints()
         )
         button_layout.addWidget(self.selected_footprints_btn, 0, 1)
 
         self.footprints_btn = QPushButton("Add Footprints")
-        self.footprints_btn.clicked.connect(self.add_footprints_layer)
+        self.footprints_btn.clicked.connect(lambda: self.add_footprints_layer())
         button_layout.addWidget(self.footprints_btn, 0, 2)
 
         self.visual_btn = QPushButton("Open Visual")
@@ -831,6 +833,7 @@ class TanagerSearchDialog(QDockWidget):
             self.items = list(items or [])
             self.gdf = gdf
             self.populate_results(self.items)
+            self.add_footprints_layer(show_message=False, zoom=True, replace=True)
             self.progress_bar.setValue(100)
             self.status_label.setText(f"{len(self.items)} Tanager scenes found")
         except Exception as exc:
@@ -986,13 +989,129 @@ class TanagerSearchDialog(QDockWidget):
         assets = item.get("assets", {}) if isinstance(item, dict) else {}
         return any(asset.get("href") for asset in assets.values())
 
-    def add_footprints_layer(self):
+    def _item_geometry(self, item):
+        """Return a QGIS geometry from a STAC item geometry.
+
+        Args:
+            item: STAC item dictionary.
+
+        Returns:
+            QgsGeometry, or ``None`` when geometry is unavailable.
+        """
+        geometry = item.get("geometry", {}) if isinstance(item, dict) else {}
+        geom_type = geometry.get("type")
+        coordinates = geometry.get("coordinates")
+        if not geom_type or not coordinates:
+            return None
+
+        def ring_points(ring):
+            """Return QGIS points for a GeoJSON ring."""
+            return [QgsPointXY(float(x), float(y)) for x, y, *rest in ring]
+
+        try:
+            if geom_type == "Polygon":
+                return QgsGeometry.fromPolygonXY(
+                    [ring_points(ring) for ring in coordinates]
+                )
+            if geom_type == "MultiPolygon":
+                return QgsGeometry.fromMultiPolygonXY(
+                    [[ring_points(ring) for ring in polygon] for polygon in coordinates]
+                )
+        except Exception:
+            return None
+        return None
+
+    def _item_stac_url(self, item):
+        """Return the best STAC URL for an item.
+
+        Args:
+            item: STAC item dictionary.
+
+        Returns:
+            STAC item URL string.
+        """
+        return item.get("_stac_url") or item.get("properties", {}).get("stac_href", "")
+
+    def _remove_result_footprints_layer(self):
+        """Remove the current search result footprint layer, if present."""
+        layer = self._result_footprints_layer
+        self._result_footprints_layer = None
+        if layer is None:
+            return
+        try:
+            QgsProject.instance().removeMapLayer(layer.id())
+        except Exception:
+            pass  # nosec B110
+
+    def _result_item_ids(self):
+        """Return selected result table item IDs.
+
+        Returns:
+            Set of selected STAC item IDs.
+        """
+        rows = self.results_table.selectionModel().selectedRows()
+        if not rows and self.results_table.currentRow() >= 0:
+            rows = [
+                self.results_table.model().index(self.results_table.currentRow(), 0)
+            ]
+
+        item_ids = set()
+        for row_index in rows:
+            table_item = self.results_table.item(row_index.row(), 0)
+            item = table_item.data(Qt.ItemDataRole.UserRole) if table_item else None
+            if isinstance(item, dict) and item.get("id"):
+                item_ids.add(item["id"])
+        return item_ids
+
+    def _select_result_footprints(self):
+        """Select result footprint features matching selected table rows."""
+        layer = self._result_footprints_layer
+        if layer is None:
+            return
+        item_ids = self._result_item_ids()
+        if not item_ids:
+            try:
+                layer.removeSelection()
+            except Exception:
+                pass  # nosec B110
+            return
+
+        feature_ids = []
+        get_features = getattr(layer, "getFeatures", None)
+        if callable(get_features):
+            try:
+                for feature in get_features():
+                    if self._feature_attr(feature, "id") in item_ids:
+                        feature_ids.append(feature.id())
+            except Exception:
+                feature_ids = []
+
+        try:
+            layer.selectByIds(feature_ids)
+        except Exception:
+            pass  # nosec B110
+
+    def _has_item_footprints(self):
+        """Return whether the current items include STAC geometries."""
+        for item in self.items:
+            geometry = item.get("geometry", {}) if isinstance(item, dict) else {}
+            if geometry.get("type") in {"Polygon", "MultiPolygon"}:
+                if geometry.get("coordinates"):
+                    return True
+        return False
+
+    def add_footprints_layer(self, show_message=True, zoom=True, replace=False):
         """Add Tanager result footprints as an in-memory vector layer."""
-        if self.gdf is None or len(self.items) == 0:
-            QMessageBox.information(self, "Tanager Footprints", "No results to add.")
+        if len(self.items) == 0:
+            if show_message:
+                QMessageBox.information(
+                    self, "Tanager Footprints", "No results to add."
+                )
             return
 
         try:
+            if replace:
+                self._remove_result_footprints_layer()
             layer = QgsVectorLayer(
                 "Polygon?crs=EPSG:4326",
                 "Tanager Footprints",
@@ -1012,39 +1131,53 @@ class TanagerSearchDialog(QDockWidget):
             layer.updateFields()
 
             features = []
-            for item, (_, row) in zip(self.items, self.gdf.iterrows()):
-                geometry = row.geometry
-                if geometry is None or geometry.is_empty:
+            for item in self.items:
+                geometry = self._item_geometry(item)
+                if geometry is None:
                     continue
                 properties = item.get("properties", {})
                 feature = QgsFeature(layer.fields())
-                feature.setGeometry(QgsGeometry.fromWkt(geometry.wkt))
+                feature.setGeometry(geometry)
                 feature.setAttributes(
                     [
                         item.get("id", ""),
                         properties.get("datetime", ""),
                         item.get("_collection_title") or item.get("collection", ""),
                         properties.get("cloud_percent"),
-                        item.get("_stac_url", ""),
+                        self._item_stac_url(item),
                         _asset_url(item, TANAGER_VISUAL_ASSET),
                         _asset_url(item, TANAGER_HDF5_ASSET),
                     ]
                 )
                 features.append(feature)
 
+            if not features:
+                if show_message:
+                    QMessageBox.information(
+                        self,
+                        "Tanager Footprints",
+                        "The search results do not include footprint geometries.",
+                    )
+                return
+
             provider.addFeatures(features)
             layer.updateExtents()
             layer.setCustomProperty(
                 "hypercoast/tanager_stac_url",
-                ",".join(item.get("_stac_url", "") for item in self.items),
+                ",".join(self._item_stac_url(item) for item in self.items),
             )
+            layer.setCustomProperty("hypercoast/tanager_result_footprints", "true")
             self._style_footprint_layer(layer)
             QgsProject.instance().addMapLayer(layer)
-            self._zoom_to_layer(layer)
+            self._result_footprints_layer = layer
+            self._select_result_footprints()
+            if zoom:
+                self._zoom_to_layer(layer)
         except Exception as exc:
-            QMessageBox.warning(
-                self, "Tanager Footprints", f"Could not add footprints: {exc}"
-            )
+            if show_message:
+                QMessageBox.warning(
+                    self, "Tanager Footprints", f"Could not add footprints: {exc}"
+                )
 
     def open_visual_layer(self):
         """Open the selected Tanager visual asset as a QGIS raster layer."""
@@ -1229,7 +1362,7 @@ class TanagerSearchDialog(QDockWidget):
     def _sync_button_state(self):
         """Enable or disable result actions based on current state."""
         has_results = self.results_table.rowCount() > 0
-        has_result_footprints = has_results and self.gdf is not None
+        has_result_footprints = has_results and self._has_item_footprints()
         has_selection = self.selected_item() is not None
         self.footprints_btn.setEnabled(has_result_footprints)
         self.visual_btn.setEnabled(has_selection)
@@ -1239,6 +1372,7 @@ class TanagerSearchDialog(QDockWidget):
     def _on_result_selection_changed(self):
         """Refresh asset options after the selected result changes."""
         self._populate_asset_combo(self.selected_item())
+        self._select_result_footprints()
         self._sync_button_state()
 
     def _populate_asset_combo(self, item=None):
@@ -1285,7 +1419,9 @@ class TanagerSearchDialog(QDockWidget):
         self.search_btn.setEnabled(not busy)
         self.selected_footprints_btn.setEnabled(not busy)
         self.footprints_btn.setEnabled(
-            (not busy) and self.results_table.rowCount() > 0 and self.gdf is not None
+            (not busy)
+            and self.results_table.rowCount() > 0
+            and self._has_item_footprints()
         )
         self.visual_btn.setEnabled((not busy) and self.selected_item() is not None)
         self.stac_btn.setEnabled((not busy) and self.selected_item() is not None)

--- a/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
@@ -1,0 +1,1434 @@
+# -*- coding: utf-8 -*-
+"""
+HyperCoast QGIS Plugin - Tanager Search Dialog
+
+SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+SPDX-License-Identifier: MIT
+"""
+
+import os
+import ast
+import json
+import urllib.request
+
+from qgis.PyQt.QtCore import Qt, QThread, QUrl, pyqtSignal
+from qgis.PyQt.QtGui import QDesktopServices
+
+try:
+    from qgis.PyQt.QtCore import QVariant
+except ImportError:  # pragma: no cover - PyQt6 test shim
+
+    class QVariant:
+        """Small QVariant fallback for Qt6-only test environments."""
+
+        String = str
+        Double = float
+
+
+from qgis.PyQt.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QComboBox,
+    QDockWidget,
+    QDoubleSpinBox,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QSpinBox,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+from qgis.core import (
+    QgsContrastEnhancement,
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsFeature,
+    QgsField,
+    QgsFillSymbol,
+    QgsGeometry,
+    QgsMessageLog,
+    QgsMultiBandColorRenderer,
+    QgsProject,
+    QgsRasterLayer,
+    QgsSingleBandGrayRenderer,
+    QgsVectorLayer,
+    Qgis,
+)
+
+from ..cache_manager import create_generated_raster_path, generated_raster_cache_dir
+from ..hyperspectral_provider import HyperspectralDataset
+
+TANAGER_HDF5_ASSET = "ortho_radiance_hdf5"
+TANAGER_HDF5_ASSETS = (
+    ("Ortho Radiance HDF5", "ortho_radiance_hdf5"),
+    ("Basic Radiance HDF5", "basic_radiance_hdf5"),
+    ("Ortho Surface Reflectance HDF5", "ortho_sr_hdf5"),
+    ("Basic Surface Reflectance HDF5", "basic_sr_hdf5"),
+)
+TANAGER_VISUAL_ASSET = "ortho_visual"
+TANAGER_GLOBAL_FOOTPRINTS_URL = (
+    "https://raw.githubusercontent.com/opengeos/planet-open-data/refs/heads/main/"
+    "data/planet-tanager-sample-products/footprints.geojson"
+)
+
+
+def _asset_url(item, asset_key):
+    """Return a STAC asset URL from an item.
+
+    Args:
+        item: STAC item dictionary.
+        asset_key: STAC asset key.
+
+    Returns:
+        Asset URL string, or an empty string when unavailable.
+    """
+    assets = item.get("assets", {}) if isinstance(item, dict) else {}
+    asset = assets.get(asset_key, {})
+    return asset.get("href", "") or ""
+
+
+def _item_title(item):
+    """Return a readable Tanager item title.
+
+    Args:
+        item: STAC item dictionary.
+
+    Returns:
+        Item title or ID.
+    """
+    properties = item.get("properties", {}) if isinstance(item, dict) else {}
+    return properties.get("title") or item.get("id") or "Tanager"
+
+
+def _stac_browser_url(stac_url):
+    """Return the Planet STAC browser URL for an item URL.
+
+    Args:
+        stac_url: Raw or browser STAC item URL.
+
+    Returns:
+        Browser URL string.
+    """
+    if not stac_url:
+        return ""
+    if "/data/stac/browser/" in stac_url:
+        return stac_url
+    return stac_url.replace("/data/stac/", "/data/stac/browser/", 1)
+
+
+def _extent_to_bbox(extent):
+    """Convert a QGIS extent-like object to a bbox list.
+
+    Args:
+        extent: Object exposing QGIS extent methods.
+
+    Returns:
+        Bounding box as ``[xmin, ymin, xmax, ymax]``.
+    """
+    return [
+        float(extent.xMinimum()),
+        float(extent.yMinimum()),
+        float(extent.xMaximum()),
+        float(extent.yMaximum()),
+    ]
+
+
+def tanager_download_dir(project=None):
+    """Return the persistent Tanager download directory.
+
+    Args:
+        project: Optional QgsProject-like object.
+
+    Returns:
+        Absolute directory path.
+    """
+    out_dir = os.path.join(generated_raster_cache_dir(project), "tanager")
+    os.makedirs(out_dir, exist_ok=True)
+    return out_dir
+
+
+class TanagerSearchWorker(QThread):
+    """Worker thread for Tanager STAC searches."""
+
+    progress = pyqtSignal(int)
+    finished = pyqtSignal(object, object, str)
+
+    def __init__(self, search_params, parent=None):
+        """Initialize the worker.
+
+        Args:
+            search_params: Keyword arguments for ``hypercoast.search_tanager``.
+            parent: Optional parent QObject.
+        """
+        super().__init__(parent)
+        self.search_params = dict(search_params)
+
+    def run(self):
+        """Run the Tanager search."""
+        try:
+            from .._hypercoast_lib import get_hypercoast
+
+            self.progress.emit(20)
+            hypercoast = get_hypercoast()
+            params = dict(self.search_params)
+            params["return_gdf"] = True
+            self.progress.emit(50)
+            items, gdf = hypercoast.search_tanager(**params)
+            self.progress.emit(90)
+            self.finished.emit(items, gdf, "")
+        except Exception as exc:
+            self.finished.emit([], None, str(exc))
+
+
+class TanagerDownloadLoadWorker(QThread):
+    """Worker thread for downloading and loading a Tanager HDF5 asset."""
+
+    progress = pyqtSignal(int)
+    finished = pyqtSignal(object, str, str, str)
+
+    def __init__(
+        self,
+        item,
+        asset_key,
+        out_dir,
+        output_path,
+        wavelengths,
+        parent=None,
+    ):
+        """Initialize the worker.
+
+        Args:
+            item: STAC item dictionary.
+            asset_key: STAC asset key to download.
+            out_dir: Download directory.
+            output_path: GeoTIFF output path.
+            wavelengths: RGB wavelengths.
+            parent: Optional parent QObject.
+        """
+        super().__init__(parent)
+        self.item = item
+        self.asset_key = asset_key
+        self.out_dir = out_dir
+        self.output_path = output_path
+        self.wavelengths = wavelengths
+
+    def run(self):
+        """Download the HDF5 asset and export an RGB raster."""
+        try:
+            from .._hypercoast_lib import get_hypercoast
+
+            self.progress.emit(15)
+            hypercoast = get_hypercoast()
+            paths = hypercoast.download_tanager(
+                self.item,
+                asset=self.asset_key,
+                out_dir=self.out_dir,
+                quiet=True,
+                overwrite=False,
+            )
+            if not paths:
+                raise ValueError("Tanager download produced no file.")
+
+            filepath = paths[0]
+            self.progress.emit(45)
+            dataset = HyperspectralDataset(filepath, "Tanager")
+            result = dataset.load_and_export(
+                self.output_path, wavelengths=self.wavelengths
+            )
+            if result is None:
+                detail = getattr(dataset, "last_error", None) or "Unknown error"
+                self.finished.emit(None, filepath, "", detail)
+                return
+
+            self.progress.emit(90)
+            self.finished.emit(dataset, filepath, self.output_path, "")
+        except Exception as exc:
+            self.finished.emit(None, "", "", str(exc))
+
+
+class TanagerSearchDialog(QDockWidget):
+    """Dockable panel for searching and visualizing Tanager data."""
+
+    def __init__(self, iface, plugin, parent=None):
+        """Initialize the dialog.
+
+        Args:
+            iface: QGIS interface.
+            plugin: Reference to the main plugin.
+            parent: Optional parent widget.
+        """
+        super().__init__(parent or iface.mainWindow())
+        self.iface = iface
+        self.plugin = plugin
+        self.items = []
+        self.gdf = None
+        self._search_worker = None
+        self._load_worker = None
+        self._pending_load_context = None
+        self._connected_global_footprint_layers = set()
+
+        self.setWindowTitle("Search Tanager Data")
+        self.setObjectName("HyperCoastTanagerSearchDock")
+        self.setMinimumWidth(680)
+        self.setMinimumHeight(560)
+
+        self.setup_ui()
+        self.refresh_extent()
+        self.add_global_footprints_layer()
+
+    def setup_ui(self):
+        """Set up the user interface."""
+        content = QWidget(self)
+        self.setWidget(content)
+        layout = QVBoxLayout(content)
+
+        search_group = QGroupBox("Search")
+        form = QFormLayout(search_group)
+
+        extent_row = QHBoxLayout()
+        self.use_extent_check = QCheckBox("Use current map extent")
+        self.use_extent_check.setChecked(True)
+        extent_row.addWidget(self.use_extent_check)
+        refresh_btn = QPushButton("Refresh")
+        refresh_btn.clicked.connect(self.refresh_extent)
+        extent_row.addWidget(refresh_btn)
+        global_btn = QPushButton("Global")
+        global_btn.clicked.connect(self.clear_bbox)
+        extent_row.addWidget(global_btn)
+        form.addRow("Area:", extent_row)
+
+        self.bbox_edit = QLineEdit()
+        self.bbox_edit.setPlaceholderText("xmin, ymin, xmax, ymax")
+        form.addRow("BBox:", self.bbox_edit)
+
+        date_row = QHBoxLayout()
+        self.start_date_edit = QLineEdit()
+        self.start_date_edit.setPlaceholderText("YYYY-MM-DD")
+        date_row.addWidget(QLabel("Start:"))
+        date_row.addWidget(self.start_date_edit)
+        self.end_date_edit = QLineEdit()
+        self.end_date_edit.setPlaceholderText("YYYY-MM-DD")
+        date_row.addWidget(QLabel("End:"))
+        date_row.addWidget(self.end_date_edit)
+        form.addRow("Dates:", date_row)
+
+        self.collection_edit = QLineEdit()
+        self.collection_edit.setPlaceholderText("Collection ID or title")
+        form.addRow("Collection:", self.collection_edit)
+
+        self.query_edit = QLineEdit()
+        self.query_edit.setPlaceholderText("Scene text")
+        form.addRow("Query:", self.query_edit)
+
+        filter_row = QHBoxLayout()
+        self.cloud_spin = QDoubleSpinBox()
+        self.cloud_spin.setRange(0, 100)
+        self.cloud_spin.setValue(100)
+        self.cloud_spin.setSuffix(" %")
+        filter_row.addWidget(QLabel("Max cloud:"))
+        filter_row.addWidget(self.cloud_spin)
+        self.count_spin = QSpinBox()
+        self.count_spin.setRange(-1, 10000)
+        self.count_spin.setValue(100)
+        filter_row.addWidget(QLabel("Count:"))
+        filter_row.addWidget(self.count_spin)
+        form.addRow("Filters:", filter_row)
+
+        layout.addWidget(search_group)
+
+        self.results_table = QTableWidget(0, 6)
+        self.results_table.setHorizontalHeaderLabels(
+            ["ID", "Datetime", "Collection", "Cloud", "Visual", "Radiance HDF5"]
+        )
+        self._stretch_result_columns()
+        try:
+            self.results_table.setSelectionBehavior(
+                QAbstractItemView.SelectionBehavior.SelectRows
+            )
+            self.results_table.setSelectionMode(
+                QAbstractItemView.SelectionMode.ExtendedSelection
+            )
+        except AttributeError:
+            self.results_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+            self.results_table.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        try:
+            self.results_table.setEditTriggers(
+                QAbstractItemView.EditTrigger.NoEditTriggers
+            )
+        except AttributeError:
+            self.results_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.results_table.itemSelectionChanged.connect(
+            self._on_result_selection_changed
+        )
+        layout.addWidget(self.results_table)
+
+        download_group = QGroupBox("Download")
+        download_form = QFormLayout(download_group)
+        self.asset_combo = QComboBox()
+        self._populate_asset_combo()
+        download_form.addRow("Asset:", self.asset_combo)
+
+        download_dir_row = QHBoxLayout()
+        self.download_dir_edit = QLineEdit()
+        self.download_dir_edit.setText(tanager_download_dir(QgsProject.instance()))
+        download_dir_row.addWidget(self.download_dir_edit)
+        browse_dir_btn = QPushButton("Browse...")
+        browse_dir_btn.clicked.connect(self.browse_download_dir)
+        download_dir_row.addWidget(browse_dir_btn)
+        download_form.addRow("Folder:", download_dir_row)
+        layout.addWidget(download_group)
+
+        self.status_label = QLabel("")
+        layout.addWidget(self.status_label)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setVisible(False)
+        layout.addWidget(self.progress_bar)
+
+        button_layout = QHBoxLayout()
+        self.search_btn = QPushButton("Search")
+        self.search_btn.clicked.connect(self.search)
+        button_layout.addWidget(self.search_btn)
+
+        self.selected_footprints_btn = QPushButton("Use Selected Footprints")
+        self.selected_footprints_btn.clicked.connect(
+            self.populate_from_selected_footprints
+        )
+        button_layout.addWidget(self.selected_footprints_btn)
+
+        self.footprints_btn = QPushButton("Add Footprints")
+        self.footprints_btn.clicked.connect(self.add_footprints_layer)
+        button_layout.addWidget(self.footprints_btn)
+
+        self.visual_btn = QPushButton("Open Visual")
+        self.visual_btn.clicked.connect(self.open_visual_layer)
+        button_layout.addWidget(self.visual_btn)
+
+        self.stac_btn = QPushButton("Open STAC")
+        self.stac_btn.clicked.connect(self.open_stac_item)
+        button_layout.addWidget(self.stac_btn)
+
+        self.download_btn = QPushButton("Download HDF5")
+        self.download_btn.clicked.connect(self.download_hdf5)
+        button_layout.addWidget(self.download_btn)
+
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.close)
+        button_layout.addWidget(close_btn)
+        layout.addLayout(button_layout)
+        self._sync_button_state()
+
+    def refresh_extent(self):
+        """Refresh the bbox field from the current QGIS map extent."""
+        bbox = self.current_canvas_bbox()
+        if bbox:
+            self.bbox_edit.setText(", ".join(f"{value:.8f}" for value in bbox))
+            self.use_extent_check.setChecked(True)
+
+    def clear_bbox(self):
+        """Clear the bbox filter for a global Tanager search."""
+        self.use_extent_check.setChecked(False)
+        self.bbox_edit.clear()
+
+    def browse_download_dir(self):
+        """Select a Tanager HDF5 download directory."""
+        directory = QFileDialog.getExistingDirectory(
+            self,
+            "Select Tanager Download Folder",
+            self.download_dir_edit.text()
+            or tanager_download_dir(QgsProject.instance()),
+        )
+        if directory:
+            self.download_dir_edit.setText(directory)
+
+    def add_global_footprints_layer(self):
+        """Add the global Tanager sample footprints layer to the project.
+
+        Returns:
+            The existing or newly added global footprint layer, or ``None``.
+        """
+        try:
+            existing = self._global_footprints_layer()
+            if existing is not None:
+                self._connect_global_footprint_selection(existing)
+                self.populate_from_selected_footprints(show_message=False)
+                return existing
+
+            layer = None
+            for source in (
+                TANAGER_GLOBAL_FOOTPRINTS_URL,
+                f"/vsicurl/{TANAGER_GLOBAL_FOOTPRINTS_URL}",
+            ):
+                candidate = QgsVectorLayer(source, "Tanager Sample Footprints", "ogr")
+                if candidate.isValid():
+                    layer = candidate
+                    break
+
+            if layer is None:
+                QgsMessageLog.logMessage(
+                    "Could not load global Tanager footprints GeoJSON",
+                    "HyperCoast",
+                    Qgis.MessageLevel.Warning,
+                )
+                return None
+
+            layer.setCustomProperty("hypercoast/tanager_global_footprints", "true")
+            layer.setCustomProperty(
+                "hypercoast/tanager_footprints_url", TANAGER_GLOBAL_FOOTPRINTS_URL
+            )
+            self._style_footprint_layer(layer)
+            QgsProject.instance().addMapLayer(layer)
+            self._connect_global_footprint_selection(layer)
+            return layer
+        except Exception as exc:
+            QgsMessageLog.logMessage(
+                f"Could not add global Tanager footprints: {exc}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+            return None
+
+    def _global_footprints_layer(self):
+        """Return an existing global Tanager footprints layer.
+
+        Returns:
+            Existing layer, or ``None``.
+        """
+        try:
+            layers = QgsProject.instance().mapLayers()
+        except Exception:
+            return None
+        if not isinstance(layers, dict):
+            return None
+        for layer in layers.values():
+            custom_property = getattr(layer, "customProperty", None)
+            if not callable(custom_property):
+                continue
+            if custom_property("hypercoast/tanager_global_footprints", "") == "true":
+                return layer
+        return None
+
+    def _connect_global_footprint_selection(self, layer):
+        """Connect global footprint selection changes to the results table.
+
+        Args:
+            layer: Global Tanager footprint layer.
+        """
+        layer_key = self._layer_key(layer)
+        if layer_key in self._connected_global_footprint_layers:
+            return
+        signal = getattr(layer, "selectionChanged", None)
+        if signal is None or not hasattr(signal, "connect"):
+            return
+        try:
+            signal.connect(
+                lambda *args: self.populate_from_selected_footprints(show_message=False)
+            )
+            self._connected_global_footprint_layers.add(layer_key)
+        except Exception:
+            pass  # nosec B110
+
+    def _layer_key(self, layer):
+        """Return a stable key for a QGIS layer object.
+
+        Args:
+            layer: QGIS layer-like object.
+
+        Returns:
+            Layer ID when available, otherwise the Python object ID.
+        """
+        layer_id = getattr(layer, "id", None)
+        if callable(layer_id):
+            try:
+                return layer_id()
+            except Exception:
+                pass  # nosec B110
+        return id(layer)
+
+    def populate_from_selected_footprints(self, show_message=True):
+        """Populate results from selected global Tanager footprints.
+
+        Args:
+            show_message: Whether to show an information dialog when no
+                footprints are selected.
+        """
+        layer = self._global_footprints_layer()
+        selected_features = []
+        if layer is not None:
+            selected = getattr(layer, "selectedFeatures", None)
+            if callable(selected):
+                try:
+                    selected_features = list(selected())
+                except Exception:
+                    selected_features = []
+
+        if not selected_features:
+            if show_message:
+                QMessageBox.information(
+                    self,
+                    "Tanager Footprints",
+                    "Select one or more global Tanager footprints on the map first.",
+                )
+            return
+
+        items = [
+            self._item_from_global_footprint_feature(feature)
+            for feature in selected_features
+        ]
+        self.items = items
+        self.gdf = None
+        self.populate_results(items)
+        self._select_result_rows(range(len(items)))
+        self.status_label.setText(
+            f"{len(items)} selected Tanager footprint scenes loaded"
+        )
+
+    def _select_result_rows(self, rows):
+        """Select result table rows.
+
+        Args:
+            rows: Iterable of row indexes.
+        """
+        self.results_table.clearSelection()
+        for row in rows:
+            self.results_table.selectRow(row)
+        self._sync_button_state()
+
+    def _item_from_global_footprint_feature(self, feature):
+        """Create a lightweight STAC item from a footprint feature.
+
+        Args:
+            feature: QGIS feature from the global footprint GeoJSON.
+
+        Returns:
+            STAC-like item dictionary.
+        """
+        asset_keys = self._asset_keys_from_value(
+            self._feature_attr(feature, "asset_keys")
+        )
+        return {
+            "id": self._feature_attr(feature, "id"),
+            "collection": self._feature_attr(feature, "collection"),
+            "_collection_title": self._feature_attr(feature, "collection_title"),
+            "_stac_url": self._feature_attr(feature, "stac_href"),
+            "properties": {
+                "title": self._feature_attr(feature, "title"),
+                "datetime": self._feature_attr(feature, "datetime"),
+                "collection_title": self._feature_attr(feature, "collection_title"),
+            },
+            "assets": {asset_key: {} for asset_key in asset_keys},
+        }
+
+    def _feature_attr(self, feature, name, default=""):
+        """Read a feature attribute by name.
+
+        Args:
+            feature: QGIS feature-like object.
+            name: Attribute name.
+            default: Fallback value.
+
+        Returns:
+            Attribute value or ``default``.
+        """
+        attribute = getattr(feature, "attribute", None)
+        if callable(attribute):
+            try:
+                value = attribute(name)
+                return self._plain_attr_value(value, default)
+            except Exception:
+                pass  # nosec B110
+        try:
+            value = feature[name]
+            return self._plain_attr_value(value, default)
+        except Exception:
+            return default
+
+    def _plain_attr_value(self, value, default=""):
+        """Convert a QGIS attribute value to a plain Python value.
+
+        Args:
+            value: Raw feature attribute value.
+            default: Fallback value.
+
+        Returns:
+            Plain attribute value suitable for display and STAC metadata.
+        """
+        if value in (None, ""):
+            return default
+        to_py_datetime = getattr(value, "toPyDateTime", None)
+        if callable(to_py_datetime):
+            try:
+                return to_py_datetime().isoformat()
+            except Exception:
+                pass  # nosec B110
+        to_string = getattr(value, "toString", None)
+        if callable(to_string):
+            for date_format in (
+                getattr(getattr(Qt, "DateFormat", object()), "ISODateWithMs", None),
+                getattr(getattr(Qt, "DateFormat", object()), "ISODate", None),
+                getattr(Qt, "ISODate", None),
+            ):
+                if date_format is None:
+                    continue
+                try:
+                    text = to_string(date_format)
+                    if text:
+                        return text
+                except Exception:
+                    pass  # nosec B110
+            try:
+                text = to_string()
+                if text:
+                    return text
+            except Exception:
+                pass  # nosec B110
+        return value
+
+    def _asset_keys_from_value(self, value):
+        """Parse a footprint ``asset_keys`` attribute.
+
+        Args:
+            value: Attribute value from the footprint layer.
+
+        Returns:
+            List of STAC asset keys.
+        """
+        if isinstance(value, (list, tuple)):
+            return [str(item) for item in value]
+        if value in (None, ""):
+            return []
+        text = str(value).strip()
+        for parser in (json.loads, ast.literal_eval):
+            try:
+                parsed = parser(text)
+                if isinstance(parsed, (list, tuple)):
+                    return [str(item) for item in parsed]
+            except Exception:
+                pass  # nosec B110
+        return [part.strip() for part in text.split(",") if part.strip()]
+
+    def current_canvas_bbox(self):
+        """Return the current map canvas extent in EPSG:4326.
+
+        Returns:
+            Bounding box list, or ``None`` when unavailable.
+        """
+        try:
+            canvas = self.iface.mapCanvas()
+            extent = canvas.extent()
+            source_crs = canvas.mapSettings().destinationCrs()
+            target_crs = QgsCoordinateReferenceSystem("EPSG:4326")
+            if (
+                source_crs
+                and target_crs.isValid()
+                and source_crs.isValid()
+                and source_crs != target_crs
+            ):
+                transform = QgsCoordinateTransform(
+                    source_crs, target_crs, QgsProject.instance()
+                )
+                extent = transform.transformBoundingBox(extent)
+            return _extent_to_bbox(extent)
+        except Exception as exc:
+            QgsMessageLog.logMessage(
+                f"Could not read map extent for Tanager search: {exc}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+            return None
+
+    def search_params(self):
+        """Return validated Tanager search parameters.
+
+        Returns:
+            Dictionary of search keyword arguments.
+
+        Raises:
+            ValueError: If the date or bbox input is invalid.
+        """
+        params = {
+            "count": self.count_spin.value(),
+            "cloud_percent": self.cloud_spin.value(),
+        }
+        collection = self.collection_edit.text().strip()
+        if collection:
+            params["collections"] = collection
+        query = self.query_edit.text().strip()
+        if query:
+            params["query"] = query
+
+        start = self.start_date_edit.text().strip()
+        end = self.end_date_edit.text().strip()
+        if start or end:
+            if not (start and end):
+                raise ValueError("Both start and end dates are required.")
+            params["temporal"] = (start, end)
+
+        if self.use_extent_check.isChecked():
+            bbox = self.current_canvas_bbox()
+        else:
+            bbox = self._parse_bbox(self.bbox_edit.text())
+        if bbox:
+            params["bbox"] = bbox
+
+        return params
+
+    def _parse_bbox(self, value):
+        """Parse bbox text.
+
+        Args:
+            value: Text in ``xmin, ymin, xmax, ymax`` format.
+
+        Returns:
+            Bounding box list, or ``None`` for blank text.
+
+        Raises:
+            ValueError: If the text is not a valid four-number bbox.
+        """
+        value = value.strip()
+        if not value:
+            return None
+        parts = [part.strip() for part in value.split(",")]
+        if len(parts) != 4:
+            raise ValueError("BBox must contain xmin, ymin, xmax, ymax.")
+        try:
+            bbox = [float(part) for part in parts]
+        except ValueError as exc:
+            raise ValueError("BBox values must be numbers.") from exc
+        if bbox[0] >= bbox[2] or bbox[1] >= bbox[3]:
+            raise ValueError("BBox minimum values must be less than maximum values.")
+        return bbox
+
+    def search(self):
+        """Search Tanager STAC data."""
+        if self._search_worker is not None and self._search_worker.isRunning():
+            return
+        try:
+            params = self.search_params()
+        except ValueError as exc:
+            QMessageBox.warning(self, "Invalid Search", str(exc))
+            return
+
+        self._set_busy(True)
+        self.progress_bar.setRange(0, 0)
+        self.progress_bar.setValue(10)
+        self.status_label.setText("Searching Tanager STAC...")
+        self._search_worker = TanagerSearchWorker(params, self)
+        self._search_worker.progress.connect(self.progress_bar.setValue)
+        self._search_worker.finished.connect(self._on_search_finished)
+        self._search_worker.start()
+
+    def _on_search_finished(self, items, gdf, error_detail):
+        """Handle search completion.
+
+        Args:
+            items: STAC item dictionaries.
+            gdf: GeoDataFrame of item footprints.
+            error_detail: Error message when search failed.
+        """
+        try:
+            if error_detail:
+                raise ValueError(error_detail)
+            self.items = list(items or [])
+            self.gdf = gdf
+            self.populate_results(self.items)
+            self.progress_bar.setValue(100)
+            self.status_label.setText(f"{len(self.items)} Tanager scenes found")
+        except Exception as exc:
+            self.items = []
+            self.gdf = None
+            self.populate_results([])
+            self.status_label.setText("Search failed")
+            QMessageBox.warning(self, "Tanager Search", str(exc))
+            QgsMessageLog.logMessage(
+                f"Tanager search failed: {exc}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+        finally:
+            self.progress_bar.setRange(0, 100)
+            self._set_busy(False)
+
+    def populate_results(self, items):
+        """Populate the result table.
+
+        Args:
+            items: STAC item dictionaries.
+        """
+        self.results_table.setRowCount(0)
+        for row, item in enumerate(items):
+            properties = item.get("properties", {})
+            self.results_table.insertRow(row)
+            values = [
+                item.get("id", ""),
+                properties.get("datetime", ""),
+                item.get("_collection_title")
+                or properties.get("collection_title", "")
+                or item.get("collection", ""),
+                properties.get("cloud_percent", ""),
+                "yes" if self._has_asset(item, TANAGER_VISUAL_ASSET) else "",
+                "yes" if self._has_hdf5_asset(item) else "",
+            ]
+            for col, value in enumerate(values):
+                table_item = QTableWidgetItem(str(value))
+                if col == 0:
+                    table_item.setData(Qt.ItemDataRole.UserRole, item)
+                self.results_table.setItem(row, col, table_item)
+        self.results_table.resizeColumnsToContents()
+        self._stretch_result_columns()
+        self._sync_button_state()
+
+    def selected_item(self):
+        """Return the currently selected STAC item.
+
+        Returns:
+            STAC item dictionary, or ``None``.
+        """
+        rows = self.results_table.selectionModel().selectedRows()
+        row = rows[0].row() if rows else self.results_table.currentRow()
+        if row < 0:
+            return None
+        table_item = self.results_table.item(row, 0)
+        return table_item.data(Qt.ItemDataRole.UserRole) if table_item else None
+
+    def hydrated_selected_item(self):
+        """Return the selected item with full STAC asset metadata.
+
+        Returns:
+            Hydrated STAC item dictionary, or ``None``.
+        """
+        row = self._selected_table_row()
+        if row < 0:
+            return None
+        item = self.selected_item()
+        if item is None:
+            return None
+        hydrated = self._hydrate_stac_item(item)
+        table_item = self.results_table.item(row, 0)
+        if table_item is not None:
+            table_item.setData(Qt.ItemDataRole.UserRole, hydrated)
+        self._populate_asset_combo(hydrated)
+        return hydrated
+
+    def _selected_table_row(self):
+        """Return the selected result table row.
+
+        Returns:
+            Selected row index, or ``-1``.
+        """
+        rows = self.results_table.selectionModel().selectedRows()
+        return rows[0].row() if rows else self.results_table.currentRow()
+
+    def _hydrate_stac_item(self, item):
+        """Load full STAC item metadata for a lightweight footprint row.
+
+        Args:
+            item: STAC-like item dictionary.
+
+        Returns:
+            Full STAC item when available, otherwise the input item.
+        """
+        if self._has_asset_url(item):
+            return item
+        stac_url = item.get("_stac_url") or item.get("properties", {}).get("stac_href")
+        if not stac_url:
+            return item
+        try:
+            with urllib.request.urlopen(stac_url, timeout=30) as response:  # nosec B310
+                loaded = json.load(response)
+            loaded = dict(loaded)
+            loaded["_stac_url"] = stac_url
+            if item.get("_collection_title"):
+                loaded["_collection_title"] = item["_collection_title"]
+            return loaded
+        except Exception as exc:
+            QgsMessageLog.logMessage(
+                f"Could not load Tanager STAC item {stac_url}: {exc}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+            return item
+
+    def _has_asset(self, item, asset_key):
+        """Return whether an item advertises an asset.
+
+        Args:
+            item: STAC item dictionary.
+            asset_key: STAC asset key.
+
+        Returns:
+            True when the asset key exists.
+        """
+        assets = item.get("assets", {}) if isinstance(item, dict) else {}
+        return asset_key in assets
+
+    def _has_hdf5_asset(self, item):
+        """Return whether an item advertises any known HDF5 asset.
+
+        Args:
+            item: STAC item dictionary.
+
+        Returns:
+            True when at least one HDF5 asset key exists.
+        """
+        return any(
+            self._has_asset(item, asset_key) for _, asset_key in TANAGER_HDF5_ASSETS
+        )
+
+    def _has_asset_url(self, item):
+        """Return whether any STAC asset has an href.
+
+        Args:
+            item: STAC item dictionary.
+
+        Returns:
+            True when at least one asset has a URL.
+        """
+        assets = item.get("assets", {}) if isinstance(item, dict) else {}
+        return any(asset.get("href") for asset in assets.values())
+
+    def add_footprints_layer(self):
+        """Add Tanager result footprints as an in-memory vector layer."""
+        if self.gdf is None or len(self.items) == 0:
+            QMessageBox.information(self, "Tanager Footprints", "No results to add.")
+            return
+
+        try:
+            layer = QgsVectorLayer(
+                "Polygon?crs=EPSG:4326",
+                "Tanager Footprints",
+                "memory",
+            )
+            provider = layer.dataProvider()
+            fields = [
+                QgsField("id", QVariant.String),
+                QgsField("datetime", QVariant.String),
+                QgsField("collection", QVariant.String),
+                QgsField("cloud_pct", QVariant.Double),
+                QgsField("stac_url", QVariant.String),
+                QgsField("visual_url", QVariant.String),
+                QgsField("hdf5_url", QVariant.String),
+            ]
+            provider.addAttributes(fields)
+            layer.updateFields()
+
+            features = []
+            for item, (_, row) in zip(self.items, self.gdf.iterrows()):
+                geometry = row.geometry
+                if geometry is None or geometry.is_empty:
+                    continue
+                properties = item.get("properties", {})
+                feature = QgsFeature(layer.fields())
+                feature.setGeometry(QgsGeometry.fromWkt(geometry.wkt))
+                feature.setAttributes(
+                    [
+                        item.get("id", ""),
+                        properties.get("datetime", ""),
+                        item.get("_collection_title") or item.get("collection", ""),
+                        properties.get("cloud_percent"),
+                        item.get("_stac_url", ""),
+                        _asset_url(item, TANAGER_VISUAL_ASSET),
+                        _asset_url(item, TANAGER_HDF5_ASSET),
+                    ]
+                )
+                features.append(feature)
+
+            provider.addFeatures(features)
+            layer.updateExtents()
+            layer.setCustomProperty(
+                "hypercoast/tanager_stac_url",
+                ",".join(item.get("_stac_url", "") for item in self.items),
+            )
+            self._style_footprint_layer(layer)
+            QgsProject.instance().addMapLayer(layer)
+            self._zoom_to_layer(layer)
+        except Exception as exc:
+            QMessageBox.warning(
+                self, "Tanager Footprints", f"Could not add footprints: {exc}"
+            )
+
+    def open_visual_layer(self):
+        """Open the selected Tanager visual asset as a QGIS raster layer."""
+        item = self.hydrated_selected_item()
+        if item is None:
+            return
+        url = _asset_url(item, TANAGER_VISUAL_ASSET)
+        if not url:
+            QMessageBox.warning(
+                self,
+                "Tanager Visual",
+                "The selected scene does not include an ortho visual asset.",
+            )
+            return
+
+        layer_name = f"Tanager Visual - {_item_title(item)}"
+        raster_layer = QgsRasterLayer(url, layer_name, "gdal")
+        if not raster_layer.isValid():
+            raster_layer = QgsRasterLayer(f"/vsicurl/{url}", layer_name, "gdal")
+        if not raster_layer.isValid():
+            QMessageBox.warning(
+                self,
+                "Tanager Visual",
+                "QGIS could not open the ortho visual asset.",
+            )
+            return
+
+        raster_layer.setCustomProperty("hypercoast/source_path", url)
+        raster_layer.setCustomProperty("hypercoast/data_type", "Tanager Visual")
+        raster_layer.setCustomProperty(
+            "hypercoast/tanager_stac_url", item.get("_stac_url", "")
+        )
+        QgsProject.instance().addMapLayer(raster_layer)
+        self.iface.setActiveLayer(raster_layer)
+        self._zoom_to_layer(raster_layer)
+
+    def open_stac_item(self):
+        """Open the selected Tanager STAC item in the Planet STAC browser."""
+        item = self.selected_item()
+        if item is None:
+            return
+        stac_url = item.get("_stac_url") or item.get("properties", {}).get("stac_href")
+        browser_url = _stac_browser_url(stac_url)
+        if not browser_url:
+            QMessageBox.warning(
+                self,
+                "Tanager STAC",
+                "The selected scene does not include a STAC item URL.",
+            )
+            return
+        QDesktopServices.openUrl(QUrl(browser_url))
+
+    def download_hdf5(self):
+        """Download and load the selected Tanager radiance HDF5 asset."""
+        item = self.hydrated_selected_item()
+        if item is None:
+            return
+        asset_key = self.asset_combo.currentData()
+        if not asset_key:
+            QMessageBox.warning(
+                self,
+                "Tanager HDF5",
+                "The selected scene does not include downloadable HDF5 assets.",
+            )
+            return
+        if not _asset_url(item, asset_key):
+            QMessageBox.warning(
+                self,
+                "Tanager HDF5",
+                f"The selected scene does not include asset '{asset_key}'.",
+            )
+            return
+        if self._load_worker is not None and self._load_worker.isRunning():
+            return
+
+        try:
+            out_dir = self.download_dir_edit.text().strip()
+            if not out_dir:
+                raise ValueError("Please select a download folder.")
+            os.makedirs(out_dir, exist_ok=True)
+            asset_label = self.asset_combo.currentText() or asset_key
+            layer_name = f"Tanager {asset_label} - {_item_title(item)}"
+            output_path = create_generated_raster_path(
+                layer_name, "rgb", project=QgsProject.instance()
+            )
+            wavelengths = [650, 550, 450]
+            self._pending_load_context = {
+                "layer_name": layer_name,
+                "wavelengths": wavelengths,
+                "stac_url": item.get("_stac_url", ""),
+            }
+            self._set_busy(True)
+            self.progress_bar.setRange(0, 100)
+            self.progress_bar.setValue(20)
+            self.status_label.setText("Downloading Tanager HDF5...")
+            self._load_worker = TanagerDownloadLoadWorker(
+                item,
+                asset_key,
+                out_dir,
+                output_path,
+                wavelengths,
+                parent=self,
+            )
+            self._load_worker.progress.connect(self.progress_bar.setValue)
+            self._load_worker.finished.connect(self._on_download_load_finished)
+            self._load_worker.start()
+        except Exception as exc:
+            self._pending_load_context = None
+            self._set_busy(False)
+            QMessageBox.warning(self, "Tanager HDF5", str(exc))
+
+    def _on_download_load_finished(self, dataset, filepath, temp_path, error_detail):
+        """Handle Tanager download and load worker completion.
+
+        Args:
+            dataset: Loaded HyperspectralDataset, or None on failure.
+            filepath: Downloaded HDF5 path.
+            temp_path: Exported GeoTIFF path.
+            error_detail: Error message when loading failed.
+        """
+        if self._pending_load_context is not None and filepath:
+            self._pending_load_context["filepath"] = filepath
+        self._on_load_finished(dataset, temp_path, error_detail)
+
+    def _on_load_finished(self, dataset, temp_path, error_detail):
+        """Add the loaded Tanager HDF5 raster to QGIS.
+
+        Args:
+            dataset: Loaded HyperspectralDataset, or None on failure.
+            temp_path: Exported GeoTIFF path.
+            error_detail: Error message when loading failed.
+        """
+        try:
+            context = self._pending_load_context or {}
+            if dataset is None:
+                raise ValueError(error_detail or "Failed to load Tanager HDF5.")
+
+            layer_name = context.get("layer_name", "Tanager Radiance")
+            raster_layer = QgsRasterLayer(temp_path, layer_name)
+            if not raster_layer.isValid():
+                raise ValueError("Created Tanager raster layer is not valid.")
+
+            if (not raster_layer.crs().isValid()) and dataset.crs:
+                known_crs = QgsCoordinateReferenceSystem(str(dataset.crs))
+                if known_crs.isValid():
+                    raster_layer.setCrs(known_crs)
+
+            self._style_raster_layer(raster_layer)
+            self._set_hyperspectral_properties(raster_layer, dataset, context)
+            QgsProject.instance().addMapLayer(raster_layer)
+
+            selected_data_var = dataset.get_data_variable()
+            selected_variable = getattr(selected_data_var, "name", None)
+            self.plugin.register_hyperspectral_layer(
+                raster_layer.id(),
+                {
+                    "dataset": dataset,
+                    "filepath": context.get("filepath", ""),
+                    "data_type": dataset.data_type,
+                    "wavelengths": dataset.wavelengths,
+                    "rgb_wavelengths": context.get("wavelengths", []),
+                    "selected_variable": selected_variable,
+                    "bounds": dataset.bounds,
+                    "crs": dataset.crs,
+                },
+            )
+            spectral_plot = getattr(self.plugin, "spectral_plot_dialog", None)
+            if spectral_plot is not None:
+                spectral_plot.clear_all_spectra()
+
+            self.iface.setActiveLayer(raster_layer)
+            self._zoom_to_layer(raster_layer)
+            self.progress_bar.setValue(100)
+            self.status_label.setText("Tanager HDF5 loaded")
+        except Exception as exc:
+            QMessageBox.warning(self, "Tanager HDF5", str(exc))
+            QgsMessageLog.logMessage(
+                f"Error loading Tanager HDF5: {exc}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+        finally:
+            self._pending_load_context = None
+            self._set_busy(False)
+
+    def _style_raster_layer(self, raster_layer):
+        """Apply a default renderer to a generated Tanager raster.
+
+        Args:
+            raster_layer: QGIS raster layer.
+        """
+        provider = raster_layer.dataProvider()
+        if provider is None:
+            return
+        for band_idx in range(1, raster_layer.bandCount() + 1):
+            try:
+                provider.setNoDataValue(band_idx, -9999.0)
+            except Exception:
+                pass  # nosec B110
+
+        if raster_layer.bandCount() >= 3:
+            renderer = QgsMultiBandColorRenderer(provider, 1, 2, 3)
+            renderer_bands = [1, 2, 3]
+        else:
+            renderer = QgsSingleBandGrayRenderer(provider, 1)
+            renderer_bands = [1]
+
+        for band_idx in renderer_bands:
+            ce = QgsContrastEnhancement(provider.dataType(band_idx))
+            ce.setContrastEnhancementAlgorithm(
+                QgsContrastEnhancement.StretchToMinimumMaximum
+            )
+            ce.setMinimumValue(0)
+            ce.setMaximumValue(0.5)
+            if raster_layer.bandCount() < 3:
+                renderer.setContrastEnhancement(ce)
+            elif band_idx == 1:
+                renderer.setRedContrastEnhancement(ce)
+            elif band_idx == 2:
+                renderer.setGreenContrastEnhancement(ce)
+            else:
+                renderer.setBlueContrastEnhancement(ce)
+        raster_layer.setRenderer(renderer)
+
+    def _style_footprint_layer(self, layer):
+        """Apply the default Tanager footprint style.
+
+        Args:
+            layer: QGIS vector layer.
+        """
+        try:
+            symbol = QgsFillSymbol.createSimple(
+                {
+                    "color": "173,216,230,80",
+                    "outline_color": "0,102,204,255",
+                    "outline_width": "0.6",
+                }
+            )
+            layer.renderer().setSymbol(symbol)
+            layer.triggerRepaint()
+        except Exception:
+            pass  # nosec B110
+
+    def _set_hyperspectral_properties(self, raster_layer, dataset, context):
+        """Persist HyperCoast metadata on a Tanager raster layer.
+
+        Args:
+            raster_layer: Layer receiving custom properties.
+            dataset: Loaded Tanager dataset provider.
+            context: Pending load context.
+        """
+        raster_layer.setCustomProperty(
+            "hypercoast/source_path", context.get("filepath", "")
+        )
+        raster_layer.setCustomProperty("hypercoast/data_type", dataset.data_type)
+        raster_layer.setCustomProperty(
+            "hypercoast/rgb_wavelengths",
+            ",".join(str(value) for value in context.get("wavelengths", [])),
+        )
+        raster_layer.setCustomProperty(
+            "hypercoast/tanager_stac_url", context.get("stac_url", "")
+        )
+        if dataset.crs:
+            raster_layer.setCustomProperty("hypercoast/crs", str(dataset.crs))
+
+    def _zoom_to_layer(self, layer):
+        """Zoom the map canvas to a layer extent.
+
+        Args:
+            layer: QGIS map layer.
+        """
+        try:
+            canvas = self.iface.mapCanvas()
+            extent = layer.extent()
+            layer_crs = layer.crs()
+            canvas_crs = canvas.mapSettings().destinationCrs()
+            if layer_crs.isValid() and canvas_crs.isValid() and layer_crs != canvas_crs:
+                transform = QgsCoordinateTransform(
+                    layer_crs, canvas_crs, QgsProject.instance()
+                )
+                extent = transform.transformBoundingBox(extent)
+            extent.scale(1.05)
+            canvas.setExtent(extent)
+            canvas.refresh()
+        except Exception:
+            pass  # nosec B110
+
+    def _sync_button_state(self):
+        """Enable or disable result actions based on current state."""
+        has_results = self.results_table.rowCount() > 0
+        has_result_footprints = has_results and self.gdf is not None
+        has_selection = self.selected_item() is not None
+        self.footprints_btn.setEnabled(has_result_footprints)
+        self.visual_btn.setEnabled(has_selection)
+        self.stac_btn.setEnabled(has_selection)
+        self.download_btn.setEnabled(has_selection)
+
+    def _on_result_selection_changed(self):
+        """Refresh asset options after the selected result changes."""
+        self._populate_asset_combo(self.selected_item())
+        self._sync_button_state()
+
+    def _populate_asset_combo(self, item=None):
+        """Populate the HDF5 asset combo.
+
+        Args:
+            item: Optional selected STAC item used to filter available assets.
+        """
+        current = (
+            self.asset_combo.currentData() if hasattr(self, "asset_combo") else None
+        )
+        available = item.get("assets", {}) if isinstance(item, dict) else None
+        self.asset_combo.blockSignals(True)
+        self.asset_combo.clear()
+        for label, asset_key in TANAGER_HDF5_ASSETS:
+            if available is None or asset_key in available:
+                self.asset_combo.addItem(label, asset_key)
+        if self.asset_combo.count() == 0:
+            self.asset_combo.addItem("No HDF5 assets available", "")
+        elif current:
+            index = self.asset_combo.findData(current)
+            if index >= 0:
+                self.asset_combo.setCurrentIndex(index)
+        self.asset_combo.blockSignals(False)
+
+    def _stretch_result_columns(self):
+        """Make result table columns use the full table width."""
+        try:
+            header = self.results_table.horizontalHeader()
+            header.setStretchLastSection(True)
+            header.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        except AttributeError:
+            header = self.results_table.horizontalHeader()
+            header.setStretchLastSection(True)
+            header.setSectionResizeMode(QHeaderView.Stretch)
+
+    def _set_busy(self, busy):
+        """Toggle controls while background work runs.
+
+        Args:
+            busy: Whether the dialog is busy.
+        """
+        self.progress_bar.setVisible(busy)
+        self.search_btn.setEnabled(not busy)
+        self.selected_footprints_btn.setEnabled(not busy)
+        self.footprints_btn.setEnabled(
+            (not busy) and self.results_table.rowCount() > 0 and self.gdf is not None
+        )
+        self.visual_btn.setEnabled((not busy) and self.selected_item() is not None)
+        self.stac_btn.setEnabled((not busy) and self.selected_item() is not None)
+        self.download_btn.setEnabled((not busy) and self.selected_item() is not None)
+
+    def _stop_worker(self, worker):
+        """Request a worker thread to stop.
+
+        Args:
+            worker: QThread instance, or None.
+        """
+        if worker is None:
+            return
+        try:
+            if worker.isRunning():
+                worker.requestInterruption()
+                worker.quit()
+                worker.wait(5000)
+        except RuntimeError:
+            pass  # nosec B110
+
+    def closeEvent(self, event):
+        """Stop background workers before the dock closes.
+
+        Args:
+            event: Qt close event.
+        """
+        self._stop_worker(self._search_worker)
+        self._stop_worker(self._load_worker)
+        super().closeEvent(event)

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -150,16 +150,6 @@ class HyperCoastPlugin:
 
         icons_dir = os.path.join(self.plugin_dir, "icons")
 
-        # Load Hyperspectral Data action
-        self.load_action = self.add_action(
-            os.path.join(icons_dir, "load_data.png"),
-            text=self.tr("Load Hyperspectral Data"),
-            callback=self.show_load_dialog,
-            parent=self.iface.mainWindow(),
-            status_tip=self.tr("Load hyperspectral data (EMIT, PACE, DESIS, etc.)"),
-            checkable=True,
-        )
-
         # Tanager search action
         self.tanager_search_action = self.add_action(
             os.path.join(icons_dir, "tanager.svg"),
@@ -167,6 +157,16 @@ class HyperCoastPlugin:
             callback=self.show_tanager_search_dialog,
             parent=self.iface.mainWindow(),
             status_tip=self.tr("Search and visualize Planet Tanager data"),
+            checkable=True,
+        )
+
+        # Load Hyperspectral Data action
+        self.load_action = self.add_action(
+            os.path.join(icons_dir, "load_data.png"),
+            text=self.tr("Load Hyperspectral Data"),
+            callback=self.show_load_dialog,
+            parent=self.iface.mainWindow(),
+            status_tip=self.tr("Load hyperspectral data (EMIT, PACE, DESIS, etc.)"),
             checkable=True,
         )
 

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -22,6 +22,7 @@ from .dialogs.update_checker import UpdateCheckerDialog
 _DATA_DIALOGS_AVAILABLE = False
 try:
     from .dialogs.load_data_dialog import LoadDataDialog
+    from .dialogs.tanager_search_dialog import TanagerSearchDialog
     from .dialogs.band_combination_dialog import BandCombinationDialog
     from .dialogs.spectral_inspector_tool import SpectralInspectorTool
     from .dialogs.spectral_plot_dialog import SpectralPlotDialog
@@ -36,6 +37,7 @@ MENU_TITLE = "&HyperCoast"
 DOCK_OBJECT_NAMES = {
     "HyperCoastSettingsDock",
     "HyperCoastLoadDataDock",
+    "HyperCoastTanagerSearchDock",
     "HyperCoastBandCombinationDock",
     "HyperCoastSpectralPlotDock",
     "HyperCoastAboutDock",
@@ -67,6 +69,7 @@ class HyperCoastPlugin:
 
         # Store reference to dialogs and dock widgets
         self.load_dialog = None
+        self.tanager_search_dialog = None
         self.band_dialog = None
         self.spectral_tool = None
         self.spectral_plot_dialog = None
@@ -154,6 +157,16 @@ class HyperCoastPlugin:
             callback=self.show_load_dialog,
             parent=self.iface.mainWindow(),
             status_tip=self.tr("Load hyperspectral data (EMIT, PACE, DESIS, etc.)"),
+            checkable=True,
+        )
+
+        # Tanager search action
+        self.tanager_search_action = self.add_action(
+            os.path.join(icons_dir, "hypercoast.png"),
+            text=self.tr("Search Tanager Data"),
+            callback=self.show_tanager_search_dialog,
+            parent=self.iface.mainWindow(),
+            status_tip=self.tr("Search and visualize Planet Tanager data"),
             checkable=True,
         )
 
@@ -444,6 +457,7 @@ class HyperCoastPlugin:
         for attr_name in (
             "_settings_dock",
             "load_dialog",
+            "tanager_search_dialog",
             "band_dialog",
             "spectral_plot_dialog",
             "about_dialog",
@@ -540,12 +554,14 @@ class HyperCoastPlugin:
             from . import hyperspectral_provider
             from .dialogs import (
                 load_data_dialog,
+                tanager_search_dialog,
                 band_combination_dialog,
                 spectral_plot_dialog,
             )
 
             importlib.reload(hyperspectral_provider)
             importlib.reload(load_data_dialog)
+            importlib.reload(tanager_search_dialog)
             importlib.reload(band_combination_dialog)
             importlib.reload(spectral_plot_dialog)
         except Exception as e:
@@ -558,6 +574,7 @@ class HyperCoastPlugin:
         # Reset cached dialog instances so they are re-created
         # with the reloaded module classes.
         self.load_dialog = None
+        self.tanager_search_dialog = None
         self.band_dialog = None
         self.spectral_tool = None
         self.spectral_plot_dialog = None
@@ -566,6 +583,9 @@ class HyperCoastPlugin:
             # Try importing again now that venv packages are on sys.path
             try:
                 from .dialogs.load_data_dialog import LoadDataDialog  # noqa: F811
+                from .dialogs.tanager_search_dialog import (  # noqa: F811
+                    TanagerSearchDialog,
+                )
                 from .dialogs.band_combination_dialog import (  # noqa: F811
                     BandCombinationDialog,
                 )
@@ -634,13 +654,13 @@ class HyperCoastPlugin:
     def _set_data_actions_enabled(self, enabled):
         """Enable or disable data-related actions.
 
-        The first 3 actions are data-dependent:
-        Load Data, Band Combination, Spectral Inspector.
+        The first 4 actions are data-dependent:
+        Load Data, Tanager Search, Band Combination, Spectral Inspector.
 
         :param enabled: Whether to enable the actions.
         """
         for i, action in enumerate(self.actions):
-            if i < 3:
+            if i < 4:
                 action.setEnabled(enabled)
 
     def toggle_settings_dock(self):
@@ -704,6 +724,20 @@ class HyperCoastPlugin:
             "load_dialog",
             lambda: LoadDataDialog(self.iface, self, self.iface.mainWindow()),
             self.load_action,
+        )
+
+    def show_tanager_search_dialog(self):
+        """Show the Tanager search dialog."""
+        if not self._deps_available:
+            self._show_deps_required_warning()
+            self.tanager_search_action.setChecked(False)
+            return
+        from .dialogs.tanager_search_dialog import TanagerSearchDialog
+
+        self._toggle_dock(
+            "tanager_search_dialog",
+            lambda: TanagerSearchDialog(self.iface, self, self.iface.mainWindow()),
+            self.tanager_search_action,
         )
 
     def show_band_dialog(self):

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -162,7 +162,7 @@ class HyperCoastPlugin:
 
         # Tanager search action
         self.tanager_search_action = self.add_action(
-            os.path.join(icons_dir, "hypercoast.png"),
+            os.path.join(icons_dir, "tanager.svg"),
             text=self.tr("Search Tanager Data"),
             callback=self.show_tanager_search_dialog,
             parent=self.iface.mainWindow(),

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -185,12 +185,54 @@ class HyperspectralDataset:
             return "PRISMA"
         elif "ENMAP" in filename:
             return "EnMAP"
-        elif "TANAGER" in filename:
+        elif (
+            "TANAGER" in filename
+            or "ORTHO_RADIANCE_HDF5" in filename
+            or "BASIC_RADIANCE_HDF5" in filename
+            or "ORTHO_SR_HDF5" in filename
+            or "BASIC_SR_HDF5" in filename
+        ):
             return "Tanager"
         elif "WYVERN" in filename:
             return "Wyvern"
+        elif ext in [".h5", ".hdf5"] and self._is_tanager_hdf5_file():
+            return "Tanager"
         else:
             return "Generic"
+
+    def _is_tanager_hdf5_file(self):
+        """Return whether an HDF5 file looks like a Tanager product.
+
+        Returns:
+            True when the file contains known Tanager cube dataset names.
+        """
+        if not (HAS_H5PY and os.path.exists(self.filepath)):
+            return False
+
+        tanager_dataset_names = {
+            "toa_radiance",
+            "surface_reflectance",
+            "ortho_radiance",
+            "ortho_surface_reflectance",
+        }
+        found = False
+
+        def visit(name, obj):
+            """Inspect HDF5 objects for Tanager cube dataset names."""
+            nonlocal found
+            if found or not isinstance(obj, h5py.Dataset):
+                return
+            dataset_name = os.path.basename(name).lower()
+            if dataset_name in tanager_dataset_names and obj.ndim >= 3:
+                found = True
+
+        try:
+            with h5py.File(self.filepath, "r") as h5_file:
+                h5_file.visititems(visit)
+        except Exception:
+            return False
+
+        return found
 
     def _log_windows_context(self, stage):
         """Log extra runtime context for Windows debugging."""

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -116,7 +116,7 @@ DATA_TYPES = {
         "variable": "reflectance",
     },
     "Tanager": {
-        "extensions": [".h5"],
+        "extensions": [".h5", ".hdf5"],
         "description": "Planet Tanager",
         "variable": "toa_radiance",
     },

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -1333,7 +1333,12 @@ class HyperspectralDataset:
                 lon_value, lat_value = self._as_lon_lat(x, y, crs, lon, lat)
                 return self._extract_with_hypercoast(lon_value, lat_value)
 
-            if "latitude" in data_var.dims and "longitude" in data_var.dims:
+            if self._has_2d_latlon_grid(data_var):
+                lon_value, lat_value = self._as_lon_lat(x, y, crs, lon, lat)
+                values = self._extract_from_2d_latlon_grid(
+                    data_var, lon_value, lat_value
+                )
+            elif "latitude" in data_var.dims and "longitude" in data_var.dims:
                 lon_value, lat_value = self._as_lon_lat(x, y, crs, lon, lat)
                 values = data_var.sel(
                     latitude=lat_value, longitude=lon_value, method="nearest"
@@ -1349,6 +1354,54 @@ class HyperspectralDataset:
         except Exception as e:
             _log(f"Error extracting spectral signature: {e}", LOG_WARNING)
             return None, None
+
+    def _has_2d_latlon_grid(self, data_var):
+        """Return whether a data variable has 2D geolocation coordinates.
+
+        Args:
+            data_var: Xarray DataArray to inspect.
+
+        Returns:
+            True when the dataset has 2D latitude/longitude on the variable's
+            spatial dimensions.
+        """
+        if self.dataset is None or "latitude" not in self.dataset:
+            return False
+        if "longitude" not in self.dataset:
+            return False
+        lat = self.dataset["latitude"]
+        lon = self.dataset["longitude"]
+        return (
+            getattr(lat, "ndim", 0) == 2
+            and getattr(lon, "ndim", 0) == 2
+            and "y" in getattr(data_var, "dims", ())
+            and "x" in getattr(data_var, "dims", ())
+        )
+
+    def _extract_from_2d_latlon_grid(self, data_var, lon, lat):
+        """Extract a spectrum by nearest 2D latitude/longitude pixel.
+
+        Args:
+            data_var: Xarray DataArray with ``y`` and ``x`` dimensions.
+            lon: Longitude in EPSG:4326.
+            lat: Latitude in EPSG:4326.
+
+        Returns:
+            One-dimensional spectral values, or ``None`` when unavailable.
+        """
+        lat_grid = np.asarray(self.dataset["latitude"].values, dtype=float)
+        lon_grid = np.asarray(self.dataset["longitude"].values, dtype=float)
+        if lat_grid.shape != lon_grid.shape:
+            return None
+
+        with np.errstate(invalid="ignore"):
+            distance = (lat_grid - float(lat)) ** 2 + (lon_grid - float(lon)) ** 2
+        if not np.isfinite(distance).any():
+            return None
+
+        row, col = np.unravel_index(np.nanargmin(distance), distance.shape)
+        values = data_var.isel(y=int(row), x=int(col)).values
+        return np.asarray(values).squeeze()
 
     def _as_lon_lat(self, x, y, crs, lon=None, lat=None):
         """Return coordinates in EPSG:4326.

--- a/qgis_plugin/hypercoast_qgis/icons/tanager.svg
+++ b/qgis_plugin/hypercoast_qgis/icons/tanager.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Tanager search">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b5f73"/>
+      <stop offset="1" stop-color="#123c69"/>
+    </linearGradient>
+    <linearGradient id="scene" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f6c85f"/>
+      <stop offset="0.55" stop-color="#2fbf71"/>
+      <stop offset="1" stop-color="#2f80ed"/>
+    </linearGradient>
+  </defs>
+  <rect x="1.5" y="1.5" width="61" height="61" rx="8" fill="url(#bg)" stroke="#ffffff" stroke-opacity="0.8" stroke-width="3"/>
+  <path d="M10 44 L24 24 L37 34 L53 15 L53 49 L10 49 Z" fill="url(#scene)" opacity="0.95"/>
+  <path d="M10 44 L24 24 L37 34 L53 15" fill="none" stroke="#ffffff" stroke-opacity="0.75" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="38" cy="34" r="13" fill="none" stroke="#ffffff" stroke-width="5"/>
+  <path d="M48 44 L57 53" stroke="#ffffff" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="38" cy="34" r="7" fill="#123c69" opacity="0.35"/>
+  <path d="M18 17 H32" stroke="#9ce6ff" stroke-width="3" stroke-linecap="round"/>
+  <path d="M18 23 H27" stroke="#9ce6ff" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/qgis_plugin/hypercoast_qgis/metadata.txt
+++ b/qgis_plugin/hypercoast_qgis/metadata.txt
@@ -4,13 +4,14 @@
 name=HyperCoast
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
-description=Visualize and analyze hyperspectral data including EMIT, PACE, DESIS, NEON, AVIRIS, PRISMA, EnMAP, Tanager, and Wyvern datasets
+description=Visualize, search, and analyze hyperspectral data including EMIT, PACE, DESIS, NEON, AVIRIS, PRISMA, EnMAP, Tanager, and Wyvern datasets
 version=0.23.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
 about=HyperCoast QGIS Plugin provides powerful tools for hyperspectral data visualization and analysis. Features include:
     - Load and display various hyperspectral formats (EMIT, PACE, DESIS, NEON, AVIRIS, PRISMA, EnMAP, Tanager, Wyvern)
+    - Search Planet Tanager STAC data, add footprints, open visual imagery, and download radiance HDF5 assets
     - Interactive band combination visualization
     - Spectral signature inspection with click-to-plot functionality
     - Export spectral profiles to CSV
@@ -20,7 +21,7 @@ about=HyperCoast QGIS Plugin provides powerful tools for hyperspectral data visu
 tracker=https://github.com/opengeos/HyperCoast/issues
 repository=https://github.com/opengeos/HyperCoast
 
-tags=hyperspectral,remote sensing,EMIT,PACE,spectral,analysis,visualization
+tags=hyperspectral,remote sensing,EMIT,PACE,Tanager,STAC,spectral,analysis,visualization
 
 homepage=https://hypercoast.org
 category=Raster
@@ -33,6 +34,7 @@ hasProcessingProvider=yes
 changelog=
     0.23.0
         - Align QGIS plugin metadata with the HyperCoast package release
+        - Add Tanager STAC search, footprint visualization, visual imagery, and radiance HDF5 loading
     0.8.0
         - Convert plugin windows to dockable QGIS panels
         - Add HyperCoast Processing provider with RGB, single-band, spectral index, and PCA tools

--- a/qgis_plugin/qt6_tests/test_dock_panels.py
+++ b/qgis_plugin/qt6_tests/test_dock_panels.py
@@ -69,6 +69,7 @@ def test_tanager_auto_detect_sets_radiance_value_range(qapp, tmp_path):
 
 def test_spectral_plot_uses_tanager_radiance_defaults(qapp):
     """Tanager spectra should switch the plot label and y-range."""
+    pytest.importorskip("matplotlib")
 
     class _Iface:
         """Small iface-like object."""

--- a/qgis_plugin/qt6_tests/test_dock_panels.py
+++ b/qgis_plugin/qt6_tests/test_dock_panels.py
@@ -1,5 +1,11 @@
 """Smoke tests for the dockable HyperCoast panel classes."""
 
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from qgis.PyQt.QtWidgets import QApplication
 from qgis.PyQt.QtWidgets import QDockWidget
 
 from hypercoast_qgis.dialogs.about_dialog import AboutDialog
@@ -10,6 +16,15 @@ from hypercoast_qgis.dialogs.settings_dock import SettingsDockWidget
 from hypercoast_qgis.dialogs.spectral_plot_dialog import SpectralPlotDialog
 from hypercoast_qgis.dialogs.tanager_search_dialog import TanagerSearchDialog
 from hypercoast_qgis.dialogs.update_checker import UpdateCheckerDialog
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Return a QApplication for widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
 
 
 def test_plugin_windows_are_dock_widgets():
@@ -27,3 +42,26 @@ def test_plugin_windows_are_dock_widgets():
 
     for dock_class in dock_classes:
         assert issubclass(dock_class, QDockWidget)
+
+
+def test_tanager_auto_detect_sets_radiance_value_range(qapp, tmp_path):
+    """Auto-detected Tanager files should use a radiance-friendly max."""
+    h5py = pytest.importorskip("h5py")
+    filepath = tmp_path / "custom_name.h5"
+    with h5py.File(filepath, "w") as h5_file:
+        h5_file.create_dataset("product/toa_radiance", shape=(2, 3, 4))
+
+    class _Iface:
+        """Small iface-like object."""
+
+        def mainWindow(self):
+            """Return no parent window."""
+            return None
+
+    plugin = type("Plugin", (), {})()
+    dialog = LoadDataDialog(_Iface(), plugin)
+    dialog.file_path_edit.setText(str(filepath))
+
+    dialog._clear_dataset_preview()
+
+    assert dialog.vmax_spin.value() == 100.0

--- a/qgis_plugin/qt6_tests/test_dock_panels.py
+++ b/qgis_plugin/qt6_tests/test_dock_panels.py
@@ -65,3 +65,41 @@ def test_tanager_auto_detect_sets_radiance_value_range(qapp, tmp_path):
     dialog._clear_dataset_preview()
 
     assert dialog.vmax_spin.value() == 100.0
+
+
+def test_spectral_plot_uses_tanager_radiance_defaults(qapp):
+    """Tanager spectra should switch the plot label and y-range."""
+
+    class _Iface:
+        """Small iface-like object."""
+
+        def mainWindow(self):
+            """Return no parent window."""
+            return None
+
+    class _Plugin:
+        """Small plugin-like object."""
+
+        spectral_tool = None
+
+        def get_all_hyperspectral_layers(self):
+            """Return no registered layers."""
+            return {}
+
+        def get_hyperspectral_data(self, layer_id):
+            """Return no layer metadata."""
+            return None
+
+    dialog = SpectralPlotDialog(_Iface(), _Plugin())
+
+    dialog.add_spectrum(
+        30.0,
+        -90.0,
+        [500.0, 600.0],
+        [12.0, 24.0],
+        "Tanager Radiance",
+        data_type="Tanager",
+    )
+
+    assert dialog.ylabel_combo.currentText() == "Radiance"
+    assert dialog.ymax_spin.value() == 100.0

--- a/qgis_plugin/qt6_tests/test_dock_panels.py
+++ b/qgis_plugin/qt6_tests/test_dock_panels.py
@@ -8,6 +8,7 @@ from hypercoast_qgis.dialogs.dependency_installer import DependencyInstallerDial
 from hypercoast_qgis.dialogs.load_data_dialog import LoadDataDialog
 from hypercoast_qgis.dialogs.settings_dock import SettingsDockWidget
 from hypercoast_qgis.dialogs.spectral_plot_dialog import SpectralPlotDialog
+from hypercoast_qgis.dialogs.tanager_search_dialog import TanagerSearchDialog
 from hypercoast_qgis.dialogs.update_checker import UpdateCheckerDialog
 
 
@@ -20,6 +21,7 @@ def test_plugin_windows_are_dock_widgets():
         LoadDataDialog,
         SettingsDockWidget,
         SpectralPlotDialog,
+        TanagerSearchDialog,
         UpdateCheckerDialog,
     ]
 

--- a/qgis_plugin/qt6_tests/test_hyperspectral_provider.py
+++ b/qgis_plugin/qt6_tests/test_hyperspectral_provider.py
@@ -186,6 +186,49 @@ def test_lat_lon_spectral_extraction_uses_geographic_coordinates(monkeypatch):
     np.testing.assert_array_equal(values, np.array([1.0, 10.0], dtype="float32"))
 
 
+def test_tanager_2d_geolocation_spectral_extraction(monkeypatch):
+    """Tanager y/x cubes should extract using 2D lat/lon geolocation."""
+    import hypercoast_qgis.hyperspectral_provider as provider_module
+
+    monkeypatch.setattr(provider_module, "HAS_HYPERCOAST", False)
+    dataset = xr.Dataset(
+        {
+            "toa_radiance": (
+                ("wavelength", "y", "x"),
+                np.array(
+                    [
+                        [[1.0, 2.0], [3.0, 4.0]],
+                        [[10.0, 20.0], [30.0, 40.0]],
+                    ],
+                    dtype="float32",
+                ),
+            )
+        },
+        coords={
+            "wavelength": np.array([500.0, 600.0]),
+            "latitude": (
+                ("y", "x"),
+                np.array([[30.0, 30.0], [31.0, 31.0]]),
+            ),
+            "longitude": (
+                ("y", "x"),
+                np.array([[-91.0, -90.0], [-91.0, -90.0]]),
+            ),
+        },
+    )
+    provider = HyperspectralDataset("scene_ortho_radiance_hdf5.h5", "Tanager")
+    provider.dataset = dataset
+    provider.wavelengths = dataset.coords["wavelength"].values
+    provider.crs = "EPSG:4326"
+
+    wavelengths, values = provider.extract_spectral_signature(
+        -90.1, 30.9, crs="EPSG:4326"
+    )
+
+    np.testing.assert_array_equal(wavelengths, np.array([500.0, 600.0]))
+    np.testing.assert_array_equal(values, np.array([4.0, 40.0], dtype="float32"))
+
+
 def test_emit_runtime_export_accepts_written_file_when_return_is_none(
     tmp_path, monkeypatch
 ):

--- a/qgis_plugin/qt6_tests/test_hyperspectral_provider.py
+++ b/qgis_plugin/qt6_tests/test_hyperspectral_provider.py
@@ -8,6 +8,25 @@ xr = pytest.importorskip("xarray")
 from hypercoast_qgis.hyperspectral_provider import HyperspectralDataset
 
 
+def test_tanager_hdf5_asset_filename_auto_detects_tanager():
+    """Tanager asset filenames should not fall through to Generic."""
+    provider = HyperspectralDataset("20240925_185509_74_4001_ortho_radiance_hdf5.h5")
+
+    assert provider.data_type == "Tanager"
+
+
+def test_tanager_hdf5_content_auto_detects_custom_filename(tmp_path):
+    """Renamed Tanager HDF5 files should still auto-detect by content."""
+    h5py = pytest.importorskip("h5py")
+    filepath = tmp_path / "custom_name.h5"
+    with h5py.File(filepath, "w") as h5_file:
+        h5_file.create_dataset("product/toa_radiance", shape=(2, 3, 4))
+
+    provider = HyperspectralDataset(str(filepath))
+
+    assert provider.data_type == "Tanager"
+
+
 def test_pace_bgc_prefers_raster_product_over_tilt():
     """PACE BGC products should select a 2D geophysical raster variable."""
     dataset = xr.Dataset(

--- a/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
+++ b/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
@@ -1,0 +1,483 @@
+"""Tests for the Tanager search dock helpers."""
+
+import os
+from datetime import datetime
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from qgis.PyQt.QtWidgets import QApplication, QHeaderView
+
+import hypercoast_qgis.dialogs.tanager_search_dialog as dialog_module
+from hypercoast_qgis.dialogs.tanager_search_dialog import (
+    TANAGER_HDF5_ASSET,
+    TANAGER_VISUAL_ASSET,
+    TanagerSearchDialog,
+    TanagerSearchWorker,
+    _asset_url,
+    _stac_browser_url,
+)
+from hypercoast_qgis.hypercoast_plugin import HyperCoastPlugin
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Return a QApplication for widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class _Extent:
+    """Small extent-like object."""
+
+    def xMinimum(self):
+        """Return xmin."""
+        return -122.0
+
+    def yMinimum(self):
+        """Return ymin."""
+        return 37.0
+
+    def xMaximum(self):
+        """Return xmax."""
+        return -121.0
+
+    def yMaximum(self):
+        """Return ymax."""
+        return 38.0
+
+
+class _MapSettings:
+    """Small map settings-like object."""
+
+    def destinationCrs(self):
+        """Return no CRS so no transform is attempted."""
+        return None
+
+
+class _Canvas:
+    """Small map canvas-like object."""
+
+    def extent(self):
+        """Return current extent."""
+        return _Extent()
+
+    def mapSettings(self):
+        """Return map settings."""
+        return _MapSettings()
+
+
+class _Iface:
+    """Small QGIS iface-like object."""
+
+    def mainWindow(self):
+        """Return no parent window."""
+        return None
+
+    def mapCanvas(self):
+        """Return a fake map canvas."""
+        return _Canvas()
+
+
+def _dialog(qapp, monkeypatch=None, tmp_path=None, skip_global=True):
+    """Return an initialized Tanager dialog."""
+    if monkeypatch is not None and skip_global:
+        monkeypatch.setattr(
+            dialog_module.TanagerSearchDialog,
+            "add_global_footprints_layer",
+            lambda self: None,
+        )
+    if tmp_path is not None:
+        monkeypatch.setattr(
+            dialog_module,
+            "tanager_download_dir",
+            lambda project=None: str(tmp_path),
+        )
+    plugin = HyperCoastPlugin.__new__(HyperCoastPlugin)
+    plugin.register_hyperspectral_layer = lambda *args, **kwargs: None
+    return TanagerSearchDialog(_Iface(), plugin)
+
+
+def test_canvas_bbox_uses_map_extent():
+    """Canvas bbox extraction should read the current map extent."""
+    dialog = TanagerSearchDialog.__new__(TanagerSearchDialog)
+    dialog.iface = _Iface()
+
+    assert dialog.current_canvas_bbox() == [-122.0, 37.0, -121.0, 38.0]
+
+
+def test_populate_results_stores_items_and_asset_flags(qapp):
+    """Search results should populate rows with stored STAC items."""
+    dialog = _dialog(qapp)
+    item = {
+        "id": "scene-1",
+        "_collection_title": "Coastal",
+        "properties": {"datetime": "2025-01-15T00:00:00Z", "cloud_percent": 5},
+        "assets": {
+            TANAGER_VISUAL_ASSET: {"href": "https://example.com/visual.tif"},
+            TANAGER_HDF5_ASSET: {"href": "https://example.com/radiance.h5"},
+        },
+    }
+
+    dialog.populate_results([item])
+
+    assert dialog.results_table.rowCount() == 1
+    assert dialog.results_table.item(0, 0).text() == "scene-1"
+    assert dialog.results_table.item(0, 4).text() == "yes"
+    assert dialog.results_table.item(0, 5).text() == "yes"
+    assert dialog.results_table.item(0, 0).data(256) == item
+    assert (
+        dialog.results_table.horizontalHeader().sectionResizeMode(0)
+        == QHeaderView.ResizeMode.Stretch
+    )
+
+
+def test_global_footprints_layer_is_added_and_styled(qapp, monkeypatch, tmp_path):
+    """Opening the Tanager dock should add styled global footprints."""
+    added = []
+    symbols = []
+
+    class _Provider:
+        """Small provider-like object."""
+
+        def addAttributes(self, fields):
+            """Ignore fields."""
+
+        def addFeatures(self, features):
+            """Ignore features."""
+
+    class _Renderer:
+        """Small renderer-like object."""
+
+        def setSymbol(self, symbol):
+            """Record the assigned symbol."""
+            symbols.append(symbol)
+
+    class _Layer:
+        """Small vector layer-like object."""
+
+        def __init__(self, source, name, provider):
+            """Initialize layer metadata."""
+            self.source = source
+            self.name = name
+            self.provider = provider
+            self.properties = {}
+            self._renderer = _Renderer()
+
+        def isValid(self):
+            """Pretend the layer is valid."""
+            return True
+
+        def setCustomProperty(self, key, value):
+            """Record custom properties."""
+            self.properties[key] = value
+
+        def customProperty(self, key, default=None):
+            """Return custom properties."""
+            return self.properties.get(key, default)
+
+        def renderer(self):
+            """Return the renderer."""
+            return self._renderer
+
+        def triggerRepaint(self):
+            """Pretend to repaint."""
+
+    class _Project:
+        """Small project-like object."""
+
+        def mapLayers(self):
+            """Return no existing layers."""
+            return {}
+
+        def addMapLayer(self, layer):
+            """Record the added layer."""
+            added.append(layer)
+
+    monkeypatch.setattr(dialog_module, "QgsVectorLayer", _Layer)
+    monkeypatch.setattr(
+        dialog_module.QgsFillSymbol,
+        "createSimple",
+        staticmethod(lambda spec: spec),
+    )
+    monkeypatch.setattr(
+        dialog_module.QgsProject, "instance", staticmethod(lambda: _Project())
+    )
+    _dialog(qapp, tmp_path=tmp_path, monkeypatch=monkeypatch, skip_global=False)
+
+    assert len(added) == 1
+    assert added[0].properties["hypercoast/tanager_global_footprints"] == "true"
+    assert symbols[0]["outline_color"] == "0,102,204,255"
+    assert symbols[0]["color"] == "173,216,230,80"
+
+
+def test_asset_url_returns_empty_for_missing_asset():
+    """Missing Tanager assets should return an empty URL."""
+    assert _asset_url({"assets": {}}, TANAGER_VISUAL_ASSET) == ""
+
+
+def test_asset_combo_filters_to_selected_item_assets(qapp, monkeypatch, tmp_path):
+    """Selecting a result should show only HDF5 assets available on that item."""
+    dialog = _dialog(qapp, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    item = {
+        "id": "scene-1",
+        "properties": {},
+        "assets": {"ortho_sr_hdf5": {"href": "https://example.com/sr.h5"}},
+    }
+
+    dialog.populate_results([item])
+    dialog.results_table.selectRow(0)
+
+    assert dialog.asset_combo.count() == 1
+    assert dialog.asset_combo.currentData() == "ortho_sr_hdf5"
+
+
+def test_selected_global_footprints_populate_results(qapp, monkeypatch, tmp_path):
+    """Selected global footprint features should become table results."""
+    dialog = _dialog(qapp, monkeypatch=monkeypatch, tmp_path=tmp_path)
+
+    class _DateTime:
+        """Small Qt date/time-like object."""
+
+        def toPyDateTime(self):
+            """Return a Python datetime."""
+            return datetime(2025, 1, 15, 12, 30, 0)
+
+    class _Feature:
+        """Small selected feature-like object."""
+
+        def __init__(self):
+            """Initialize feature attributes."""
+            self.attrs = {
+                "id": "scene-1",
+                "title": "Scene One",
+                "datetime": _DateTime(),
+                "collection": "coastal-water-bodies",
+                "collection_title": "Coastal",
+                "stac_href": "https://example.com/item.json",
+                "asset_keys": "['ortho_visual', 'ortho_radiance_hdf5']",
+            }
+
+        def attribute(self, name):
+            """Return a feature attribute."""
+            return self.attrs.get(name)
+
+    class _Layer:
+        """Small global footprint layer-like object."""
+
+        def customProperty(self, key, default=None):
+            """Return global footprint marker."""
+            if key == "hypercoast/tanager_global_footprints":
+                return "true"
+            return default
+
+        def selectedFeatures(self):
+            """Return selected features."""
+            return [_Feature()]
+
+    class _Project:
+        """Small project-like object."""
+
+        def mapLayers(self):
+            """Return a global footprint layer."""
+            return {"layer-1": _Layer()}
+
+    monkeypatch.setattr(
+        dialog_module.QgsProject, "instance", staticmethod(lambda: _Project())
+    )
+
+    dialog.populate_from_selected_footprints()
+
+    item = dialog.results_table.item(0, 0).data(256)
+    assert dialog.results_table.rowCount() == 1
+    assert dialog.results_table.item(0, 0).text() == "scene-1"
+    assert dialog.results_table.item(0, 1).text() == "2025-01-15T12:30:00"
+    assert dialog.results_table.item(0, 4).text() == "yes"
+    assert dialog.results_table.item(0, 5).text() == "yes"
+    assert dialog.results_table.selectionModel().selectedRows()[0].row() == 0
+    assert item["_stac_url"] == "https://example.com/item.json"
+    assert "ortho_radiance_hdf5" in item["assets"]
+
+
+def test_hydrated_selected_item_fetches_stac_asset_urls(qapp, monkeypatch, tmp_path):
+    """Lightweight footprint rows should hydrate one STAC item on demand."""
+    dialog = _dialog(qapp, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    item = {
+        "id": "scene-1",
+        "_stac_url": "https://example.com/item.json",
+        "properties": {},
+        "assets": {"ortho_visual": {}, "ortho_radiance_hdf5": {}},
+    }
+    dialog.populate_results([item])
+    dialog.results_table.selectRow(0)
+
+    class _Response:
+        """Small HTTP response-like object."""
+
+        def __enter__(self):
+            """Return response context."""
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            """Exit response context."""
+
+        def read(self):
+            """Return STAC JSON bytes."""
+            return (
+                b'{"id": "scene-1", "assets": {'
+                b'"ortho_visual": {"href": "https://example.com/visual.tif"},'
+                b'"ortho_radiance_hdf5": {"href": "https://example.com/rad.h5"}}}'
+            )
+
+    monkeypatch.setattr(
+        dialog_module.urllib.request,
+        "urlopen",
+        lambda url, timeout=30: _Response(),
+    )
+
+    hydrated = dialog.hydrated_selected_item()
+
+    assert hydrated["assets"]["ortho_visual"]["href"].endswith("visual.tif")
+    assert hydrated["_stac_url"] == "https://example.com/item.json"
+
+
+def test_open_stac_item_uses_planet_browser_url(qapp, monkeypatch, tmp_path):
+    """Open STAC should convert raw STAC URLs to browser URLs."""
+    dialog = _dialog(qapp, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    item = {
+        "id": "scene-1",
+        "_stac_url": (
+            "https://www.planet.com/data/stac/tanager-core-imagery/agriculture/"
+            "20250223_165538_00_4001/20250223_165538_00_4001.json"
+        ),
+        "properties": {},
+        "assets": {},
+    }
+    opened = []
+    monkeypatch.setattr(
+        dialog_module.QDesktopServices,
+        "openUrl",
+        lambda url: opened.append(url.toString()),
+    )
+    dialog.populate_results([item])
+    dialog.results_table.selectRow(0)
+
+    dialog.open_stac_item()
+
+    assert opened == [
+        "https://www.planet.com/data/stac/browser/tanager-core-imagery/"
+        "agriculture/20250223_165538_00_4001/"
+        "20250223_165538_00_4001.json"
+    ]
+
+
+def test_stac_browser_url_keeps_existing_browser_url():
+    """Existing browser STAC URLs should be preserved."""
+    url = "https://www.planet.com/data/stac/browser/a/b/item.json"
+
+    assert _stac_browser_url(url) == url
+
+
+def test_download_uses_selected_folder_and_asset(qapp, monkeypatch, tmp_path):
+    """Download should pass the selected folder and asset to the worker."""
+    dialog = _dialog(qapp, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    item = {
+        "id": "scene-1",
+        "properties": {"title": "Scene One"},
+        "assets": {"basic_sr_hdf5": {"href": "https://example.com/sr.h5"}},
+    }
+    dialog.populate_results([item])
+    dialog.results_table.selectRow(0)
+    dialog.download_dir_edit.setText(str(tmp_path))
+    monkeypatch.setattr(
+        dialog_module,
+        "create_generated_raster_path",
+        lambda *args, **kwargs: str(tmp_path / "out.tif"),
+    )
+    recorded = {}
+
+    class _Signal:
+        """Small Qt signal-like object."""
+
+        def connect(self, callback):
+            """Ignore signal connections."""
+
+    class _Worker:
+        """Small worker-like object."""
+
+        def __init__(self, item, asset_key, out_dir, output_path, wavelengths, parent):
+            """Record worker arguments."""
+            recorded.update(
+                {
+                    "item": item,
+                    "asset_key": asset_key,
+                    "out_dir": out_dir,
+                    "output_path": output_path,
+                    "wavelengths": wavelengths,
+                    "parent": parent,
+                }
+            )
+            self.progress = _Signal()
+            self.finished = _Signal()
+
+        def isRunning(self):
+            """Return that the worker is idle."""
+            return False
+
+        def start(self):
+            """Record that the worker started."""
+            recorded["started"] = True
+
+    monkeypatch.setattr(dialog_module, "TanagerDownloadLoadWorker", _Worker)
+
+    dialog.download_hdf5()
+
+    assert recorded["asset_key"] == "basic_sr_hdf5"
+    assert recorded["out_dir"] == str(tmp_path)
+    assert recorded["started"]
+
+
+def test_search_worker_reports_errors(qapp, monkeypatch):
+    """Search worker should emit an error instead of raising."""
+    import hypercoast_qgis._hypercoast_lib as lib
+
+    def _raise():
+        """Raise a fake dependency error."""
+        raise RuntimeError("missing dependency")
+
+    monkeypatch.setattr(lib, "get_hypercoast", _raise)
+    worker = TanagerSearchWorker({})
+    emitted = []
+    worker.finished.connect(lambda items, gdf, error: emitted.append(error))
+
+    worker.run()
+
+    assert emitted == ["missing dependency"]
+
+
+def test_tanager_action_is_dependency_gated():
+    """The Tanager dock action should respect plugin dependency gating."""
+    plugin = HyperCoastPlugin.__new__(HyperCoastPlugin)
+    plugin._deps_available = False
+    plugin.warning_shown = False
+    plugin._show_deps_required_warning = lambda: setattr(plugin, "warning_shown", True)
+
+    class _Action:
+        """Small action-like object."""
+
+        def __init__(self):
+            """Initialize checked state."""
+            self.checked = True
+
+        def setChecked(self, checked):
+            """Store checked state."""
+            self.checked = checked
+
+    plugin.tanager_search_action = _Action()
+
+    plugin.show_tanager_search_dialog()
+
+    assert plugin.warning_shown
+    assert not plugin.tanager_search_action.checked

--- a/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
+++ b/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
@@ -8,6 +8,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 import pytest
 from qgis.PyQt.QtWidgets import QApplication, QHeaderView
 
+import hypercoast_qgis.hypercoast_plugin as plugin_module
 import hypercoast_qgis.dialogs.tanager_search_dialog as dialog_module
 from hypercoast_qgis.dialogs.tanager_search_dialog import (
     TANAGER_HDF5_ASSET,
@@ -496,3 +497,42 @@ def test_tanager_action_is_dependency_gated():
 
     assert plugin.warning_shown
     assert not plugin.tanager_search_action.checked
+
+
+def test_tanager_action_is_first_toolbar_icon(qapp, monkeypatch):
+    """The Tanager search action should be first in the toolbar."""
+    added_actions = []
+
+    class _Toolbar:
+        """Small toolbar-like object."""
+
+        def addAction(self, action):
+            """Record added toolbar action."""
+            added_actions.append(action)
+
+    class _Iface:
+        """Small QGIS iface-like object."""
+
+        def mainWindow(self):
+            """Return no parent window."""
+            return None
+
+        def addPluginToRasterMenu(self, menu, action):
+            """Ignore menu registration."""
+
+    plugin = HyperCoastPlugin.__new__(HyperCoastPlugin)
+    plugin.iface = _Iface()
+    plugin.plugin_dir = os.path.dirname(os.path.dirname(dialog_module.__file__))
+    plugin.actions = []
+    plugin.menu = plugin.tr("&HyperCoast")
+    plugin.toolbar = _Toolbar()
+    monkeypatch.setattr(plugin_module.QTimer, "singleShot", lambda *args: None)
+    monkeypatch.setattr(
+        plugin,
+        "_connect_project_signals",
+        lambda: None,
+    )
+
+    plugin.initGui()
+
+    assert added_actions[0].text() == "Search Tanager Data"

--- a/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
+++ b/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
@@ -143,6 +143,70 @@ def test_populate_results_stores_items_and_asset_flags(qapp):
     )
 
 
+def test_search_finished_adds_footprints_without_gdf(qapp, monkeypatch, tmp_path):
+    """STAC search results should add footprints without GeoDataFrame output."""
+    dialog = _dialog(qapp, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    recorded = {}
+
+    def _add_footprints_layer(**kwargs):
+        """Record footprint layer creation arguments."""
+        recorded.update(kwargs)
+
+    monkeypatch.setattr(dialog, "add_footprints_layer", _add_footprints_layer)
+
+    dialog._on_search_finished([{"id": "scene-1", "properties": {}}], None, "")
+
+    assert dialog.gdf is None
+    assert recorded == {"show_message": False, "zoom": True, "replace": True}
+
+
+def test_table_selection_selects_matching_result_footprint(qapp, monkeypatch, tmp_path):
+    """Selecting a result row should select the matching map footprint."""
+    dialog = _dialog(qapp, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    selected = []
+
+    class _Feature:
+        """Small feature-like object."""
+
+        def __init__(self, feature_id, item_id):
+            """Initialize feature identifiers."""
+            self.feature_id = feature_id
+            self.item_id = item_id
+
+        def id(self):
+            """Return the feature id."""
+            return self.feature_id
+
+        def attribute(self, name):
+            """Return the requested attribute."""
+            if name == "id":
+                return self.item_id
+            return None
+
+    class _Layer:
+        """Small vector layer-like object."""
+
+        def getFeatures(self):
+            """Return footprint features."""
+            return [_Feature(11, "scene-1"), _Feature(22, "scene-2")]
+
+        def selectByIds(self, feature_ids):
+            """Record selected feature ids."""
+            selected[:] = feature_ids
+
+    dialog._result_footprints_layer = _Layer()
+    dialog.populate_results(
+        [
+            {"id": "scene-1", "properties": {}, "geometry": {"type": "Point"}},
+            {"id": "scene-2", "properties": {}, "geometry": {"type": "Point"}},
+        ]
+    )
+
+    dialog.results_table.selectRow(1)
+
+    assert selected == [22]
+
+
 def test_global_footprints_layer_is_added_and_styled(qapp, monkeypatch, tmp_path):
     """Opening the Tanager dock should add styled global footprints."""
     added = []
@@ -471,6 +535,33 @@ def test_search_worker_reports_errors(qapp, monkeypatch):
     worker.run()
 
     assert emitted == ["missing dependency"]
+
+
+def test_search_worker_requests_items_without_geodataframe(qapp, monkeypatch):
+    """Search worker should avoid GeoDataFrame creation for faster searches."""
+    import hypercoast_qgis._hypercoast_lib as lib
+
+    recorded = {}
+
+    class _HyperCoast:
+        """Fake HyperCoast module."""
+
+        def search_tanager(self, **params):
+            """Record search parameters and return items."""
+            recorded.update(params)
+            return [{"id": "scene-1"}]
+
+    monkeypatch.setattr(lib, "get_hypercoast", lambda: _HyperCoast())
+    worker = TanagerSearchWorker({"count": 1})
+    emitted = []
+    worker.finished.connect(
+        lambda items, gdf, error: emitted.append((items, gdf, error))
+    )
+
+    worker.run()
+
+    assert recorded["return_gdf"] is False
+    assert emitted == [([{"id": "scene-1"}], None, "")]
 
 
 def test_tanager_action_is_dependency_gated():

--- a/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
+++ b/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
@@ -14,6 +14,7 @@ from hypercoast_qgis.dialogs.tanager_search_dialog import (
     TANAGER_VISUAL_ASSET,
     TanagerSearchDialog,
     TanagerSearchWorker,
+    _asset_filename,
     _asset_url,
     _stac_browser_url,
 )
@@ -106,6 +107,13 @@ def test_canvas_bbox_uses_map_extent():
     dialog.iface = _Iface()
 
     assert dialog.current_canvas_bbox() == [-122.0, 37.0, -121.0, 38.0]
+
+
+def test_dialog_minimum_width_is_compact(qapp, monkeypatch, tmp_path):
+    """The Tanager dock should fit into a compact side panel."""
+    dialog = _dialog(qapp, monkeypatch=monkeypatch, tmp_path=tmp_path)
+
+    assert dialog.minimumWidth() == 520
 
 
 def test_populate_results_stores_items_and_asset_flags(qapp):
@@ -380,8 +388,15 @@ def test_stac_browser_url_keeps_existing_browser_url():
     assert _stac_browser_url(url) == url
 
 
-def test_download_uses_selected_folder_and_asset(qapp, monkeypatch, tmp_path):
-    """Download should pass the selected folder and asset to the worker."""
+def test_asset_filename_ignores_query_string():
+    """Asset filenames should be parsed from URL paths."""
+    url = "https://example.com/data/scene_ortho_radiance_hdf5.h5?token=abc"
+
+    assert _asset_filename(url) == "scene_ortho_radiance_hdf5.h5"
+
+
+def test_download_prompts_for_save_path_and_asset(qapp, monkeypatch, tmp_path):
+    """Download should prompt for a destination HDF5 path."""
     dialog = _dialog(qapp, monkeypatch=monkeypatch, tmp_path=tmp_path)
     item = {
         "id": "scene-1",
@@ -391,10 +406,11 @@ def test_download_uses_selected_folder_and_asset(qapp, monkeypatch, tmp_path):
     dialog.populate_results([item])
     dialog.results_table.selectRow(0)
     dialog.download_dir_edit.setText(str(tmp_path))
+    save_path = str(tmp_path / "custom.h5")
     monkeypatch.setattr(
-        dialog_module,
-        "create_generated_raster_path",
-        lambda *args, **kwargs: str(tmp_path / "out.tif"),
+        dialog_module.QFileDialog,
+        "getSaveFileName",
+        staticmethod(lambda *args, **kwargs: (save_path, "")),
     )
     recorded = {}
 
@@ -407,15 +423,13 @@ def test_download_uses_selected_folder_and_asset(qapp, monkeypatch, tmp_path):
     class _Worker:
         """Small worker-like object."""
 
-        def __init__(self, item, asset_key, out_dir, output_path, wavelengths, parent):
+        def __init__(self, item, asset_key, output_path, parent):
             """Record worker arguments."""
             recorded.update(
                 {
                     "item": item,
                     "asset_key": asset_key,
-                    "out_dir": out_dir,
                     "output_path": output_path,
-                    "wavelengths": wavelengths,
                     "parent": parent,
                 }
             )
@@ -430,12 +444,13 @@ def test_download_uses_selected_folder_and_asset(qapp, monkeypatch, tmp_path):
             """Record that the worker started."""
             recorded["started"] = True
 
-    monkeypatch.setattr(dialog_module, "TanagerDownloadLoadWorker", _Worker)
+    monkeypatch.setattr(dialog_module, "TanagerDownloadWorker", _Worker)
 
     dialog.download_hdf5()
 
     assert recorded["asset_key"] == "basic_sr_hdf5"
-    assert recorded["out_dir"] == str(tmp_path)
+    assert recorded["output_path"] == save_path
+    assert dialog.download_dir_edit.text() == str(tmp_path)
     assert recorded["started"]
 
 


### PR DESCRIPTION
## Summary
- Add a dockable Tanager search panel that queries Planet Tanager STAC scenes from QGIS
- Support adding footprint layers, opening orthorectified visual imagery, and downloading radiance HDF5 assets
- Wire the new dialog into the plugin actions, dev-mode reload, dock tracking, and Qt6 dock panel tests

## Test plan
- [x] pre-commit run --all-files
- [ ] Load the plugin in QGIS 3.x and confirm Search Tanager Data dock opens and runs a STAC query
- [ ] Verify footprint, visual asset, and radiance HDF5 download actions work end to end
- [ ] Run qt6_tests/test_tanager_search_dialog.py on QGIS 4.x preview