### PR TITLE
feat: add NASA AppEEARS integration for EMIT data access

### DIFF
--- a/docs/appeears.md
+++ b/docs/appeears.md
@@ -1,0 +1,3 @@
+# appeears module
+
+::: hypercoast.appeears

--- a/docs/examples/appeears_emit_area.ipynb
+++ b/docs/examples/appeears_emit_area.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "0",
    "metadata": {},
    "source": [
     "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/HyperCoast/blob/main/docs/examples/appeears_emit_area.ipynb)\n",
@@ -14,6 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,6 +25,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "Log in to AppEEARS. This uses your saved Earthdata credentials, environment variables, or netrc credentials when available."
@@ -39,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,6 +52,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5",
    "metadata": {},
    "source": [
     "Choose a small set of EMIT reflectance wavelengths. HyperCoast converts these wavelengths to the nearest AppEEARS band layers."
@@ -55,6 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,6 +72,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7",
    "metadata": {},
    "source": [
     "Build and submit a small area request. The bounding box is `[xmin, ymin, xmax, ymax]` in longitude and latitude."
@@ -73,6 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,6 +101,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9",
    "metadata": {},
    "source": [
     "Wait for the task, download the GeoTIFF files, and stack them into a small hyperspectral cube."
@@ -100,6 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,6 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,6 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/examples/appeears_emit_area.ipynb
+++ b/docs/examples/appeears_emit_area.ipynb
@@ -29,6 +29,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
     "import hypercoast"
    ]
   },
@@ -75,7 +77,7 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "Build and submit a small area request. The bounding box is `[xmin, ymin, xmax, ymax]` in longitude and latitude."
+    "Build and submit a small area request. The bounding box is `[xmin, ymin, xmax, ymax]` in longitude and latitude. For EMIT area tasks, HyperCoast includes the AppEEARS orthorectification option automatically."
    ]
   },
   {
@@ -104,7 +106,7 @@
    "id": "9",
    "metadata": {},
    "source": [
-    "Wait for the task, download the GeoTIFF files, and stack them into a small hyperspectral cube."
+    "Wait for the task, download the NetCDF files, and stack them into a small hyperspectral cube."
    ]
   },
   {
@@ -121,9 +123,9 @@
     "    task_id,\n",
     "    out_dir=\"data/appeears_emit_area\",\n",
     "    client=client,\n",
-    "    file_types=[\"tif\"],\n",
     ")\n",
-    "files[:3]"
+    "nc_files = [file for file in files if Path(file).suffix.lower() in {\".nc\", \".nc4\"}]\n",
+    "nc_files"
    ]
   },
   {
@@ -139,7 +141,7 @@
     "    return_metadata=True,\n",
     ")\n",
     "\n",
-    "dataset = hypercoast.read_appeears(files, layers=metadata)\n",
+    "dataset = hypercoast.read_appeears(nc_files, layers=metadata)\n",
     "dataset"
    ]
   },
@@ -150,7 +152,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset[\"reflectance\"].sel(wavelength=650, method=\"nearest\").plot.imshow(cmap=\"viridis\")"
+    "band = dataset[\"reflectance\"].sel(wavelength=650, method=\"nearest\")\n",
+    "if \"time\" in band.dims:\n",
+    "    band = band.isel(time=0)\n",
+    "band.plot.imshow(cmap=\"viridis\")"
    ]
   }
  ],

--- a/docs/examples/appeears_emit_area.ipynb
+++ b/docs/examples/appeears_emit_area.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/HyperCoast/blob/main/docs/examples/appeears_emit_area.ipynb)\n",
+    "\n",
+    "# Request EMIT hyperspectral bands with AppEEARS\n",
+    "\n",
+    "This notebook uses a compact HyperCoast API to request selected EMIT surface reflectance bands from NASA AppEEARS for a small area."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"hypercoast[extra]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hypercoast"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Log in to AppEEARS. This uses your saved Earthdata credentials, environment variables, or netrc credentials when available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = hypercoast.appeears_login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Choose a small set of EMIT reflectance wavelengths. HyperCoast converts these wavelengths to the nearest AppEEARS band layers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wavelengths = [560, 650, 865, 1640, 2210]\n",
+    "layers = hypercoast.appeears_emit_layers(wavelengths, client=client)\n",
+    "layers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Build and submit a small area request. The bounding box is `[xmin, ymin, xmax, ymax]` in longitude and latitude."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bbox = [-118.45, 33.85, -118.25, 34.05]\n",
+    "\n",
+    "task = hypercoast.appeears_area_task(\n",
+    "    task_name=\"emit_hyperspectral_area\",\n",
+    "    geometry=bbox,\n",
+    "    layers=layers,\n",
+    "    start_date=\"2024-04-01\",\n",
+    "    end_date=\"2024-04-30\",\n",
+    ")\n",
+    "\n",
+    "response = hypercoast.appeears_submit_task(task, client=client)\n",
+    "response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Wait for the task, download the GeoTIFF files, and stack them into a small hyperspectral cube."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task_id = response[\"task_id\"]\n",
+    "hypercoast.appeears_wait(task_id, client=client, interval=60)\n",
+    "\n",
+    "files = hypercoast.appeears_download(\n",
+    "    task_id,\n",
+    "    out_dir=\"data/appeears_emit_area\",\n",
+    "    client=client,\n",
+    "    file_types=[\"tif\"],\n",
+    ")\n",
+    "files[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metadata = hypercoast.appeears_emit_layers(\n",
+    "    wavelengths,\n",
+    "    client=client,\n",
+    "    return_metadata=True,\n",
+    ")\n",
+    "\n",
+    "dataset = hypercoast.read_appeears(files, layers=metadata)\n",
+    "dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset[\"reflectance\"].sel(wavelength=650, method=\"nearest\").plot.imshow(cmap=\"viridis\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/appeears_emit_point.ipynb
+++ b/docs/examples/appeears_emit_point.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "0",
    "metadata": {},
    "source": [
     "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/HyperCoast/blob/main/docs/examples/appeears_emit_point.ipynb)\n",
@@ -14,6 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,6 +25,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,6 +37,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "Log in and select EMIT reflectance layers by wavelength."
@@ -42,6 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,6 +64,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5",
    "metadata": {},
    "source": [
     "Build and submit a point task. Point coordinates use `(longitude, latitude)`."
@@ -67,6 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,6 +91,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7",
    "metadata": {},
    "source": [
     "Wait for the task and download the CSV result."
@@ -92,6 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,6 +118,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9",
    "metadata": {},
    "source": [
     "Read the point table and keep the EMIT band columns."
@@ -117,6 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,14 +139,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
     "wavelength_by_layer = {item[\"layer\"]: item[\"wavelength\"] for item in metadata}\n",
     "band_columns = [column for column in df.columns if \"EMIT_L2A_RFL_001_B\" in column]\n",
     "wavelength_by_column = {\n",
-    "    column: wavelength_by_layer[column.split(\"_\")[-1]]\n",
-    "    for column in band_columns\n",
+    "    column: wavelength_by_layer[column.split(\"_\")[-1]] for column in band_columns\n",
     "}\n",
     "spectrum = df[band_columns].mean().rename(index=wavelength_by_column)\n",
     "spectrum.index.name = \"wavelength\"\n",

--- a/docs/examples/appeears_emit_point.ipynb
+++ b/docs/examples/appeears_emit_point.ipynb
@@ -52,7 +52,8 @@
    "source": [
     "client = hypercoast.appeears_login()\n",
     "\n",
-    "wavelengths = [490, 560, 650, 705, 865, 1640, 2210]\n",
+    "# wavelengths = [490, 560, 650, 705, 865, 1640, 2210]\n",
+    "wavelengths = None\n",
     "metadata = hypercoast.appeears_emit_layers(\n",
     "    wavelengths,\n",
     "    client=client,\n",
@@ -112,6 +113,7 @@
     "    out_dir=\"data/appeears_emit_point\",\n",
     "    client=client,\n",
     "    file_types=[\"csv\"],\n",
+    "    overwrite=True,\n",
     ")\n",
     "files"
    ]
@@ -121,7 +123,7 @@
    "id": "9",
    "metadata": {},
    "source": [
-    "Read the point table and keep the EMIT band columns."
+    "Read the point table and plot the returned spectrum."
    ]
   },
   {
@@ -131,7 +133,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "csv_file = next(Path(\"data/appeears_emit_point\").glob(\"*.csv\"))\n",
+    "csv_file = (\n",
+    "    Path(files[0]) if files else next(Path(\"data/appeears_emit_point\").glob(\"*.csv\"))\n",
+    ")\n",
     "df = pd.read_csv(csv_file)\n",
     "df.head()"
    ]
@@ -143,14 +147,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wavelength_by_layer = {item[\"layer\"]: item[\"wavelength\"] for item in metadata}\n",
-    "band_columns = [column for column in df.columns if \"EMIT_L2A_RFL_001_B\" in column]\n",
-    "wavelength_by_column = {\n",
-    "    column: wavelength_by_layer[column.split(\"_\")[-1]] for column in band_columns\n",
-    "}\n",
-    "spectrum = df[band_columns].mean().rename(index=wavelength_by_column)\n",
+    "if {\"wavelength\", \"reflectance\"}.issubset(df.columns):\n",
+    "    spectrum = (\n",
+    "        df.dropna(subset=[\"wavelength\", \"reflectance\"])\n",
+    "        .sort_values(\"wavelength\")\n",
+    "        .groupby(\"wavelength\")[\"reflectance\"]\n",
+    "        .mean()\n",
+    "    )\n",
+    "else:\n",
+    "    wavelength_by_layer = {item[\"layer\"]: item[\"wavelength\"] for item in metadata}\n",
+    "    band_columns = [column for column in df.columns if \"EMIT_L2A_RFL_001_B\" in column]\n",
+    "    wavelength_by_column = {\n",
+    "        column: wavelength_by_layer[column.split(\"_\")[-1]] for column in band_columns\n",
+    "    }\n",
+    "    spectrum = df[band_columns].mean().rename(index=wavelength_by_column).sort_index()\n",
+    "\n",
     "spectrum.index.name = \"wavelength\"\n",
     "spectrum.plot(marker=\"o\", xlabel=\"Wavelength (nm)\", ylabel=\"Reflectance\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "![](https://github.com/user-attachments/assets/60f6d9ee-c8c4-4c8c-b362-79e17f476ae8)"
    ]
   }
  ],

--- a/docs/examples/appeears_emit_point.ipynb
+++ b/docs/examples/appeears_emit_point.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/HyperCoast/blob/main/docs/examples/appeears_emit_point.ipynb)\n",
+    "\n",
+    "# Request an EMIT point spectrum with AppEEARS\n",
+    "\n",
+    "This notebook requests selected EMIT surface reflectance wavelengths for one point with the HyperCoast AppEEARS helpers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"hypercoast[extra]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "import hypercoast"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Log in and select EMIT reflectance layers by wavelength."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = hypercoast.appeears_login()\n",
+    "\n",
+    "wavelengths = [490, 560, 650, 705, 865, 1640, 2210]\n",
+    "metadata = hypercoast.appeears_emit_layers(\n",
+    "    wavelengths,\n",
+    "    client=client,\n",
+    "    return_metadata=True,\n",
+    ")\n",
+    "layers = [{\"product\": item[\"product\"], \"layer\": item[\"layer\"]} for item in metadata]\n",
+    "layers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Build and submit a point task. Point coordinates use `(longitude, latitude)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task = hypercoast.appeears_point_task(\n",
+    "    task_name=\"emit_hyperspectral_point\",\n",
+    "    coordinates=(-118.33, 33.96),\n",
+    "    layers=layers,\n",
+    "    start_date=\"2024-04-01\",\n",
+    "    end_date=\"2024-04-30\",\n",
+    ")\n",
+    "\n",
+    "response = hypercoast.appeears_submit_task(task, client=client)\n",
+    "response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Wait for the task and download the CSV result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task_id = response[\"task_id\"]\n",
+    "hypercoast.appeears_wait(task_id, client=client, interval=60)\n",
+    "\n",
+    "files = hypercoast.appeears_download(\n",
+    "    task_id,\n",
+    "    out_dir=\"data/appeears_emit_point\",\n",
+    "    client=client,\n",
+    "    file_types=[\"csv\"],\n",
+    ")\n",
+    "files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read the point table and keep the EMIT band columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv_file = next(Path(\"data/appeears_emit_point\").glob(\"*.csv\"))\n",
+    "df = pd.read_csv(csv_file)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wavelength_by_layer = {item[\"layer\"]: item[\"wavelength\"] for item in metadata}\n",
+    "band_columns = [column for column in df.columns if \"EMIT_L2A_RFL_001_B\" in column]\n",
+    "wavelength_by_column = {\n",
+    "    column: wavelength_by_layer[column.split(\"_\")[-1]]\n",
+    "    for column in band_columns\n",
+    "}\n",
+    "spectrum = df[band_columns].mean().rename(index=wavelength_by_column)\n",
+    "spectrum.index.name = \"wavelength\"\n",
+    "spectrum.plot(marker=\"o\", xlabel=\"Wavelength (nm)\", ylabel=\"Reflectance\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/hypercoast/appeears.py
+++ b/hypercoast/appeears.py
@@ -13,7 +13,6 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
-
 APPEEARS_API_URL = "https://appeears.earthdatacloud.nasa.gov/api/"
 EMIT_REFLECTANCE_PRODUCT = "EMIT_L2A_RFL.001"
 _WAVELENGTH_RE = re.compile(

--- a/hypercoast/appeears.py
+++ b/hypercoast/appeears.py
@@ -1,0 +1,1049 @@
+# SPDX-FileCopyrightText: 2026 Qiusheng Wu <giswqs@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Utilities for submitting and downloading NASA AppEEARS tasks."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+
+APPEEARS_API_URL = "https://appeears.earthdatacloud.nasa.gov/api/"
+EMIT_REFLECTANCE_PRODUCT = "EMIT_L2A_RFL.001"
+_WAVELENGTH_RE = re.compile(
+    r"Wavelength:\s*([0-9]+(?:\.[0-9]+)?)\s*nm"
+    r"(?:,\s*FWHM:\s*([0-9]+(?:\.[0-9]+)?)\s*nm)?"
+)
+_BAND_RE = re.compile(r"(?:^|[_\-.])(B\d{3})(?:_GW)?(?:$|[_\-.])")
+
+
+class AppEEARSClient:
+    """Client for the NASA AppEEARS API.
+
+    Args:
+        api_url: Base URL for the AppEEARS API.
+        token: Existing AppEEARS bearer token.
+        session: Optional requests-compatible session.
+    """
+
+    def __init__(
+        self,
+        api_url: str = APPEEARS_API_URL,
+        token: Optional[str] = None,
+        session: Optional[Any] = None,
+    ) -> None:
+        import requests
+
+        self.api_url = api_url.rstrip("/") + "/"
+        self.token = token
+        self.session = session or requests.Session()
+
+    @property
+    def headers(self) -> Dict[str, str]:
+        """Return authorization headers for authenticated requests.
+
+        Returns:
+            Dictionary containing the bearer token header when a token exists.
+        """
+
+        if self.token is None:
+            return {}
+        return {"Authorization": f"Bearer {self.token}"}
+
+    def login(
+        self,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Authenticate with AppEEARS.
+
+        Args:
+            username: NASA Earthdata username. If omitted, environment variables
+                or a netrc entry for urs.earthdata.nasa.gov are used.
+            password: NASA Earthdata password.
+            token: Existing AppEEARS token. When provided, no login request is
+                sent.
+
+        Returns:
+            AppEEARS login response containing the bearer token.
+        """
+
+        if token is not None:
+            self.token = token
+            return {"token": token}
+
+        if username is None:
+            username = os.environ.get("EARTHDATA_USERNAME")
+        if password is None:
+            password = os.environ.get("EARTHDATA_PASSWORD")
+
+        if username is None or password is None:
+            try:
+                from netrc import netrc
+
+                auth = netrc().authenticators("urs.earthdata.nasa.gov")
+            except (FileNotFoundError, OSError):
+                auth = None
+            if auth is not None:
+                username = username or auth[0]
+                password = password or auth[2]
+
+        if username is None or password is None:
+            raise ValueError(
+                "username and password are required unless EARTHDATA_USERNAME "
+                "and EARTHDATA_PASSWORD or a netrc entry are available."
+            )
+
+        response = self._request(
+            "post", "login", auth=(username, password), auth_header=False
+        )
+        self.token = response["token"]
+        return response
+
+    def products(
+        self,
+        keyword: Optional[str] = None,
+        platform: Optional[str] = None,
+        available: Optional[bool] = True,
+    ) -> List[Dict[str, Any]]:
+        """List AppEEARS products.
+
+        Args:
+            keyword: Case-insensitive search text matched against product fields.
+            platform: Platform name, such as ``"EMIT"``.
+            available: If set, filter by the AppEEARS availability flag.
+
+        Returns:
+            List of product metadata dictionaries.
+        """
+
+        products = self._request("get", "product", auth_header=False)
+        if keyword is not None:
+            query = keyword.lower()
+            products = [p for p in products if query in json.dumps(p).lower()]
+        if platform is not None:
+            products = [
+                p
+                for p in products
+                if str(p.get("Platform", "")).lower() == platform.lower()
+            ]
+        if available is not None:
+            products = [p for p in products if p.get("Available") is available]
+        return products
+
+    def layers(self, product: str) -> Dict[str, Dict[str, Any]]:
+        """List layers for an AppEEARS product.
+
+        Args:
+            product: Product and version string, such as ``"EMIT_L2A_RFL.001"``.
+
+        Returns:
+            Dictionary keyed by layer name.
+        """
+
+        return self._request("get", f"product/{product}", auth_header=False)
+
+    def spectral_layers(
+        self,
+        product: str = EMIT_REFLECTANCE_PRODUCT,
+        wavelengths: Optional[Sequence[float]] = None,
+        include_flags: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Return spectral layer metadata, optionally nearest to wavelengths.
+
+        Args:
+            product: AppEEARS product and version.
+            wavelengths: Target wavelengths in nanometers. If omitted, all
+                spectral bands are returned.
+            include_flags: Whether to include good wavelength flag layers.
+
+        Returns:
+            List of layer records containing product, layer, wavelength, fwhm,
+            units, description, and data type.
+        """
+
+        records = []
+        for layer, metadata in self.layers(product).items():
+            if not include_flags and layer.endswith("_GW"):
+                continue
+            pattern = r"B\d{3}(?:_GW)?" if include_flags else r"B\d{3}"
+            if not re.fullmatch(pattern, layer):
+                continue
+            record = _layer_record(product, layer, metadata)
+            if record["wavelength"] is not None:
+                records.append(record)
+
+        records.sort(key=lambda item: item["wavelength"])
+        if wavelengths is None:
+            return records
+
+        selected = []
+        used_layers = set()
+        for wavelength in wavelengths:
+            nearest = min(
+                records,
+                key=lambda item: abs(float(item["wavelength"]) - float(wavelength)),
+            )
+            if nearest["layer"] not in used_layers:
+                selected.append(nearest)
+                used_layers.add(nearest["layer"])
+        return selected
+
+    def projections(self) -> Dict[str, Any]:
+        """List AppEEARS output projections.
+
+        Returns:
+            Dictionary of AppEEARS projection metadata.
+        """
+
+        return self._request("get", "spatial/proj", auth_header=False)
+
+    def submit_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        """Submit an AppEEARS task.
+
+        Args:
+            task: AppEEARS task payload.
+
+        Returns:
+            AppEEARS task submission response.
+        """
+
+        self._require_token()
+        return self._request("post", "task", json=task)
+
+    def tasks(
+        self,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        pretty: bool = False,
+    ) -> Dict[str, Any]:
+        """List submitted AppEEARS tasks for the authenticated user.
+
+        Args:
+            limit: Maximum number of tasks to return.
+            offset: Result offset for pagination.
+            pretty: Whether AppEEARS should pretty-print the JSON response.
+
+        Returns:
+            Task list response from AppEEARS.
+        """
+
+        self._require_token()
+        params = {"pretty": pretty}
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        return self._request("get", "task", params=params)
+
+    def task(self, task_id: str) -> Dict[str, Any]:
+        """Get an AppEEARS task.
+
+        Args:
+            task_id: AppEEARS task identifier.
+
+        Returns:
+            Task metadata response.
+        """
+
+        self._require_token()
+        return self._request("get", f"task/{task_id}")
+
+    def status(self, task_id: str) -> Dict[str, Any]:
+        """Get an AppEEARS task status.
+
+        Args:
+            task_id: AppEEARS task identifier.
+
+        Returns:
+            Task status response.
+        """
+
+        self._require_token()
+        return self._request("get", f"status/{task_id}")
+
+    def wait_for_task(
+        self,
+        task_id: str,
+        interval: int = 20,
+        timeout: Optional[int] = None,
+        verbose: bool = True,
+    ) -> Dict[str, Any]:
+        """Wait for an AppEEARS task to finish.
+
+        Args:
+            task_id: AppEEARS task identifier.
+            interval: Polling interval in seconds.
+            timeout: Optional timeout in seconds.
+            verbose: Whether to print status changes.
+
+        Returns:
+            Final task metadata response.
+        """
+
+        start = time.time()
+        last_status = None
+        while True:
+            response = self.task(task_id)
+            status = response.get("status")
+            if verbose and status != last_status:
+                print(status)
+            if status == "done":
+                return response
+            if status in {"error", "failed"}:
+                raise RuntimeError(f"AppEEARS task {task_id} failed: {response}")
+            if timeout is not None and time.time() - start > timeout:
+                raise TimeoutError(f"Timed out waiting for AppEEARS task {task_id}.")
+            last_status = status
+            time.sleep(interval)
+
+    def bundle(self, task_id: str) -> Dict[str, Any]:
+        """Get bundle metadata for a completed AppEEARS task.
+
+        Args:
+            task_id: AppEEARS task identifier.
+
+        Returns:
+            Bundle metadata response.
+        """
+
+        self._require_token()
+        return self._request("get", f"bundle/{task_id}")
+
+    def download_bundle(
+        self,
+        task_id: str,
+        out_dir: Union[str, os.PathLike[str]] = ".",
+        file_ids: Optional[Iterable[str]] = None,
+        file_types: Optional[Iterable[str]] = None,
+        overwrite: bool = False,
+    ) -> List[str]:
+        """Download files from an AppEEARS task bundle.
+
+        Args:
+            task_id: AppEEARS task identifier.
+            out_dir: Output directory.
+            file_ids: Optional subset of AppEEARS file identifiers to download.
+            file_types: Optional file type filter, such as ``["tif", "csv"]``.
+            overwrite: Whether to overwrite existing files.
+
+        Returns:
+            List of downloaded file paths.
+        """
+
+        bundle = self.bundle(task_id)
+        selected_file_ids = set(file_ids) if file_ids is not None else None
+        selected_file_types = set(file_types) if file_types is not None else None
+        paths = []
+        for item in bundle.get("files", []):
+            file_id = item["file_id"]
+            if selected_file_ids is not None and file_id not in selected_file_ids:
+                continue
+            if (
+                selected_file_types is not None
+                and item.get("file_type") not in selected_file_types
+            ):
+                continue
+            path = self.download_file(
+                task_id=task_id,
+                file_id=file_id,
+                file_name=item["file_name"],
+                out_dir=out_dir,
+                overwrite=overwrite,
+            )
+            paths.append(path)
+        return paths
+
+    def download_file(
+        self,
+        task_id: str,
+        file_id: str,
+        file_name: str,
+        out_dir: Union[str, os.PathLike[str]] = ".",
+        overwrite: bool = False,
+        chunk_size: int = 8192,
+    ) -> str:
+        """Download one AppEEARS bundle file.
+
+        Args:
+            task_id: AppEEARS task identifier.
+            file_id: Bundle file identifier.
+            file_name: Bundle file name.
+            out_dir: Output directory.
+            overwrite: Whether to overwrite an existing file.
+            chunk_size: Response chunk size in bytes.
+
+        Returns:
+            Path to the downloaded file.
+        """
+
+        self._require_token()
+        out_path = _bundle_output_path(out_dir, file_name)
+        if out_path.exists() and not overwrite:
+            return str(out_path)
+
+        response = self._raw_request("get", f"bundle/{task_id}/{file_id}", stream=True)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("wb") as dst:
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                if chunk:
+                    dst.write(chunk)
+        return str(out_path)
+
+    def s3credentials(self) -> Dict[str, Any]:
+        """Request temporary S3 credentials from AppEEARS.
+
+        Returns:
+            Temporary credential response from AppEEARS.
+        """
+
+        self._require_token()
+        return self._request("get", "s3credentials")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        auth_header: bool = True,
+        **kwargs: Any,
+    ) -> Any:
+        """Send a JSON request to AppEEARS.
+
+        Args:
+            method: HTTP method name.
+            path: API path relative to the base URL.
+            auth_header: Whether to include the bearer token header.
+            **kwargs: Additional request keyword arguments.
+
+        Returns:
+            Decoded JSON response.
+        """
+
+        response = self._raw_request(method, path, auth_header=auth_header, **kwargs)
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
+
+    def _raw_request(
+        self,
+        method: str,
+        path: str,
+        auth_header: bool = True,
+        **kwargs: Any,
+    ) -> Any:
+        """Send a raw request to AppEEARS.
+
+        Args:
+            method: HTTP method name.
+            path: API path relative to the base URL.
+            auth_header: Whether to include the bearer token header.
+            **kwargs: Additional request keyword arguments.
+
+        Returns:
+            Requests response object.
+        """
+
+        headers = kwargs.pop("headers", {})
+        if auth_header:
+            headers = {**self.headers, **headers}
+        response = self.session.request(
+            method.upper(), self.api_url + path.lstrip("/"), headers=headers, **kwargs
+        )
+        response.raise_for_status()
+        return response
+
+    def _require_token(self) -> None:
+        """Raise an error when an authenticated request lacks a token."""
+
+        if self.token is None:
+            raise ValueError("Call login() or provide a token before this request.")
+
+
+def appeears_login(
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    token: Optional[str] = None,
+    api_url: str = APPEEARS_API_URL,
+) -> AppEEARSClient:
+    """Create and authenticate an AppEEARS client.
+
+    Args:
+        username: NASA Earthdata username.
+        password: NASA Earthdata password.
+        token: Existing AppEEARS token.
+        api_url: Base URL for the AppEEARS API.
+
+    Returns:
+        Authenticated AppEEARS client.
+    """
+
+    client = AppEEARSClient(api_url=api_url)
+    client.login(username=username, password=password, token=token)
+    return client
+
+
+def appeears_products(
+    keyword: Optional[str] = None,
+    platform: Optional[str] = None,
+    available: Optional[bool] = True,
+    client: Optional[AppEEARSClient] = None,
+) -> List[Dict[str, Any]]:
+    """List AppEEARS products.
+
+    Args:
+        keyword: Case-insensitive search text matched against product fields.
+        platform: Platform name, such as ``"EMIT"``.
+        available: If set, filter by the AppEEARS availability flag.
+        client: Optional AppEEARS client.
+
+    Returns:
+        List of product metadata dictionaries.
+    """
+
+    client = client or AppEEARSClient()
+    return client.products(keyword=keyword, platform=platform, available=available)
+
+
+def appeears_layers(
+    product: str,
+    client: Optional[AppEEARSClient] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """List AppEEARS layers for a product.
+
+    Args:
+        product: Product and version string.
+        client: Optional AppEEARS client.
+
+    Returns:
+        Dictionary keyed by layer name.
+    """
+
+    client = client or AppEEARSClient()
+    return client.layers(product)
+
+
+def appeears_emit_layers(
+    wavelengths: Optional[Sequence[float]] = None,
+    product: str = EMIT_REFLECTANCE_PRODUCT,
+    include_flags: bool = False,
+    return_metadata: bool = False,
+    client: Optional[AppEEARSClient] = None,
+) -> List[Dict[str, Any]]:
+    """Select EMIT AppEEARS layers by wavelength.
+
+    Args:
+        wavelengths: Target wavelengths in nanometers. If omitted, all spectral
+            EMIT bands are returned.
+        product: EMIT product and version.
+        include_flags: Whether to include good wavelength flag layers.
+        return_metadata: Whether to return wavelength metadata. If False,
+            task-ready ``{"product": product, "layer": layer}`` dictionaries
+            are returned.
+        client: Optional AppEEARS client.
+
+    Returns:
+        Selected EMIT layer records or task-ready layer dictionaries.
+    """
+
+    client = client or AppEEARSClient()
+    layers = client.spectral_layers(
+        product=product, wavelengths=wavelengths, include_flags=include_flags
+    )
+    if return_metadata:
+        return layers
+    return [{"product": item["product"], "layer": item["layer"]} for item in layers]
+
+
+def appeears_point_task(
+    task_name: str,
+    coordinates: Union[Sequence[float], Sequence[Dict[str, Any]]],
+    layers: Sequence[Dict[str, str]],
+    start_date: str,
+    end_date: str,
+    recurring: bool = False,
+    year_range: Optional[Sequence[int]] = None,
+) -> Dict[str, Any]:
+    """Build an AppEEARS point task payload.
+
+    Args:
+        task_name: AppEEARS task name.
+        coordinates: One ``(longitude, latitude)`` pair or AppEEARS coordinate
+            dictionaries containing longitude and latitude.
+        layers: Task-ready AppEEARS layers.
+        start_date: Start date as ``YYYY-MM-DD`` or ``MM-DD-YYYY``.
+        end_date: End date as ``YYYY-MM-DD`` or ``MM-DD-YYYY``.
+        recurring: Whether the task uses recurring dates.
+        year_range: Two-year range for recurring tasks.
+
+    Returns:
+        AppEEARS point task payload.
+    """
+
+    params = {
+        "dates": [
+            _date_range(
+                start_date=start_date,
+                end_date=end_date,
+                recurring=recurring,
+                year_range=year_range,
+            )
+        ],
+        "layers": list(layers),
+        "coordinates": _normalize_coordinates(coordinates),
+    }
+    return {"task_type": "point", "task_name": task_name, "params": params}
+
+
+def appeears_area_task(
+    task_name: str,
+    geometry: Any,
+    layers: Sequence[Dict[str, str]],
+    start_date: str,
+    end_date: str,
+    output_format: str = "geotiff",
+    projection: str = "geographic",
+    recurring: bool = False,
+    year_range: Optional[Sequence[int]] = None,
+) -> Dict[str, Any]:
+    """Build an AppEEARS area task payload.
+
+    Args:
+        task_name: AppEEARS task name.
+        geometry: GeoJSON geometry, feature, feature collection, GeoDataFrame,
+            vector file path, or bounding box ``[xmin, ymin, xmax, ymax]``.
+        layers: Task-ready AppEEARS layers.
+        start_date: Start date as ``YYYY-MM-DD`` or ``MM-DD-YYYY``.
+        end_date: End date as ``YYYY-MM-DD`` or ``MM-DD-YYYY``.
+        output_format: AppEEARS output format, such as ``"geotiff"`` or
+            ``"netcdf4"``.
+        projection: AppEEARS output projection name.
+        recurring: Whether the task uses recurring dates.
+        year_range: Two-year range for recurring tasks.
+
+    Returns:
+        AppEEARS area task payload.
+    """
+
+    params = {
+        "dates": [
+            _date_range(
+                start_date=start_date,
+                end_date=end_date,
+                recurring=recurring,
+                year_range=year_range,
+            )
+        ],
+        "layers": list(layers),
+        "output": {"format": {"type": output_format}, "projection": projection},
+        "geo": _normalize_geojson(geometry),
+    }
+    return {"task_type": "area", "task_name": task_name, "params": params}
+
+
+def appeears_submit_task(
+    task: Dict[str, Any],
+    client: Optional[AppEEARSClient] = None,
+) -> Dict[str, Any]:
+    """Submit an AppEEARS task.
+
+    Args:
+        task: AppEEARS task payload.
+        client: Authenticated AppEEARS client.
+
+    Returns:
+        AppEEARS task submission response.
+    """
+
+    if client is None:
+        client = appeears_login()
+    return client.submit_task(task)
+
+
+def appeears_wait(
+    task_id: str,
+    client: Optional[AppEEARSClient] = None,
+    interval: int = 20,
+    timeout: Optional[int] = None,
+    verbose: bool = True,
+) -> Dict[str, Any]:
+    """Wait for an AppEEARS task to finish.
+
+    Args:
+        task_id: AppEEARS task identifier.
+        client: Authenticated AppEEARS client.
+        interval: Polling interval in seconds.
+        timeout: Optional timeout in seconds.
+        verbose: Whether to print status changes.
+
+    Returns:
+        Final task metadata response.
+    """
+
+    if client is None:
+        client = appeears_login()
+    return client.wait_for_task(
+        task_id=task_id, interval=interval, timeout=timeout, verbose=verbose
+    )
+
+
+def appeears_download(
+    task_id: str,
+    out_dir: Union[str, os.PathLike[str]] = ".",
+    client: Optional[AppEEARSClient] = None,
+    file_types: Optional[Iterable[str]] = None,
+    overwrite: bool = False,
+) -> List[str]:
+    """Download an AppEEARS task bundle.
+
+    Args:
+        task_id: AppEEARS task identifier.
+        out_dir: Output directory.
+        client: Authenticated AppEEARS client.
+        file_types: Optional file type filter, such as ``["tif"]``.
+        overwrite: Whether to overwrite existing files.
+
+    Returns:
+        List of downloaded file paths.
+    """
+
+    if client is None:
+        client = appeears_login()
+    return client.download_bundle(
+        task_id=task_id,
+        out_dir=out_dir,
+        file_types=file_types,
+        overwrite=overwrite,
+    )
+
+
+def read_appeears(
+    files: Union[str, os.PathLike[str], Sequence[Union[str, os.PathLike[str]]]],
+    layers: Optional[Union[Dict[str, Dict[str, Any]], Sequence[Dict[str, Any]]]] = None,
+    product: str = EMIT_REFLECTANCE_PRODUCT,
+    variable: str = "reflectance",
+    client: Optional[AppEEARSClient] = None,
+    **kwargs: Any,
+) -> Any:
+    """Read AppEEARS single-band GeoTIFFs as an xarray hyperspectral cube.
+
+    Args:
+        files: GeoTIFF path, directory, or sequence of paths.
+        layers: Optional AppEEARS layer metadata from ``appeears_layers`` or
+            ``appeears_emit_layers(..., return_metadata=True)``.
+        product: AppEEARS product used to infer wavelength metadata when layers
+            are omitted.
+        variable: Output data variable name.
+        client: Optional AppEEARS client used to fetch layer metadata.
+        **kwargs: Additional keyword arguments passed to
+            ``rioxarray.open_rasterio``.
+
+    Returns:
+        xarray.Dataset containing the stacked raster data.
+    """
+
+    import rioxarray
+    import xarray as xr
+
+    paths = _coerce_paths(files)
+    if layers is None:
+        client = client or AppEEARSClient()
+        layers = client.layers(product)
+    metadata = _metadata_by_layer(product, layers)
+
+    arrays = []
+    wavelengths = []
+    band_names = []
+    for path in paths:
+        layer_name = _layer_from_filename(path)
+        if layer_name is None:
+            continue
+        layer_info = metadata.get(layer_name)
+        wavelength = None if layer_info is None else layer_info.get("wavelength")
+        if wavelength is None:
+            continue
+        data = rioxarray.open_rasterio(path, masked=True, **kwargs)
+        if "band" in data.dims and data.sizes.get("band") == 1:
+            data = data.squeeze("band", drop=True)
+        arrays.append(data)
+        wavelengths.append(float(wavelength))
+        band_names.append(layer_name)
+
+    if not arrays:
+        raise ValueError("No AppEEARS spectral GeoTIFF files could be read.")
+
+    order = sorted(range(len(wavelengths)), key=lambda index: wavelengths[index])
+    arrays = [arrays[index] for index in order]
+    wavelengths = [wavelengths[index] for index in order]
+    band_names = [band_names[index] for index in order]
+    data = xr.concat(
+        arrays,
+        dim=xr.DataArray(wavelengths, dims="wavelength", name="wavelength"),
+    )
+    dataset = data.to_dataset(name=variable)
+    dataset[variable].attrs["band_names"] = band_names
+    dataset.attrs["source"] = "NASA AppEEARS"
+    dataset.attrs["product"] = product
+    return dataset
+
+
+def _layer_record(
+    product: str,
+    layer: str,
+    metadata: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Create a normalized AppEEARS layer metadata record.
+
+    Args:
+        product: AppEEARS product and version.
+        layer: AppEEARS layer name.
+        metadata: Layer metadata response.
+
+    Returns:
+        Normalized layer metadata record.
+    """
+
+    wavelength, fwhm = _parse_wavelength(metadata.get("Description", ""))
+    return {
+        "product": product,
+        "layer": layer,
+        "wavelength": wavelength,
+        "fwhm": fwhm,
+        "units": metadata.get("Units"),
+        "description": metadata.get("Description"),
+        "data_type": metadata.get("DataType"),
+    }
+
+
+def _parse_wavelength(description: str) -> Tuple[Optional[float], Optional[float]]:
+    """Parse wavelength and FWHM values from AppEEARS layer descriptions.
+
+    Args:
+        description: AppEEARS layer description.
+
+    Returns:
+        Tuple containing wavelength and FWHM in nanometers.
+    """
+
+    match = _WAVELENGTH_RE.search(description or "")
+    if match is None:
+        return None, None
+    wavelength = float(match.group(1))
+    fwhm = float(match.group(2)) if match.group(2) is not None else None
+    return wavelength, fwhm
+
+
+def _date_range(
+    start_date: str,
+    end_date: str,
+    recurring: bool = False,
+    year_range: Optional[Sequence[int]] = None,
+) -> Dict[str, Any]:
+    """Build an AppEEARS date range dictionary.
+
+    Args:
+        start_date: Start date as ``YYYY-MM-DD`` or ``MM-DD-YYYY``.
+        end_date: End date as ``YYYY-MM-DD`` or ``MM-DD-YYYY``.
+        recurring: Whether the task uses recurring dates.
+        year_range: Two-year range for recurring tasks.
+
+    Returns:
+        AppEEARS date range dictionary.
+    """
+
+    date = {
+        "startDate": _format_appeears_date(start_date),
+        "endDate": _format_appeears_date(end_date),
+    }
+    if recurring:
+        date["recurring"] = True
+        if year_range is not None:
+            date["yearRange"] = list(year_range)
+    return date
+
+
+def _format_appeears_date(value: str) -> str:
+    """Format a date for AppEEARS.
+
+    Args:
+        value: Date string in ``YYYY-MM-DD`` or ``MM-DD-YYYY`` format.
+
+    Returns:
+        Date string in ``MM-DD-YYYY`` format.
+    """
+
+    match = re.fullmatch(r"(\d{4})-(\d{2})-(\d{2})", value)
+    if match is not None:
+        year, month, day = match.groups()
+        return f"{month}-{day}-{year}"
+    if re.fullmatch(r"\d{2}-\d{2}-\d{4}", value):
+        return value
+    raise ValueError("Dates must use YYYY-MM-DD or MM-DD-YYYY format.")
+
+
+def _normalize_coordinates(
+    coordinates: Union[Sequence[float], Sequence[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Normalize point coordinates for AppEEARS.
+
+    Args:
+        coordinates: One ``(longitude, latitude)`` pair or a sequence of
+            AppEEARS coordinate dictionaries.
+
+    Returns:
+        List of AppEEARS coordinate dictionaries.
+    """
+
+    if len(coordinates) == 2 and all(
+        isinstance(value, (int, float)) for value in coordinates
+    ):
+        lon, lat = coordinates
+        return [{"longitude": lon, "latitude": lat, "id": "point-1"}]
+
+    normalized = []
+    for index, coord in enumerate(coordinates):
+        item = dict(coord)
+        if "id" not in item:
+            item["id"] = f"point-{index + 1}"
+        normalized.append(item)
+    return normalized
+
+
+def _normalize_geojson(geometry: Any) -> Dict[str, Any]:
+    """Normalize area geometry for AppEEARS.
+
+    Args:
+        geometry: GeoJSON, GeoDataFrame, vector path, or bounding box.
+
+    Returns:
+        GeoJSON feature collection, feature, or geometry dictionary.
+    """
+
+    if isinstance(geometry, (str, os.PathLike)):
+        import geopandas as gpd
+
+        return json.loads(gpd.read_file(geometry).to_json())
+
+    if isinstance(geometry, (list, tuple)) and len(geometry) == 4:
+        xmin, ymin, xmax, ymax = geometry
+        return {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [xmin, ymin],
+                                [xmax, ymin],
+                                [xmax, ymax],
+                                [xmin, ymax],
+                                [xmin, ymin],
+                            ]
+                        ],
+                    },
+                }
+            ],
+        }
+
+    if hasattr(geometry, "to_json"):
+        return json.loads(geometry.to_json())
+
+    if hasattr(geometry, "__geo_interface__"):
+        return geometry.__geo_interface__
+
+    if isinstance(geometry, dict):
+        return geometry
+
+    raise TypeError(
+        "geometry must be GeoJSON, a GeoDataFrame, a vector file path, "
+        "or a bounding box."
+    )
+
+
+def _bundle_output_path(
+    out_dir: Union[str, os.PathLike[str]],
+    file_name: str,
+) -> Path:
+    """Build a local bundle output path.
+
+    Args:
+        out_dir: Output directory.
+        file_name: AppEEARS bundle file name.
+
+    Returns:
+        Local output path.
+    """
+
+    file_path = Path(file_name)
+    parts = file_path.parts
+    if len(parts) > 1 and file_path.suffix.lower() == ".tif":
+        file_path = Path(parts[-1])
+    return Path(out_dir) / file_path
+
+
+def _coerce_paths(
+    files: Union[str, os.PathLike[str], Sequence[Union[str, os.PathLike[str]]]],
+) -> List[str]:
+    """Coerce file input to a sorted list of GeoTIFF paths.
+
+    Args:
+        files: Path, directory, or sequence of paths.
+
+    Returns:
+        Sorted list of GeoTIFF paths.
+    """
+
+    if isinstance(files, (str, os.PathLike)):
+        path = Path(files)
+        if path.is_dir():
+            return sorted(str(item) for item in path.rglob("*.tif"))
+        return [str(path)]
+    return sorted(str(Path(item)) for item in files)
+
+
+def _metadata_by_layer(
+    product: str,
+    layers: Union[Dict[str, Dict[str, Any]], Sequence[Dict[str, Any]]],
+) -> Dict[str, Dict[str, Any]]:
+    """Index AppEEARS layer metadata by layer name.
+
+    Args:
+        product: AppEEARS product and version.
+        layers: AppEEARS layer metadata.
+
+    Returns:
+        Dictionary keyed by layer name.
+    """
+
+    if isinstance(layers, dict):
+        return {
+            layer: _layer_record(product, layer, metadata)
+            for layer, metadata in layers.items()
+        }
+    return {item["layer"]: dict(item) for item in layers}
+
+
+def _layer_from_filename(path: Union[str, os.PathLike[str]]) -> Optional[str]:
+    """Extract an AppEEARS layer name from a file path.
+
+    Args:
+        path: AppEEARS output file path.
+
+    Returns:
+        Layer name when a band token is present.
+    """
+
+    matches = _BAND_RE.findall(Path(path).name)
+    if not matches:
+        return None
+    return matches[-1]

--- a/hypercoast/appeears.py
+++ b/hypercoast/appeears.py
@@ -453,6 +453,7 @@ class AppEEARSClient:
         headers = kwargs.pop("headers", {})
         if auth_header:
             headers = {**self.headers, **headers}
+        kwargs.setdefault("timeout", 120)
         response = self.session.request(
             method.upper(), self.api_url + path.lstrip("/"), headers=headers, **kwargs
         )
@@ -930,7 +931,11 @@ def _normalize_geojson(geometry: Any) -> Dict[str, Any]:
 
         return json.loads(gpd.read_file(geometry).to_json())
 
-    if isinstance(geometry, (list, tuple)) and len(geometry) == 4:
+    if (
+        isinstance(geometry, (list, tuple))
+        and len(geometry) == 4
+        and all(isinstance(v, (int, float)) for v in geometry)
+    ):
         xmin, ymin, xmax, ymax = geometry
         return {
             "type": "FeatureCollection",
@@ -984,6 +989,8 @@ def _bundle_output_path(
     """
 
     file_path = Path(file_name)
+    if file_path.is_absolute() or ".." in file_path.parts:
+        file_path = Path(file_path.name)
     parts = file_path.parts
     if len(parts) > 1 and file_path.suffix.lower() == ".tif":
         file_path = Path(parts[-1])

--- a/hypercoast/appeears.py
+++ b/hypercoast/appeears.py
@@ -457,7 +457,13 @@ class AppEEARSClient:
         response = self.session.request(
             method.upper(), self.api_url + path.lstrip("/"), headers=headers, **kwargs
         )
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except Exception as error:
+            message = _response_error_message(response)
+            if message:
+                error.args = (*error.args, message)
+            raise
         return response
 
     def _require_token(self) -> None:
@@ -608,10 +614,12 @@ def appeears_area_task(
     layers: Sequence[Dict[str, str]],
     start_date: str,
     end_date: str,
-    output_format: str = "geotiff",
+    output_format: Optional[str] = None,
     projection: str = "geographic",
     recurring: bool = False,
     year_range: Optional[Sequence[int]] = None,
+    orthorectify: Optional[bool] = True,
+    additional_options: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build an AppEEARS area task payload.
 
@@ -623,14 +631,30 @@ def appeears_area_task(
         start_date: Start date as ``YYYY-MM-DD`` or ``MM-DD-YYYY``.
         end_date: End date as ``YYYY-MM-DD`` or ``MM-DD-YYYY``.
         output_format: AppEEARS output format, such as ``"geotiff"`` or
-            ``"netcdf4"``.
+            ``"netcdf4"``. If None, EMIT tasks use ``"netcdf4"`` and other
+            tasks use ``"geotiff"``.
         projection: AppEEARS output projection name.
         recurring: Whether the task uses recurring dates.
         year_range: Two-year range for recurring tasks.
+        orthorectify: Whether AppEEARS should orthorectify EMIT area outputs.
+            AppEEARS requires this option for EMIT area tasks. Set to None to
+            omit it.
+        additional_options: Additional AppEEARS output options.
 
     Returns:
         AppEEARS area task payload.
     """
+
+    has_emit = _has_emit_layers(layers)
+    if output_format is None:
+        output_format = "netcdf4" if has_emit else "geotiff"
+
+    output = {"format": {"type": output_format}, "projection": projection}
+    options = dict(additional_options or {})
+    if orthorectify is not None and has_emit:
+        options.setdefault("orthorectify", bool(orthorectify))
+    if options:
+        output["additionalOptions"] = options
 
     params = {
         "dates": [
@@ -642,7 +666,7 @@ def appeears_area_task(
             )
         ],
         "layers": list(layers),
-        "output": {"format": {"type": output_format}, "projection": projection},
+        "output": output,
         "geo": _normalize_geojson(geometry),
     }
     return {"task_type": "area", "task_name": task_name, "params": params}
@@ -732,10 +756,10 @@ def read_appeears(
     client: Optional[AppEEARSClient] = None,
     **kwargs: Any,
 ) -> Any:
-    """Read AppEEARS single-band GeoTIFFs as an xarray hyperspectral cube.
+    """Read AppEEARS raster output as an xarray hyperspectral cube.
 
     Args:
-        files: GeoTIFF path, directory, or sequence of paths.
+        files: GeoTIFF or NetCDF path, directory, or sequence of paths.
         layers: Optional AppEEARS layer metadata from ``appeears_layers`` or
             ``appeears_emit_layers(..., return_metadata=True)``.
         product: AppEEARS product used to infer wavelength metadata when layers
@@ -749,14 +773,16 @@ def read_appeears(
         xarray.Dataset containing the stacked raster data.
     """
 
-    import rioxarray
-    import xarray as xr
-
     paths = _coerce_paths(files)
     if layers is None:
         client = client or AppEEARSClient()
         layers = client.layers(product)
     metadata = _metadata_by_layer(product, layers)
+    if paths and all(Path(path).suffix.lower() in {".nc", ".nc4"} for path in paths):
+        return _read_appeears_netcdf(paths, metadata, product, variable, **kwargs)
+
+    import rioxarray
+    import xarray as xr
 
     arrays = []
     wavelengths = []
@@ -789,6 +815,71 @@ def read_appeears(
     )
     dataset = data.to_dataset(name=variable)
     dataset[variable].attrs["band_names"] = band_names
+    dataset.attrs["source"] = "NASA AppEEARS"
+    dataset.attrs["product"] = product
+    return dataset
+
+
+def _read_appeears_netcdf(
+    paths: Sequence[str],
+    metadata: Dict[str, Dict[str, Any]],
+    product: str,
+    variable: str,
+    **kwargs: Any,
+) -> Any:
+    """Read AppEEARS NetCDF output as an xarray hyperspectral cube.
+
+    Args:
+        paths: NetCDF paths.
+        metadata: Layer metadata indexed by layer name.
+        product: AppEEARS product and version.
+        variable: Output data variable name.
+        **kwargs: Additional keyword arguments passed to ``xarray.open_dataset``.
+
+    Returns:
+        xarray.Dataset containing stacked spectral variables.
+    """
+
+    import xarray as xr
+
+    datasets = []
+    for path in paths:
+        source = xr.open_dataset(path, **kwargs)
+        arrays = []
+        wavelengths = []
+        band_names = []
+        for name in source.data_vars:
+            layer_name = _layer_from_name(name)
+            if layer_name is None:
+                continue
+            layer_info = metadata.get(layer_name)
+            wavelength = None if layer_info is None else layer_info.get("wavelength")
+            if wavelength is None:
+                continue
+            arrays.append(source[name])
+            wavelengths.append(float(wavelength))
+            band_names.append(layer_name)
+
+        if not arrays:
+            continue
+
+        order = sorted(range(len(wavelengths)), key=lambda index: wavelengths[index])
+        data = xr.concat(
+            [arrays[index] for index in order],
+            dim=xr.DataArray(
+                [wavelengths[index] for index in order],
+                dims="wavelength",
+                name="wavelength",
+            ),
+        )
+        dataset = data.to_dataset(name=variable)
+        dataset[variable].attrs["band_names"] = [band_names[index] for index in order]
+        datasets.append(dataset)
+
+    if not datasets:
+        raise ValueError("No AppEEARS spectral NetCDF variables could be read.")
+
+    dataset = xr.concat(datasets, dim="time") if len(datasets) > 1 else datasets[0]
     dataset.attrs["source"] = "NASA AppEEARS"
     dataset.attrs["product"] = product
     return dataset
@@ -1039,6 +1130,45 @@ def _metadata_by_layer(
     return {item["layer"]: dict(item) for item in layers}
 
 
+def _has_emit_layers(layers: Sequence[Dict[str, str]]) -> bool:
+    """Check whether task layers include an EMIT product.
+
+    Args:
+        layers: Task-ready AppEEARS layer dictionaries.
+
+    Returns:
+        True if any layer belongs to an EMIT product.
+    """
+
+    return any(str(item.get("product", "")).startswith("EMIT_") for item in layers)
+
+
+def _response_error_message(response: Any) -> str:
+    """Build a readable AppEEARS HTTP error message.
+
+    Args:
+        response: Requests-compatible response object.
+
+    Returns:
+        Error message extracted from the response body.
+    """
+
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+
+    if isinstance(payload, dict):
+        if "message" in payload:
+            return f"AppEEARS error: {payload['message']}"
+        return f"AppEEARS error: {payload}"
+
+    text = getattr(response, "text", "")
+    if text:
+        return f"AppEEARS error: {text}"
+    return ""
+
+
 def _layer_from_filename(path: Union[str, os.PathLike[str]]) -> Optional[str]:
     """Extract an AppEEARS layer name from a file path.
 
@@ -1049,7 +1179,20 @@ def _layer_from_filename(path: Union[str, os.PathLike[str]]) -> Optional[str]:
         Layer name when a band token is present.
     """
 
-    matches = _BAND_RE.findall(Path(path).name)
+    return _layer_from_name(Path(path).name)
+
+
+def _layer_from_name(name: str) -> Optional[str]:
+    """Extract an AppEEARS layer name from a file or variable name.
+
+    Args:
+        name: File or variable name.
+
+    Returns:
+        Layer name when a band token is present.
+    """
+
+    matches = _BAND_RE.findall(name)
     if not matches:
         return None
     return matches[-1]

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -68,6 +68,19 @@ from .cesl import (
     cesl_to_gdf,
     cesl_to_geojson,
 )
+from .appeears import (
+    AppEEARSClient,
+    appeears_area_task,
+    appeears_download,
+    appeears_emit_layers,
+    appeears_layers,
+    appeears_login,
+    appeears_point_task,
+    appeears_products,
+    appeears_submit_task,
+    appeears_wait,
+    read_appeears,
+)
 from .ui import SpectralWidget
 from .common import (
     download_file,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,8 @@ nav:
           - examples/image_cube.ipynb
           - examples/image_slicing.ipynb
           - examples/aviris.ipynb
+          - examples/appeears_emit_area.ipynb
+          - examples/appeears_emit_point.ipynb
           - examples/cesl.ipynb
           - examples/desis.ipynb
           - examples/emit.ipynb
@@ -133,6 +135,7 @@ nav:
           - workshops/pace.ipynb
     - API Reference:
           - aviris module: aviris.md
+          - appeears module: appeears.md
           - chla module: chla.md
           - cesl module: cesl.md
           - common module: common.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ netcdf4
 numpy
 openpyxl
 psutil
+requests
 rioxarray
 s3fs
 scikit-learn

--- a/tests/test_appeears.py
+++ b/tests/test_appeears.py
@@ -10,6 +10,8 @@ import unittest
 from pathlib import Path
 
 import hypercoast
+import numpy as np
+import xarray as xr
 from hypercoast import appeears
 
 
@@ -157,6 +159,11 @@ class TestAppEEARS(unittest.TestCase):
         self.assertEqual(task["task_type"], "area")
         self.assertEqual(geo["type"], "FeatureCollection")
         self.assertEqual(geo["features"][0]["geometry"]["type"], "Polygon")
+        self.assertEqual(task["params"]["output"]["format"]["type"], "netcdf4")
+        self.assertEqual(
+            task["params"]["output"]["additionalOptions"],
+            {"orthorectify": True},
+        )
 
     def test_download_bundle_filters_file_types(self):
         session = MockSession()
@@ -169,6 +176,30 @@ class TestAppEEARS(unittest.TestCase):
             self.assertEqual(Path(paths[0]).name, "EMIT_L2A_RFL_001_B001_doy.tif")
             self.assertTrue(os.path.exists(paths[0]))
             self.assertEqual(Path(paths[0]).read_bytes(), b"data")
+
+    def test_read_appeears_stacks_netcdf_band_variables(self):
+        layers = [
+            {"product": "EMIT_L2A_RFL.001", "layer": "B001", "wavelength": 381.006},
+            {"product": "EMIT_L2A_RFL.001", "layer": "B002", "wavelength": 388.409},
+        ]
+        source = xr.Dataset(
+            {
+                "EMIT_L2A_RFL_001_B002": (("y", "x"), np.full((2, 2), 2.0)),
+                "EMIT_L2A_RFL_001_B001": (("y", "x"), np.full((2, 2), 1.0)),
+            },
+            coords={"y": [0, 1], "x": [10, 11]},
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "appeears.nc"
+            source.to_netcdf(filepath)
+
+            dataset = hypercoast.read_appeears(str(filepath), layers=layers)
+
+        self.assertEqual(dataset["reflectance"].dims, ("wavelength", "y", "x"))
+        self.assertEqual(dataset.sizes["wavelength"], 2)
+        self.assertEqual(dataset["wavelength"].values.tolist(), [381.006, 388.409])
+        self.assertEqual(dataset["reflectance"].isel(wavelength=0).values[0, 0], 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_appeears.py
+++ b/tests/test_appeears.py
@@ -69,20 +69,22 @@ class MockSession:
         if url.endswith("/login"):
             return MockResponse({"token": "abc"})
         if url.endswith("/product/EMIT_L2A_RFL.001"):
+            reflectance = "Reflectance for Wavelength: {} nm, FWHM: 8.415 nm"
+            flag = "Usable wavelengths flag for Wavelength: 388.409 nm, FWHM: 8.415 nm"
             return MockResponse(
                 {
                     "B001": {
-                        "Description": "Reflectance for Wavelength: 381.006 nm, FWHM: 8.415 nm",
+                        "Description": reflectance.format("381.006"),
                         "Units": "spectral reflectance",
                         "DataType": "float32",
                     },
                     "B002": {
-                        "Description": "Reflectance for Wavelength: 388.409 nm, FWHM: 8.415 nm",
+                        "Description": reflectance.format("388.409"),
                         "Units": "spectral reflectance",
                         "DataType": "float32",
                     },
                     "B002_GW": {
-                        "Description": "Usable wavelengths flag for Wavelength: 388.409 nm, FWHM: 8.415 nm",
+                        "Description": flag,
                         "Units": "binary flag",
                         "DataType": "uint8",
                     },

--- a/tests/test_appeears.py
+++ b/tests/test_appeears.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: 2026 Qiusheng Wu <giswqs@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for AppEEARS helpers."""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import hypercoast
+from hypercoast import appeears
+
+
+class MockResponse:
+    """Minimal requests response mock."""
+
+    def __init__(self, payload=None, content=None):
+        """Create a mock response.
+
+        Args:
+            payload: JSON payload returned by ``json``.
+            content: Binary content returned by ``iter_content``.
+        """
+        self.payload = payload
+        self.content = content or b""
+        self.text = ""
+
+    def json(self):
+        """Return the mocked JSON payload."""
+        return self.payload
+
+    def raise_for_status(self):
+        """Mock a successful HTTP response."""
+
+    def iter_content(self, chunk_size=8192):
+        """Yield mocked response content.
+
+        Args:
+            chunk_size: Maximum chunk size.
+
+        Yields:
+            Binary chunks.
+        """
+        for index in range(0, len(self.content), chunk_size):
+            yield self.content[index : index + chunk_size]
+
+
+class MockSession:
+    """Requests-compatible session mock."""
+
+    def __init__(self):
+        """Create a mock session."""
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        """Record the request and return a fixture response.
+
+        Args:
+            method: HTTP method.
+            url: Request URL.
+            **kwargs: Request options.
+
+        Returns:
+            MockResponse: Fixture response.
+        """
+        self.calls.append((method, url, kwargs))
+        if url.endswith("/login"):
+            return MockResponse({"token": "abc"})
+        if url.endswith("/product/EMIT_L2A_RFL.001"):
+            return MockResponse(
+                {
+                    "B001": {
+                        "Description": "Reflectance for Wavelength: 381.006 nm, FWHM: 8.415 nm",
+                        "Units": "spectral reflectance",
+                        "DataType": "float32",
+                    },
+                    "B002": {
+                        "Description": "Reflectance for Wavelength: 388.409 nm, FWHM: 8.415 nm",
+                        "Units": "spectral reflectance",
+                        "DataType": "float32",
+                    },
+                    "B002_GW": {
+                        "Description": "Usable wavelengths flag for Wavelength: 388.409 nm, FWHM: 8.415 nm",
+                        "Units": "binary flag",
+                        "DataType": "uint8",
+                    },
+                }
+            )
+        if url.endswith("/bundle/task-1"):
+            return MockResponse(
+                {
+                    "files": [
+                        {
+                            "file_id": "file-1",
+                            "file_name": "folder/EMIT_L2A_RFL_001_B001_doy.tif",
+                            "file_type": "tif",
+                        },
+                        {
+                            "file_id": "file-2",
+                            "file_name": "readme.txt",
+                            "file_type": "txt",
+                        },
+                    ]
+                }
+            )
+        if url.endswith("/bundle/task-1/file-1"):
+            return MockResponse(content=b"data")
+        return MockResponse({})
+
+
+class TestAppEEARS(unittest.TestCase):
+    """Test AppEEARS helper behavior."""
+
+    def test_emit_layers_selects_nearest_wavelength(self):
+        session = MockSession()
+        client = appeears.AppEEARSClient(token="abc", session=session)
+
+        layers = hypercoast.appeears_emit_layers(
+            wavelengths=[389],
+            client=client,
+            return_metadata=True,
+        )
+
+        self.assertEqual(layers[0]["layer"], "B002")
+        self.assertEqual(layers[0]["wavelength"], 388.409)
+
+    def test_point_task_formats_dates_and_coordinates(self):
+        task = hypercoast.appeears_point_task(
+            task_name="point",
+            coordinates=(-118.3, 34.1),
+            layers=[{"product": "EMIT_L2A_RFL.001", "layer": "B001"}],
+            start_date="2024-04-01",
+            end_date="2024-04-30",
+        )
+
+        self.assertEqual(task["task_type"], "point")
+        self.assertEqual(task["params"]["dates"][0]["startDate"], "04-01-2024")
+        self.assertEqual(
+            task["params"]["coordinates"][0],
+            {"longitude": -118.3, "latitude": 34.1, "id": "point-1"},
+        )
+
+    def test_area_task_accepts_bbox(self):
+        task = hypercoast.appeears_area_task(
+            task_name="area",
+            geometry=[-118.5, 33.8, -118.2, 34.1],
+            layers=[{"product": "EMIT_L2A_RFL.001", "layer": "B001"}],
+            start_date="04-01-2024",
+            end_date="04-30-2024",
+        )
+
+        geo = task["params"]["geo"]
+        self.assertEqual(task["task_type"], "area")
+        self.assertEqual(geo["type"], "FeatureCollection")
+        self.assertEqual(geo["features"][0]["geometry"]["type"], "Polygon")
+
+    def test_download_bundle_filters_file_types(self):
+        session = MockSession()
+        client = appeears.AppEEARSClient(token="abc", session=session)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            paths = client.download_bundle("task-1", out_dir=tmpdir, file_types=["tif"])
+
+            self.assertEqual(len(paths), 1)
+            self.assertEqual(Path(paths[0]).name, "EMIT_L2A_RFL_001_B001_doy.tif")
+            self.assertTrue(os.path.exists(paths[0]))
+            self.assertEqual(Path(paths[0]).read_bytes(), b"data")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `hypercoast.appeears` module with `AppEEARSClient` and convenience functions for authenticating, listing products/layers, building point and area tasks, submitting tasks, downloading bundles, and reading single-band GeoTIFFs as xarray hyperspectral cubes
- Add `appeears_emit_layers` for selecting EMIT spectral bands by wavelength
- Add example notebooks for area and point workflows, API reference docs, and unit tests

## Test plan
- [x] `pre-commit run --all-files` passes
- [x] Unit tests pass (`tests/test_appeears.py`)
- [ ] Verify notebooks render correctly in docs build