### PR TITLE
feat: add bbox drawing tool and reflectance defaults for Tanager

### DIFF
--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -1,0 +1,91 @@
+# QGIS Plugin
+
+[![QGIS](https://img.shields.io/badge/QGIS-plugin-orange.svg)](https://plugins.qgis.org/plugins/hypercoast)
+
+
+HyperCoast provides a QGIS plugin for visualizing and analyzing hyperspectral data, including EMIT, PACE, DESIS, NEON, AVIRIS, PRISMA, EnMAP, Tanager, and Wyvern datasets.
+
+## Video Tutorials
+
+Check out this [short video demo](https://youtu.be/EEUAC5BxqtM) and [full video tutorial](https://youtu.be/RxDUcfv-vBc) on how to use the HyperCoast plugin in QGIS.
+
+[![youtube-video](https://github.com/user-attachments/assets/d7bb977a-c523-485f-8ffb-3c99cb4e89d3)](https://youtu.be/RxDUcfv-vBc)
+
+## Features
+
+-   Load NASA EMIT, PACE, DESIS, NEON AOP, AVIRIS, PRISMA, EnMAP, Planet Tanager, Wyvern, and generic GeoTIFF or NetCDF hyperspectral data.
+-   Search Planet Tanager STAC scenes from QGIS, add footprint layers, open visual imagery, and download HDF5 assets for hyperspectral analysis.
+-   Change RGB band combinations by wavelength and use presets such as true color, color infrared, agriculture, vegetation, water, geology, and chlorophyll-a.
+-   Extract and compare spectral signatures by clicking hyperspectral layers on the map.
+-   Use dockable QGIS panels and batch-friendly Processing tools.
+
+## Installation
+
+The plugin is available from the official QGIS plugin repository:
+
+1. Open QGIS.
+2. Go to **Plugins** > **Manage and Install Plugins**.
+3. Search for **HyperCoast**.
+4. Click **Install Plugin**.
+
+For development installation, packaging, and troubleshooting details, see the [QGIS plugin README](https://github.com/opengeos/HyperCoast/tree/main/qgis_plugin).
+
+## Usage
+
+### Searching Tanager Data
+
+![](https://github.com/user-attachments/assets/f59327cd-3ea4-43ee-8a15-2af32b85c6fb)
+
+1. Click the **Search Tanager Data** button.
+2. Use the current map extent, draw a bounding box, or enter coordinates manually.
+3. Set optional date, collection, query, cloud, and count filters.
+4. Click **Search**.
+5. Add footprints, open the visual asset, or download an HDF5 asset for analysis.
+
+### Loading Hyperspectral Data
+
+![](https://github.com/user-attachments/assets/b9f388f9-8cbc-4f83-b905-4b7c0ba78bef)
+
+1. Click the **Load Hyperspectral Data** button in the toolbar.
+2. Browse to your hyperspectral data file.
+3. Select the data type, or use auto-detect.
+4. Configure RGB wavelengths for visualization.
+5. Click **Load Data**.
+
+### Changing Band Combinations
+
+![](https://github.com/user-attachments/assets/ae452a32-eafb-4487-ac50-861b84ffb7fb)
+
+1. Click the **Band Combination** button.
+2. Select the hyperspectral layer.
+3. Adjust R, G, B wavelengths using spinboxes or sliders.
+4. Use presets for quick common combinations.
+5. Click **Apply**.
+
+### Inspecting Spectral Signatures
+
+![](https://github.com/user-attachments/assets/a0f0582a-2973-4761-b0ec-e4345461e836)
+
+1. Click the **Spectral Inspector** button.
+2. Click a location within a hyperspectral layer.
+3. Compare spectra in the spectral plot panel.
+4. Export data to CSV or save the plot image.
+
+### Running Processing Tools
+
+Open **Processing** > **Toolbox** > **HyperCoast** to run batch tools for RGB composites, single-band export, spectral index rasters, and PCA components.
+
+## Supported File Formats
+
+| Sensor  | Extensions      | Description               |
+| ------- | --------------- | ------------------------- |
+| EMIT    | .nc, .nc4       | NASA EMIT L2A Reflectance |
+| PACE    | .nc, .nc4       | NASA PACE OCI L2 AOP      |
+| DESIS   | .nc, .tif       | DESIS Hyperspectral       |
+| NEON    | .h5             | NEON AOP Hyperspectral    |
+| AVIRIS  | .nc, .img, .bil | AVIRIS/AVIRIS-NG          |
+| PRISMA  | .he5, .nc       | ASI PRISMA                |
+| EnMAP   | .nc, .tif       | DLR EnMAP                 |
+| Tanager | .h5             | Planet Tanager            |
+| Wyvern  | .tif, .tiff     | Wyvern Hyperspectral      |
+| Generic | .tif, .nc       | Multi-band GeoTIFF/NetCDF |

--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -77,15 +77,15 @@ Open **Processing** > **Toolbox** > **HyperCoast** to run batch tools for RGB co
 
 ## Supported File Formats
 
-| Sensor  | Extensions      | Description               |
-| ------- | --------------- | ------------------------- |
-| EMIT    | .nc, .nc4       | NASA EMIT L2A Reflectance |
-| PACE    | .nc, .nc4       | NASA PACE OCI L2 AOP      |
-| DESIS   | .nc, .tif       | DESIS Hyperspectral       |
-| NEON    | .h5             | NEON AOP Hyperspectral    |
-| AVIRIS  | .nc, .img, .bil | AVIRIS/AVIRIS-NG          |
-| PRISMA  | .he5, .nc       | ASI PRISMA                |
-| EnMAP   | .nc, .tif       | DLR EnMAP                 |
-| Tanager | .h5             | Planet Tanager            |
-| Wyvern  | .tif, .tiff     | Wyvern Hyperspectral      |
-| Generic | .tif, .nc       | Multi-band GeoTIFF/NetCDF |
+Sensor | Extensions | Description
+--- | --- | ---
+EMIT | .nc, .nc4 | NASA EMIT L2A Reflectance
+PACE | .nc, .nc4 | NASA PACE OCI L2 AOP
+DESIS | .nc, .tif | DESIS Hyperspectral
+NEON | .h5 | NEON AOP Hyperspectral
+AVIRIS | .nc, .img, .bil | AVIRIS/AVIRIS-NG
+PRISMA | .he5, .nc | ASI PRISMA
+EnMAP | .nc, .tif | DLR EnMAP
+Tanager | .h5 | Planet Tanager
+Wyvern | .tif, .tiff | Wyvern Hyperspectral
+Generic | .tif, .nc | Multi-band GeoTIFF/NetCDF

--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -9,6 +9,9 @@ HyperCoast provides a QGIS plugin for visualizing and analyzing hyperspectral da
 
 Check out this [short video demo](https://youtu.be/EEUAC5BxqtM) and [full video tutorial](https://youtu.be/RxDUcfv-vBc) on how to use the HyperCoast plugin in QGIS.
 
+- [HyperCoast QGIS Plugin: Hyperspectral Data Visualization Made Easy](https://youtu.be/RxDUcfv-vBc)
+- [Working with Planet Tanager Hyperspectral Data (426 Bands) in QGIS with HyperCoast](https://youtu.be/I1LumODB5PU)
+
 [![youtube-video](https://github.com/user-attachments/assets/d7bb977a-c523-485f-8ffb-3c99cb4e89d3)](https://youtu.be/RxDUcfv-vBc)
 
 ## Features

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
     - Home: index.md
     - Installation: installation.md
     - Usage: usage.md
+    - QGIS Plugin: qgis_plugin.md
     - Contributing: contributing.md
     - Changelog: changelog.md
     - Report Issues: https://github.com/opengeos/HyperCoast/issues

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -86,7 +86,7 @@ When QGIS is launched from this Conda environment, the plugin automatically dete
 ### Searching Tanager Data
 
 1. Click the **Search Tanager Data** button
-2. Use the current map extent or enter a bounding box
+2. Use the current map extent, draw a bounding box, or enter coordinates manually
 3. Set optional date, collection, query, cloud, and count filters
 4. Click **Search**
 5. Add footprints, open the visual asset, or download the radiance HDF5 for analysis

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -89,7 +89,7 @@ When QGIS is launched from this Conda environment, the plugin automatically dete
 2. Use the current map extent, draw a bounding box, or enter coordinates manually
 3. Set optional date, collection, query, cloud, and count filters
 4. Click **Search**
-5. Add footprints, open the visual asset, or download the radiance HDF5 for analysis
+5. Add footprints, open the visual asset, or download an HDF5 asset for analysis
 
 ### Changing Band Combinations
 

--- a/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
@@ -48,7 +48,7 @@ from ..hyperspectral_provider import (
 from ..cache_manager import create_generated_raster_path
 
 DEFAULT_VALUE_RANGE = (0.0, 0.5)
-TANAGER_VALUE_RANGE = (0.0, 100.0)
+TANAGER_VALUE_RANGE = (0.0, 0.5)
 
 
 class DatasetPreviewWorker(QThread):

--- a/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
@@ -50,7 +50,7 @@ except ImportError:
     HAS_MATPLOTLIB = False
 
 DEFAULT_Y_RANGE = (0.0, 0.5)
-TANAGER_Y_RANGE = (0.0, 100.0)
+TANAGER_Y_RANGE = (0.0, 0.5)
 
 
 class SpectralPlotDialog(QDockWidget):
@@ -373,7 +373,7 @@ class SpectralPlotDialog(QDockWidget):
         if not HAS_MATPLOTLIB or data_type != "Tanager":
             return
 
-        index = self.ylabel_combo.findText("Radiance")
+        index = self.ylabel_combo.findText("Reflectance")
         if index >= 0:
             self.ylabel_combo.setCurrentIndex(index)
         self.ymin_spin.setValue(TANAGER_Y_RANGE[0])

--- a/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
@@ -226,7 +226,7 @@ class TanagerBboxMapTool(QgsMapTool):
         """
         super().__init__(canvas)
         self.canvas = canvas
-        self.parent = parent
+        self._parent_widget = parent
         self._start_point = None
         self._rubber_band = None
         try:

--- a/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
@@ -12,8 +12,9 @@ import json
 from urllib.parse import unquote, urlparse
 import urllib.request
 
-from qgis.PyQt.QtCore import Qt, QThread, QUrl, pyqtSignal
-from qgis.PyQt.QtGui import QDesktopServices
+from qgis.PyQt.QtCore import QObject, Qt, QThread, QUrl, pyqtSignal
+from qgis.PyQt.QtGui import QColor, QCursor, QDesktopServices
+from qgis.gui import QgsMapTool as _QgsMapTool, QgsRubberBand
 
 try:
     from qgis.PyQt.QtCore import QVariant
@@ -60,11 +61,50 @@ from qgis.core import (
     QgsPointXY,
     QgsProject,
     QgsRasterLayer,
+    QgsRectangle,
     QgsVectorLayer,
+    QgsWkbTypes,
     Qgis,
 )
 
-from ..cache_manager import generated_raster_cache_dir
+if isinstance(_QgsMapTool, type):
+    QgsMapTool = _QgsMapTool
+else:  # pragma: no cover - used by lightweight Qt-only test stubs
+
+    class QgsMapTool(QObject):
+        """Minimal QgsMapTool fallback for tests without QGIS GUI classes."""
+
+        def __init__(self, canvas=None):
+            """Initialize the fallback map tool.
+
+            Args:
+                canvas: Optional map canvas.
+            """
+            super().__init__()
+            self.canvas = canvas
+
+        def setCursor(self, cursor):
+            """Store the requested cursor.
+
+            Args:
+                cursor: Cursor object.
+            """
+            self.cursor = cursor
+
+        def toMapCoordinates(self, position):
+            """Return the provided position as a map coordinate.
+
+            Args:
+                position: Position-like object.
+
+            Returns:
+                The input position.
+            """
+            return position
+
+        def deactivate(self):
+            """Deactivate the fallback map tool."""
+
 
 TANAGER_HDF5_ASSET = "ortho_radiance_hdf5"
 TANAGER_HDF5_ASSETS = (
@@ -160,14 +200,234 @@ def tanager_download_dir(project=None):
     """Return the persistent Tanager download directory.
 
     Args:
-        project: Optional QgsProject-like object.
+        project: Optional QgsProject-like object. Kept for backward
+            compatibility and ignored.
 
     Returns:
         Absolute directory path.
     """
-    out_dir = os.path.join(generated_raster_cache_dir(project), "tanager")
+    out_dir = os.path.join(os.path.expanduser("~"), "Downloads")
     os.makedirs(out_dir, exist_ok=True)
     return out_dir
+
+
+class TanagerBboxMapTool(QgsMapTool):
+    """Map tool for drawing a Tanager search bounding box."""
+
+    bbox_drawn = pyqtSignal(list)
+    canceled = pyqtSignal()
+
+    def __init__(self, canvas, parent=None):
+        """Initialize the map tool.
+
+        Args:
+            canvas: QGIS map canvas.
+            parent: Optional QObject parent.
+        """
+        super().__init__(canvas)
+        self.canvas = canvas
+        self.parent = parent
+        self._start_point = None
+        self._rubber_band = None
+        try:
+            self.setCursor(QCursor(Qt.CursorShape.CrossCursor))
+        except AttributeError:
+            self.setCursor(QCursor(Qt.CrossCursor))
+        except Exception:
+            pass  # nosec B110
+
+    def canvasPressEvent(self, event):
+        """Start drawing the bounding box.
+
+        Args:
+            event: QGIS map mouse event.
+        """
+        if not self._is_left_button(event):
+            return
+        self._start_point = self.toMapCoordinates(event.pos())
+        self._ensure_rubber_band()
+
+    def canvasMoveEvent(self, event):
+        """Update the live bounding box preview.
+
+        Args:
+            event: QGIS map mouse event.
+        """
+        if self._start_point is None:
+            return
+        self._update_rubber_band(self._start_point, self.toMapCoordinates(event.pos()))
+
+    def canvasReleaseEvent(self, event):
+        """Finish drawing and emit the WGS84 bbox.
+
+        Args:
+            event: QGIS map mouse event.
+        """
+        if self._start_point is None or not self._is_left_button(event):
+            return
+        end_point = self.toMapCoordinates(event.pos())
+        bbox = self._bbox_from_points(self._start_point, end_point)
+        self._start_point = None
+        self._remove_rubber_band()
+        if bbox[0] == bbox[2] or bbox[1] == bbox[3]:
+            self.canceled.emit()
+            return
+        self.bbox_drawn.emit(self._transform_bbox_to_wgs84(bbox))
+
+    def keyPressEvent(self, event):
+        """Cancel drawing when Escape is pressed.
+
+        Args:
+            event: QGIS key event.
+        """
+        escape_key = getattr(getattr(Qt, "Key", Qt), "Key_Escape", None)
+        if escape_key is None:
+            escape_key = getattr(Qt, "Key_Escape", None)
+        if escape_key is not None and event.key() == escape_key:
+            self._start_point = None
+            self._remove_rubber_band()
+            self.canceled.emit()
+
+    def deactivate(self):
+        """Remove the live preview when the map tool is deactivated."""
+        self._start_point = None
+        self._remove_rubber_band()
+        super_deactivate = getattr(super(), "deactivate", None)
+        if callable(super_deactivate):
+            super_deactivate()
+
+    def _is_left_button(self, event):
+        """Return whether the event used the left mouse button.
+
+        Args:
+            event: QGIS map mouse event.
+
+        Returns:
+            True when the left mouse button was used.
+        """
+        left_button = getattr(getattr(Qt, "MouseButton", Qt), "LeftButton", None)
+        if left_button is None:
+            left_button = getattr(Qt, "LeftButton", None)
+        button = getattr(event, "button", None)
+        if callable(button) and left_button is not None:
+            return button() == left_button
+        return True
+
+    def _ensure_rubber_band(self):
+        """Create the preview rubber band if needed."""
+        if self._rubber_band is not None:
+            return
+        self._rubber_band = QgsRubberBand(self.canvas, self._polygon_geometry_type())
+        try:
+            self._rubber_band.setColor(QColor(0, 102, 204, 90))
+            self._rubber_band.setStrokeColor(QColor(0, 102, 204, 220))
+            self._rubber_band.setFillColor(QColor(173, 216, 230, 55))
+            self._rubber_band.setWidth(2)
+        except Exception:
+            pass  # nosec B110
+
+    def _update_rubber_band(self, start_point, end_point):
+        """Update the preview rectangle.
+
+        Args:
+            start_point: First corner in map coordinates.
+            end_point: Opposite corner in map coordinates.
+        """
+        self._ensure_rubber_band()
+        points = self._rectangle_points(start_point, end_point)
+        try:
+            self._rubber_band.reset(self._polygon_geometry_type())
+            for point in points:
+                self._rubber_band.addPoint(point, False)
+            self._rubber_band.addPoint(points[0], True)
+        except Exception:
+            pass  # nosec B110
+
+    def _remove_rubber_band(self):
+        """Remove the preview rubber band from the canvas."""
+        if self._rubber_band is None:
+            return
+        try:
+            self.canvas.scene().removeItem(self._rubber_band)
+        except Exception:
+            pass  # nosec B110
+        self._rubber_band = None
+
+    def _transform_bbox_to_wgs84(self, bbox):
+        """Transform a map-canvas bbox to EPSG:4326.
+
+        Args:
+            bbox: Bounding box in the map canvas CRS.
+
+        Returns:
+            Bounding box list in EPSG:4326.
+        """
+        try:
+            source_crs = self.canvas.mapSettings().destinationCrs()
+            target_crs = QgsCoordinateReferenceSystem("EPSG:4326")
+            if (
+                source_crs
+                and target_crs.isValid()
+                and source_crs.isValid()
+                and source_crs != target_crs
+            ):
+                transform = QgsCoordinateTransform(
+                    source_crs, target_crs, QgsProject.instance()
+                )
+                extent = transform.transformBoundingBox(QgsRectangle(*bbox))
+                return _extent_to_bbox(extent)
+        except Exception as exc:
+            QgsMessageLog.logMessage(
+                f"Could not transform drawn Tanager bbox: {exc}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+        return bbox
+
+    def _bbox_from_points(self, start_point, end_point):
+        """Return a normalized bbox from two map points.
+
+        Args:
+            start_point: First corner point.
+            end_point: Opposite corner point.
+
+        Returns:
+            Bounding box list.
+        """
+        x_values = [float(start_point.x()), float(end_point.x())]
+        y_values = [float(start_point.y()), float(end_point.y())]
+        return [min(x_values), min(y_values), max(x_values), max(y_values)]
+
+    def _rectangle_points(self, start_point, end_point):
+        """Return rectangle corner points.
+
+        Args:
+            start_point: First corner point.
+            end_point: Opposite corner point.
+
+        Returns:
+            List of QGIS points in map coordinates.
+        """
+        xmin, ymin, xmax, ymax = self._bbox_from_points(start_point, end_point)
+        return [
+            QgsPointXY(xmin, ymin),
+            QgsPointXY(xmax, ymin),
+            QgsPointXY(xmax, ymax),
+            QgsPointXY(xmin, ymax),
+        ]
+
+    def _polygon_geometry_type(self):
+        """Return the QGIS polygon geometry type enum.
+
+        Returns:
+            Polygon geometry enum value.
+        """
+        geometry_type = getattr(QgsWkbTypes, "GeometryType", QgsWkbTypes)
+        return getattr(
+            geometry_type,
+            "PolygonGeometry",
+            getattr(QgsWkbTypes, "PolygonGeometry", 2),
+        )
 
 
 class TanagerSearchWorker(QThread):
@@ -267,6 +527,8 @@ class TanagerSearchDialog(QDockWidget):
         self._pending_load_context = None
         self._connected_global_footprint_layers = set()
         self._result_footprints_layer = None
+        self._bbox_map_tool = None
+        self._previous_map_tool = None
 
         self.setWindowTitle("Search Tanager Data")
         self.setObjectName("HyperCoastTanagerSearchDock")
@@ -293,6 +555,9 @@ class TanagerSearchDialog(QDockWidget):
         refresh_btn = QPushButton("Refresh")
         refresh_btn.clicked.connect(self.refresh_extent)
         extent_row.addWidget(refresh_btn)
+        draw_btn = QPushButton("Draw BBox")
+        draw_btn.clicked.connect(self.start_bbox_drawing)
+        extent_row.addWidget(draw_btn)
         global_btn = QPushButton("Global")
         global_btn.clicked.connect(self.clear_bbox)
         extent_row.addWidget(global_btn)
@@ -421,15 +686,94 @@ class TanagerSearchDialog(QDockWidget):
 
     def refresh_extent(self):
         """Refresh the bbox field from the current QGIS map extent."""
+        self._restore_previous_map_tool()
         bbox = self.current_canvas_bbox()
         if bbox:
             self.bbox_edit.setText(", ".join(f"{value:.8f}" for value in bbox))
             self.use_extent_check.setChecked(True)
 
+    def start_bbox_drawing(self):
+        """Activate a map tool for drawing the Tanager search bbox."""
+        try:
+            canvas = self.iface.mapCanvas()
+        except Exception as exc:
+            QMessageBox.warning(self, "Draw BBox", f"Could not access map: {exc}")
+            return
+
+        if self._bbox_map_tool is None:
+            self._bbox_map_tool = TanagerBboxMapTool(canvas, self)
+            self._bbox_map_tool.bbox_drawn.connect(self._on_bbox_drawn)
+            self._bbox_map_tool.canceled.connect(self._on_bbox_drawing_canceled)
+
+        map_tool = getattr(canvas, "mapTool", None)
+        if callable(map_tool):
+            try:
+                current_tool = map_tool()
+                if current_tool is not self._bbox_map_tool:
+                    self._previous_map_tool = current_tool
+            except Exception:
+                self._previous_map_tool = None
+
+        try:
+            canvas.setMapTool(self._bbox_map_tool)
+            self.use_extent_check.setChecked(False)
+            self.status_label.setText("Draw a rectangle on the map for the search bbox")
+        except Exception as exc:
+            QMessageBox.warning(
+                self, "Draw BBox", f"Could not activate map tool: {exc}"
+            )
+
+    def _on_bbox_drawn(self, bbox):
+        """Use a drawn bbox as manual search input.
+
+        Args:
+            bbox: Bounding box list in EPSG:4326.
+        """
+        self.use_extent_check.setChecked(False)
+        self.bbox_edit.setText(", ".join(f"{value:.8f}" for value in bbox))
+        self.status_label.setText("Drawn bbox ready for Tanager search")
+        self._restore_previous_map_tool()
+
+    def _on_bbox_drawing_canceled(self):
+        """Handle bbox drawing cancellation."""
+        self.status_label.setText("BBox drawing canceled")
+        self._restore_previous_map_tool()
+
+    def _restore_previous_map_tool(self):
+        """Restore the previous QGIS map tool after bbox drawing."""
+        if self._bbox_map_tool is None:
+            return
+        try:
+            canvas = self.iface.mapCanvas()
+            map_tool = getattr(canvas, "mapTool", None)
+            current_tool = map_tool() if callable(map_tool) else None
+            if current_tool is not self._bbox_map_tool:
+                return
+            if self._previous_map_tool is not None:
+                canvas.setMapTool(self._previous_map_tool)
+            else:
+                unset_map_tool = getattr(canvas, "unsetMapTool", None)
+                if callable(unset_map_tool):
+                    unset_map_tool(self._bbox_map_tool)
+        except Exception:
+            pass  # nosec B110
+        finally:
+            self._previous_map_tool = None
+
     def clear_bbox(self):
         """Clear the bbox filter for a global Tanager search."""
+        self._restore_previous_map_tool()
         self.use_extent_check.setChecked(False)
         self.bbox_edit.clear()
+
+    def closeEvent(self, event):
+        """Restore the previous map tool before closing.
+
+        Args:
+            event: QGIS close event.
+        """
+        self._restore_previous_map_tool()
+        super().closeEvent(event)
 
     def browse_download_dir(self):
         """Select a Tanager HDF5 download directory."""

--- a/qgis_plugin/qt6_tests/test_dock_panels.py
+++ b/qgis_plugin/qt6_tests/test_dock_panels.py
@@ -44,8 +44,8 @@ def test_plugin_windows_are_dock_widgets():
         assert issubclass(dock_class, QDockWidget)
 
 
-def test_tanager_auto_detect_sets_radiance_value_range(qapp, tmp_path):
-    """Auto-detected Tanager files should use a radiance-friendly max."""
+def test_tanager_auto_detect_sets_reflectance_value_range(qapp, tmp_path):
+    """Auto-detected Tanager files should use the default reflectance max."""
     h5py = pytest.importorskip("h5py")
     filepath = tmp_path / "custom_name.h5"
     with h5py.File(filepath, "w") as h5_file:
@@ -64,11 +64,11 @@ def test_tanager_auto_detect_sets_radiance_value_range(qapp, tmp_path):
 
     dialog._clear_dataset_preview()
 
-    assert dialog.vmax_spin.value() == 100.0
+    assert dialog.vmax_spin.value() == 0.5
 
 
-def test_spectral_plot_uses_tanager_radiance_defaults(qapp):
-    """Tanager spectra should switch the plot label and y-range."""
+def test_spectral_plot_uses_tanager_reflectance_defaults(qapp):
+    """Tanager spectra should keep the plot label and y-range on reflectance."""
     pytest.importorskip("matplotlib")
 
     class _Iface:
@@ -102,5 +102,5 @@ def test_spectral_plot_uses_tanager_radiance_defaults(qapp):
         data_type="Tanager",
     )
 
-    assert dialog.ylabel_combo.currentText() == "Radiance"
-    assert dialog.ymax_spin.value() == 100.0
+    assert dialog.ylabel_combo.currentText() == "Reflectance"
+    assert dialog.ymax_spin.value() == 0.5

--- a/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
+++ b/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
@@ -13,6 +13,7 @@ import hypercoast_qgis.dialogs.tanager_search_dialog as dialog_module
 from hypercoast_qgis.dialogs.tanager_search_dialog import (
     TANAGER_HDF5_ASSET,
     TANAGER_VISUAL_ASSET,
+    TanagerBboxMapTool,
     TanagerSearchDialog,
     TanagerSearchWorker,
     _asset_filename,
@@ -108,6 +109,59 @@ def test_canvas_bbox_uses_map_extent():
     dialog.iface = _Iface()
 
     assert dialog.current_canvas_bbox() == [-122.0, 37.0, -121.0, 38.0]
+
+
+def test_tanager_download_dir_defaults_to_user_downloads(monkeypatch, tmp_path):
+    """The default Tanager download folder should be the user's Downloads folder."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    out_dir = dialog_module.tanager_download_dir(project=object())
+
+    assert out_dir == str(tmp_path / "Downloads")
+    assert os.path.isdir(out_dir)
+
+
+def test_drawn_bbox_updates_manual_bbox(qapp, monkeypatch, tmp_path):
+    """Drawing a bbox should fill the bbox field as manual search input."""
+    dialog = _dialog(qapp, monkeypatch=monkeypatch, tmp_path=tmp_path)
+
+    dialog._on_bbox_drawn([-123.0, 36.5, -122.5, 37.25])
+
+    assert not dialog.use_extent_check.isChecked()
+    assert (
+        dialog.bbox_edit.text()
+        == "-123.00000000, 36.50000000, -122.50000000, 37.25000000"
+    )
+    assert dialog.search_params()["bbox"] == [-123.0, 36.5, -122.5, 37.25]
+
+
+def test_bbox_map_tool_normalizes_drag_direction():
+    """Drawn bboxes should be normalized regardless of drag direction."""
+
+    class _Point:
+        """Small point-like object."""
+
+        def __init__(self, x, y):
+            """Initialize point coordinates."""
+            self._x = x
+            self._y = y
+
+        def x(self):
+            """Return the x coordinate."""
+            return self._x
+
+        def y(self):
+            """Return the y coordinate."""
+            return self._y
+
+    tool = TanagerBboxMapTool.__new__(TanagerBboxMapTool)
+
+    assert tool._bbox_from_points(_Point(-121.0, 38.0), _Point(-122.0, 37.0)) == [
+        -122.0,
+        37.0,
+        -121.0,
+        38.0,
+    ]
 
 
 def test_dialog_minimum_width_is_compact(qapp, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Add an interactive map tool (`TanagerBboxMapTool`) for drawing search bounding boxes directly on the QGIS map canvas, with live rubber band preview and CRS transform to WGS84
- Correct Tanager value ranges from radiance (0-100) to reflectance (0-0.5) in both the load data and spectral plot dialogs
- Change the default Tanager download directory to `~/Downloads` for easier access
- Add a QGIS Plugin documentation page to the mkdocs site

## Test plan
- [ ] Verify the "Draw BBox" button activates the map tool and allows drawing a rectangle
- [ ] Confirm drawn bbox coordinates populate the search field correctly
- [ ] Check that Escape cancels drawing and restores the previous map tool
- [ ] Verify Tanager data loads with reflectance range (0-0.5) instead of radiance (0-100)
- [ ] Confirm spectral plot defaults to "Reflectance" label for Tanager data
- [ ] Run `pytest qgis_plugin/qt6_tests/` and confirm all tests pass