### PR TITLE
feat: add 3D image cube dialog to QGIS plugin

### DIFF
--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -20,6 +20,7 @@ Check out this [short video demo](https://youtu.be/EEUAC5BxqtM) and [full video 
 -   Search Planet Tanager STAC scenes from QGIS, add footprint layers, open visual imagery, and download HDF5 assets for hyperspectral analysis.
 -   Change RGB band combinations by wavelength and use presets such as true color, color infrared, agriculture, vegetation, water, geology, and chlorophyll-a.
 -   Extract and compare spectral signatures by clicking hyperspectral layers on the map.
+-   Create PyVista-based 3D hyperspectral image cubes with optional slicing and threshold widgets.
 -   Use dockable QGIS panels and batch-friendly Processing tools.
 
 ## Installation
@@ -73,6 +74,15 @@ For development installation, packaging, and troubleshooting details, see the [Q
 2. Click a location within a hyperspectral layer.
 3. Compare spectra in the spectral plot panel.
 4. Export data to CSV or save the plot image.
+
+### Creating 3D Image Cubes
+
+1. Load a hyperspectral layer.
+2. Click the **3D Image Cube** button.
+3. Select the layer, data variable, display range, RGB wavelengths, and widget mode.
+4. Click **Draw Subset** and draw a small rectangle on the map for large scenes.
+5. Adjust spatial or spectral stride to reduce memory use.
+6. Click **Create 3D Cube**.
 
 ### Running Processing Tools
 

--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -77,6 +77,8 @@ For development installation, packaging, and troubleshooting details, see the [Q
 
 ### Creating 3D Image Cubes
 
+![](https://github.com/user-attachments/assets/ee0cc11e-42ae-4ee7-89b2-d6f4fc27ca73)
+
 1. Load a hyperspectral layer.
 2. Click the **3D Image Cube** button.
 3. Select the layer, data variable, display range, RGB wavelengths, and widget mode.

--- a/hypercoast/common.py
+++ b/hypercoast/common.py
@@ -607,6 +607,7 @@ def image_cube(
     rgb_cmap: Optional[str] = None,
     rgb_clim: Optional[Tuple[float, float]] = None,
     rgb_args: Dict[str, Any] = None,
+    rgb_z_offset: Optional[float] = None,
     widget=None,
     plotter_args: Dict[str, Any] = None,
     show_axes: bool = True,
@@ -639,6 +640,10 @@ def image_cube(
             the RGB image. Defaults to None.
         rgb_args (Dict[str, Any], optional): Additional arguments for the
             `add_mesh` method for the RGB image. Defaults to {}.
+        rgb_z_offset (Optional[float], optional): Offset added above the cube
+            top face for the RGB overlay. If None, a small offset is computed
+            automatically to avoid z-fighting artifacts. Set to 0 to draw the
+            overlay exactly on the cube top face.
         widget (Optional[str], optional): The widget to use for the image cube.
             Can be one of the following: "box", "plane", "slice", "orthogonal",
             and "threshold". Defaults to None.
@@ -825,7 +830,9 @@ def image_cube(
         )
 
         grid_z_max = grid.bounds[5]
-        im.origin = (0, 0, grid_z_max)
+        if rgb_z_offset is None:
+            rgb_z_offset = max(abs(grid.spacing[2]) * 1e-3, 1e-6)
+        im.origin = (0, 0, grid_z_max + rgb_z_offset)
 
         if rgb_image.shape[2] < 3:
             if rgb_cmap is None:

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -27,6 +27,8 @@ Check out this [short video demo](https://youtu.be/EEUAC5BxqtM) and [full video 
 
 -   **Dockable QGIS Panels**: Open HyperCoast tools as dockable panels that can be tabbed with the QGIS interface.
 
+-   **3D Image Cubes**: Create PyVista-based 3D hyperspectral cubes from loaded HyperCoast layers, with optional slicing and threshold widgets.
+
 -   **Processing Tools**: Run batch-friendly Processing algorithms for RGB composites, single-band exports, spectral indices, and PCA components.
 
 Before using the plugin, please create a new conda environment to install QGIS and HyperCoast:
@@ -106,6 +108,15 @@ When QGIS is launched from this Conda environment, the plugin automatically dete
 3. The spectral plot window will show the extracted spectrum
 4. Click multiple locations to compare spectra
 5. Export data to CSV or save the plot image
+
+### Creating 3D Image Cubes
+
+1. Load a hyperspectral layer
+2. Click the **3D Image Cube** button
+3. Select the layer, data variable, display range, RGB wavelengths, and widget mode
+4. Click **Draw Subset** and draw a small rectangle on the map for large scenes
+5. Adjust spatial or spectral stride to reduce memory use
+6. Click **Create 3D Cube**
 
 ### Running Processing Tools
 

--- a/qgis_plugin/hypercoast_qgis/dialogs/__init__.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/__init__.py
@@ -17,6 +17,7 @@ from .update_checker import UpdateCheckerDialog
 try:
     from .load_data_dialog import LoadDataDialog
     from .band_combination_dialog import BandCombinationDialog
+    from .image_cube_dialog import ImageCubeDialog
     from .spectral_inspector_tool import SpectralInspectorTool
     from .spectral_plot_dialog import SpectralPlotDialog
 
@@ -28,6 +29,7 @@ __all__ = [
     "DependencyInstallerDialog",
     "LoadDataDialog",
     "BandCombinationDialog",
+    "ImageCubeDialog",
     "SpectralInspectorTool",
     "SpectralPlotDialog",
     "UpdateCheckerDialog",

--- a/qgis_plugin/hypercoast_qgis/dialogs/image_cube_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/image_cube_dialog.py
@@ -1,0 +1,1154 @@
+# -*- coding: utf-8 -*-
+"""
+HyperCoast QGIS Plugin - 3D Image Cube Dialog
+
+SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+SPDX-License-Identifier: MIT
+"""
+
+import json
+import os
+import subprocess
+import sys
+import uuid
+
+from qgis.PyQt.QtCore import QObject, Qt, QThread, pyqtSignal
+from qgis.PyQt.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDockWidget,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+from qgis.core import QgsMessageLog, QgsProject, Qgis
+
+from ..cache_manager import generated_raster_cache_dir
+from .tanager_search_dialog import TanagerBboxMapTool
+
+DEFAULT_CLIM = (0.0, 0.5)
+MAX_CUBE_POINTS = 5_000_000
+SPECTRAL_DIMS = {"wavelength", "wavelengths", "band", "bands"}
+WIDGET_OPTIONS = (
+    ("None", None),
+    ("Slice", "slice"),
+    ("Orthogonal Slices", "orthogonal"),
+    ("Threshold", "threshold"),
+    ("Clip Box", "box"),
+    ("Clip Plane", "plane"),
+)
+
+
+def _write_cube_dataset_file(dataset, path):
+    """Write a prepared cube dataset to NetCDF.
+
+    Args:
+        dataset: Xarray dataset.
+        path: Output NetCDF path.
+    """
+    loaded = dataset.load()
+    try:
+        loaded.to_netcdf(path, engine="scipy")
+    except Exception:
+        loaded.to_netcdf(path)
+
+
+def _json_safe_options(options):
+    """Return image cube options that can be serialized to JSON.
+
+    Args:
+        options: Raw keyword arguments for ``hypercoast.image_cube``.
+
+    Returns:
+        JSON-serializable dictionary.
+    """
+    safe_options = {}
+    for key, value in options.items():
+        if isinstance(value, tuple):
+            safe_options[key] = list(value)
+        else:
+            safe_options[key] = value
+    return safe_options
+
+
+def _viewer_script_source():
+    """Return the standalone image cube viewer script.
+
+    Returns:
+        Python source code for the viewer process.
+    """
+    return """\
+import json
+import sys
+import traceback
+
+import hypercoast
+import xarray as xr
+
+
+def main():
+    dataset_path = sys.argv[1]
+    options_path = sys.argv[2]
+    with open(options_path, "r", encoding="utf-8") as options_file:
+        options = json.load(options_file)
+    dataset = xr.open_dataset(dataset_path).load()
+    plotter = hypercoast.image_cube(dataset, **options)
+    show = getattr(plotter, "show", None)
+    if callable(show):
+        show()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        traceback.print_exc()
+        raise
+"""
+
+
+def _run_image_cube_launch(dataset, options, context):
+    """Write cube viewer inputs and start the external viewer process.
+
+    Args:
+        dataset: Prepared xarray dataset.
+        options: Keyword arguments for ``hypercoast.image_cube``.
+        context: Launch context containing paths, environment, and command
+            options.
+
+    Returns:
+        Tuple of subprocess handle and stderr log path.
+    """
+    _write_cube_dataset_file(dataset, context["dataset_path"])
+    with open(context["options_path"], "w", encoding="utf-8") as options_file:
+        json.dump(_json_safe_options(options), options_file)
+    with open(context["script_path"], "w", encoding="utf-8") as script_file:
+        script_file.write(_viewer_script_source())
+
+    with open(context["stdout_path"], "w", encoding="utf-8") as stdout_file:
+        with open(context["stderr_path"], "w", encoding="utf-8") as stderr_file:
+            process = subprocess.Popen(
+                context["cmd"],
+                cwd=context["cache_dir"],
+                env=context["env"],
+                stdout=stdout_file,
+                stderr=stderr_file,
+                **context["popen_kwargs"],
+            )
+    return process, context["stderr_path"]
+
+
+class ImageCubeLaunchWorker(QObject):
+    """Worker for writing cube files and launching the standalone viewer."""
+
+    finished = pyqtSignal(object, str)
+    failed = pyqtSignal(str)
+
+    def __init__(self, dataset, options, context):
+        """Initialize the worker.
+
+        Args:
+            dataset: Prepared xarray dataset.
+            options: Keyword arguments for ``hypercoast.image_cube``.
+            context: External viewer launch context.
+        """
+        super().__init__()
+        self.dataset = dataset
+        self.options = options
+        self.context = context
+
+    def run(self):
+        """Run the external viewer preparation and launch."""
+        try:
+            process, stderr_path = _run_image_cube_launch(
+                self.dataset, self.options, self.context
+            )
+            self.finished.emit(process, stderr_path)
+        except Exception as exc:
+            self.failed.emit(str(exc))
+
+
+class ImageCubeDialog(QDockWidget):
+    """Dockable panel for creating PyVista 3D hyperspectral image cubes."""
+
+    def __init__(self, iface, plugin, parent=None):
+        """Initialize the dialog.
+
+        Args:
+            iface: QGIS interface.
+            plugin: Reference to the main plugin.
+            parent: Optional parent widget.
+        """
+        super().__init__(parent or iface.mainWindow())
+        self.iface = iface
+        self.plugin = plugin
+        self._viewer_processes = []
+        self._bbox_map_tool = None
+        self._previous_map_tool = None
+        self._subset_bbox = None
+        self._cube_thread = None
+        self._cube_worker = None
+
+        self.setWindowTitle("3D Image Cube")
+        self.setObjectName("HyperCoastImageCubeDock")
+        self.setMinimumWidth(520)
+        self.setMinimumHeight(420)
+
+        self.setup_ui()
+
+    def setup_ui(self):
+        """Set up the user interface."""
+        content = QWidget(self)
+        self.setWidget(content)
+        layout = QVBoxLayout(content)
+
+        layer_group = QGroupBox("Layer")
+        layer_layout = QHBoxLayout(layer_group)
+        self.layer_combo = QComboBox()
+        self.layer_combo.currentIndexChanged.connect(self._on_layer_changed)
+        layer_layout.addWidget(self.layer_combo, 1)
+        refresh_btn = QPushButton("Refresh")
+        refresh_btn.clicked.connect(self.refresh_layers)
+        layer_layout.addWidget(refresh_btn)
+        layout.addWidget(layer_group)
+
+        cube_group = QGroupBox("Cube Options")
+        cube_form = QFormLayout(cube_group)
+
+        self.variable_combo = QComboBox()
+        cube_form.addRow("Variable:", self.variable_combo)
+
+        self.widget_combo = QComboBox()
+        for label, value in WIDGET_OPTIONS:
+            self.widget_combo.addItem(label, value)
+        cube_form.addRow("Widget:", self.widget_combo)
+
+        self.cmap_combo = QComboBox()
+        self.cmap_combo.addItems(["jet", "viridis", "plasma", "inferno", "gray"])
+        cube_form.addRow("Colormap:", self.cmap_combo)
+
+        clim_row = QHBoxLayout()
+        self.vmin_spin = QDoubleSpinBox()
+        self.vmin_spin.setRange(-1_000_000, 1_000_000)
+        self.vmin_spin.setDecimals(4)
+        self.vmin_spin.setValue(DEFAULT_CLIM[0])
+        clim_row.addWidget(QLabel("Min:"))
+        clim_row.addWidget(self.vmin_spin)
+        self.vmax_spin = QDoubleSpinBox()
+        self.vmax_spin.setRange(-1_000_000, 1_000_000)
+        self.vmax_spin.setDecimals(4)
+        self.vmax_spin.setValue(DEFAULT_CLIM[1])
+        clim_row.addWidget(QLabel("Max:"))
+        clim_row.addWidget(self.vmax_spin)
+        cube_form.addRow("Value Range:", clim_row)
+
+        rgb_row = QHBoxLayout()
+        self.red_spin = self._wavelength_spin(650)
+        self.green_spin = self._wavelength_spin(550)
+        self.blue_spin = self._wavelength_spin(450)
+        rgb_row.addWidget(QLabel("R:"))
+        rgb_row.addWidget(self.red_spin)
+        rgb_row.addWidget(QLabel("G:"))
+        rgb_row.addWidget(self.green_spin)
+        rgb_row.addWidget(QLabel("B:"))
+        rgb_row.addWidget(self.blue_spin)
+        cube_form.addRow("RGB Wavelengths:", rgb_row)
+
+        self.gamma_spin = QDoubleSpinBox()
+        self.gamma_spin.setRange(0.01, 10.0)
+        self.gamma_spin.setDecimals(2)
+        self.gamma_spin.setSingleStep(0.1)
+        self.gamma_spin.setValue(1.0)
+        cube_form.addRow("RGB Gamma:", self.gamma_spin)
+
+        layout.addWidget(cube_group)
+
+        subset_group = QGroupBox("Subset")
+        subset_layout = QHBoxLayout(subset_group)
+        self.subset_bbox_edit = QLineEdit()
+        self.subset_bbox_edit.setReadOnly(True)
+        self.subset_bbox_edit.setPlaceholderText("Draw a small rectangle on the map")
+        subset_layout.addWidget(self.subset_bbox_edit, 1)
+        draw_subset_btn = QPushButton("Draw Subset")
+        draw_subset_btn.clicked.connect(self.start_subset_drawing)
+        subset_layout.addWidget(draw_subset_btn)
+        clear_subset_btn = QPushButton("Clear")
+        clear_subset_btn.clicked.connect(self.clear_subset)
+        subset_layout.addWidget(clear_subset_btn)
+        layout.addWidget(subset_group)
+
+        performance_group = QGroupBox("Performance")
+        performance_form = QFormLayout(performance_group)
+
+        self.spatial_stride_spin = QSpinBox()
+        self.spatial_stride_spin.setRange(1, 100)
+        self.spatial_stride_spin.setValue(4)
+        performance_form.addRow("Spatial Stride:", self.spatial_stride_spin)
+
+        self.spectral_stride_spin = QSpinBox()
+        self.spectral_stride_spin.setRange(1, 100)
+        self.spectral_stride_spin.setValue(1)
+        performance_form.addRow("Spectral Stride:", self.spectral_stride_spin)
+
+        self.crop_spin = QSpinBox()
+        self.crop_spin.setRange(0, 100000)
+        self.crop_spin.setValue(0)
+        performance_form.addRow("Crop Pixels:", self.crop_spin)
+
+        nodata_row = QHBoxLayout()
+        self.nodata_check = QCheckBox("Mask")
+        self.nodata_check.stateChanged.connect(self._sync_nodata_state)
+        nodata_row.addWidget(self.nodata_check)
+        self.nodata_spin = QDoubleSpinBox()
+        self.nodata_spin.setRange(-1_000_000, 1_000_000)
+        self.nodata_spin.setDecimals(4)
+        self.nodata_spin.setValue(0.0)
+        self.nodata_spin.setEnabled(False)
+        nodata_row.addWidget(self.nodata_spin)
+        performance_form.addRow("NoData:", nodata_row)
+
+        layout.addWidget(performance_group)
+
+        self.status_label = QLabel("")
+        layout.addWidget(self.status_label)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setRange(0, 0)
+        self.progress_bar.setTextVisible(False)
+        self.progress_bar.setVisible(False)
+        layout.addWidget(self.progress_bar)
+
+        button_layout = QHBoxLayout()
+        self.create_btn = QPushButton("Create 3D Cube")
+        self.create_btn.clicked.connect(self.create_cube)
+        button_layout.addWidget(self.create_btn)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.close)
+        button_layout.addWidget(close_btn)
+        layout.addLayout(button_layout)
+
+        layout.addStretch()
+        self.refresh_layers()
+
+    def _wavelength_spin(self, value):
+        """Create a wavelength spin box.
+
+        Args:
+            value: Initial wavelength value.
+
+        Returns:
+            Configured spin box.
+        """
+        spin = QDoubleSpinBox()
+        spin.setRange(0, 5000)
+        spin.setDecimals(1)
+        spin.setSuffix(" nm")
+        spin.setValue(value)
+        return spin
+
+    def start_subset_drawing(self):
+        """Activate a map tool for drawing a small image-cube subset."""
+        try:
+            canvas = self.iface.mapCanvas()
+        except Exception as exc:
+            QMessageBox.warning(self, "3D Image Cube", f"Could not access map: {exc}")
+            return
+
+        if self._bbox_map_tool is None:
+            self._bbox_map_tool = TanagerBboxMapTool(canvas, self)
+            self._bbox_map_tool.bbox_drawn.connect(self._on_subset_bbox_drawn)
+            self._bbox_map_tool.canceled.connect(self._on_subset_drawing_canceled)
+
+        map_tool = getattr(canvas, "mapTool", None)
+        if callable(map_tool):
+            try:
+                current_tool = map_tool()
+                if current_tool is not self._bbox_map_tool:
+                    self._previous_map_tool = current_tool
+            except Exception:
+                self._previous_map_tool = None
+
+        try:
+            canvas.setMapTool(self._bbox_map_tool)
+            self.status_label.setText("Draw a small rectangle for the 3D cube subset")
+        except Exception as exc:
+            QMessageBox.warning(
+                self, "3D Image Cube", f"Could not activate map tool: {exc}"
+            )
+
+    def clear_subset(self):
+        """Clear the drawn image-cube subset."""
+        self._restore_previous_map_tool()
+        self._subset_bbox = None
+        self.subset_bbox_edit.clear()
+        self.status_label.setText("")
+
+    def _on_subset_bbox_drawn(self, bbox):
+        """Store the drawn image-cube subset bbox.
+
+        Args:
+            bbox: Bounding box list in EPSG:4326.
+        """
+        self._subset_bbox = [float(value) for value in bbox]
+        self.subset_bbox_edit.setText(
+            ", ".join(f"{value:.8f}" for value in self._subset_bbox)
+        )
+        self.status_label.setText("Subset ready for 3D image cube")
+        self._restore_previous_map_tool()
+
+    def _on_subset_drawing_canceled(self):
+        """Handle subset drawing cancellation."""
+        self.status_label.setText("Subset drawing canceled")
+        self._restore_previous_map_tool()
+
+    def _restore_previous_map_tool(self):
+        """Restore the previous QGIS map tool after subset drawing."""
+        if self._bbox_map_tool is None:
+            return
+        try:
+            canvas = self.iface.mapCanvas()
+            map_tool = getattr(canvas, "mapTool", None)
+            current_tool = map_tool() if callable(map_tool) else None
+            if current_tool is not self._bbox_map_tool:
+                return
+            if self._previous_map_tool is not None:
+                canvas.setMapTool(self._previous_map_tool)
+            else:
+                unset_map_tool = getattr(canvas, "unsetMapTool", None)
+                if callable(unset_map_tool):
+                    unset_map_tool(self._bbox_map_tool)
+        except Exception:
+            pass  # nosec B110
+        finally:
+            self._previous_map_tool = None
+
+    def refresh_layers(self):
+        """Refresh the available HyperCoast layer list."""
+        current_layer_id = self.selected_layer_id()
+        self.layer_combo.blockSignals(True)
+        self.layer_combo.clear()
+
+        layers = self.plugin.get_all_hyperspectral_layers()
+        for layer_id in layers:
+            layer = self._project_layer(layer_id)
+            name = layer.name() if layer is not None else layer_id
+            if not isinstance(name, str):
+                name = layer_id
+            self.layer_combo.addItem(name, layer_id)
+
+        if self.layer_combo.count() == 0:
+            self.layer_combo.addItem("No HyperCoast layers", None)
+        elif current_layer_id:
+            index = self.layer_combo.findData(current_layer_id)
+            if index >= 0:
+                self.layer_combo.setCurrentIndex(index)
+
+        self.layer_combo.blockSignals(False)
+        self._on_layer_changed()
+
+    def selected_layer_id(self):
+        """Return the selected layer ID.
+
+        Returns:
+            QGIS layer ID, or None.
+        """
+        return self.layer_combo.currentData() if hasattr(self, "layer_combo") else None
+
+    def _on_layer_changed(self, *args):
+        """Update controls for the selected layer."""
+        data_info = self._selected_data_info()
+        if not data_info:
+            self.variable_combo.clear()
+            return
+
+        rgb_wavelengths = data_info.get("rgb_wavelengths") or []
+        if len(rgb_wavelengths) >= 3:
+            self.red_spin.setValue(float(rgb_wavelengths[0]))
+            self.green_spin.setValue(float(rgb_wavelengths[1]))
+            self.blue_spin.setValue(float(rgb_wavelengths[2]))
+
+        dataset = data_info.get("dataset")
+        self._populate_variables(getattr(dataset, "dataset", None), data_info)
+
+    def _selected_data_info(self):
+        """Return metadata for the selected HyperCoast layer.
+
+        Returns:
+            Layer metadata dictionary, or None.
+        """
+        layer_id = self.selected_layer_id()
+        if not layer_id:
+            return None
+        return self.plugin.get_hyperspectral_data(layer_id) or {}
+
+    def _populate_variables(self, dataset, data_info=None):
+        """Populate the data-variable selector.
+
+        Args:
+            dataset: Xarray dataset, or None.
+            data_info: Optional layer metadata.
+        """
+        current = self.variable_combo.currentData()
+        selected = (data_info or {}).get("selected_variable")
+        self.variable_combo.blockSignals(True)
+        self.variable_combo.clear()
+
+        names = (
+            list(getattr(dataset, "data_vars", {}).keys())
+            if dataset is not None
+            else []
+        )
+        if names:
+            for name in names:
+                self.variable_combo.addItem(name, name)
+            desired = current or selected
+            if desired:
+                index = self.variable_combo.findData(desired)
+                if index >= 0:
+                    self.variable_combo.setCurrentIndex(index)
+        else:
+            self.variable_combo.addItem("Default variable", None)
+
+        self.variable_combo.blockSignals(False)
+
+    def create_cube(self):
+        """Create and display a 3D image cube for the selected layer."""
+        layer_id = self.selected_layer_id()
+        if not layer_id:
+            QMessageBox.warning(self, "3D Image Cube", "No HyperCoast layer selected.")
+            return
+
+        dataset_obj = self.plugin.ensure_hyperspectral_dataset(layer_id)
+        if dataset_obj is None or getattr(dataset_obj, "dataset", None) is None:
+            QMessageBox.warning(
+                self, "3D Image Cube", "Could not load the selected dataset."
+            )
+            return
+
+        dataset = dataset_obj.dataset
+        self._populate_variables(dataset, self.plugin.get_hyperspectral_data(layer_id))
+        variable = self._selected_variable_name(dataset_obj)
+        if not variable or variable not in dataset.data_vars:
+            QMessageBox.warning(
+                self, "3D Image Cube", "No raster-like data variable found."
+            )
+            return
+        if dataset[variable].ndim != 3:
+            QMessageBox.warning(
+                self,
+                "3D Image Cube",
+                f"Expected a 3D data variable, got shape {dataset[variable].shape}.",
+            )
+            return
+
+        try:
+            cube_dataset = self._subset_dataset(dataset, variable, self._subset_bbox)
+            cube_dataset = self._downsample_dataset(
+                cube_dataset,
+                self.spatial_stride_spin.value(),
+                self.spectral_stride_spin.value(),
+            )
+            cube_dataset = self._prepare_image_cube_dataset(cube_dataset, variable)
+            if not self._validate_cube_size(cube_dataset, variable):
+                return
+            kwargs = self._image_cube_kwargs(cube_dataset, variable)
+            self._start_image_cube_worker(cube_dataset, kwargs)
+        except Exception as exc:
+            QMessageBox.warning(
+                self,
+                "3D Image Cube",
+                f"Could not create 3D image cube.\n\nDetails:\n{exc}",
+            )
+            QgsMessageLog.logMessage(
+                f"Could not create 3D image cube: {exc}",
+                "HyperCoast",
+                Qgis.MessageLevel.Warning,
+            )
+            self.status_label.setText("3D image cube failed")
+            self._set_cube_busy(False)
+
+    def _start_image_cube_worker(self, dataset, kwargs):
+        """Start a worker thread that prepares and launches the cube viewer.
+
+        Args:
+            dataset: Prepared xarray dataset to visualize.
+            kwargs: Keyword arguments for ``hypercoast.image_cube``.
+        """
+        if self._cube_thread is not None and self._cube_thread.isRunning():
+            QMessageBox.warning(
+                self,
+                "3D Image Cube",
+                "A 3D image cube is already being prepared.",
+            )
+            return
+
+        context = self._image_cube_launch_context()
+        thread = QThread(self)
+        worker = ImageCubeLaunchWorker(dataset, kwargs, context)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.finished.connect(self._on_image_cube_worker_finished)
+        worker.failed.connect(self._on_image_cube_worker_failed)
+        worker.finished.connect(thread.quit)
+        worker.failed.connect(thread.quit)
+        worker.finished.connect(worker.deleteLater)
+        worker.failed.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        thread.finished.connect(self._clear_image_cube_worker)
+
+        self._cube_thread = thread
+        self._cube_worker = worker
+        self._set_cube_busy(True, "Creating 3D image cube...")
+        thread.start()
+
+    def _on_image_cube_worker_finished(self, process, stderr_path):
+        """Handle successful external viewer startup.
+
+        Args:
+            process: Viewer subprocess handle.
+            stderr_path: Path to the viewer stderr log.
+        """
+        self._viewer_processes.append(process)
+        QgsMessageLog.logMessage(
+            f"3D image cube viewer launched. Error log: {stderr_path}",
+            "HyperCoast",
+            Qgis.MessageLevel.Info,
+        )
+        self._set_cube_busy(False, "3D image cube viewer launched")
+
+    def _on_image_cube_worker_failed(self, message):
+        """Handle image cube worker failure.
+
+        Args:
+            message: User-visible failure details.
+        """
+        QMessageBox.warning(
+            self,
+            "3D Image Cube",
+            f"Could not create 3D image cube.\n\nDetails:\n{message}",
+        )
+        QgsMessageLog.logMessage(
+            f"Could not create 3D image cube: {message}",
+            "HyperCoast",
+            Qgis.MessageLevel.Warning,
+        )
+        self._set_cube_busy(False, "3D image cube failed")
+
+    def _clear_image_cube_worker(self):
+        """Clear references to the completed image cube worker."""
+        self._cube_thread = None
+        self._cube_worker = None
+
+    def _set_cube_busy(self, busy, message=None):
+        """Show or hide the busy progress indicator.
+
+        Args:
+            busy: Whether image cube creation is running.
+            message: Optional status text.
+        """
+        self.progress_bar.setVisible(busy)
+        self.create_btn.setEnabled(not busy)
+        if message is not None:
+            self.status_label.setText(message)
+
+    def _launch_image_cube_viewer(self, dataset, kwargs):
+        """Launch ``hypercoast.image_cube`` in a separate Python process.
+
+        Rendering PyVista/VTK inside QGIS can terminate the whole QGIS process
+        when native libraries conflict. The dialog therefore prepares a small
+        temporary NetCDF cube and starts a standalone viewer process.
+
+        Args:
+            dataset: Prepared xarray dataset to visualize.
+            kwargs: Keyword arguments for ``hypercoast.image_cube``.
+
+        Raises:
+            OSError: If temporary files cannot be written or the viewer cannot
+                be launched.
+        """
+        context = self._image_cube_launch_context()
+        process, stderr_path = _run_image_cube_launch(dataset, kwargs, context)
+        self._viewer_processes.append(process)
+        QgsMessageLog.logMessage(
+            f"3D image cube viewer launched. Error log: {stderr_path}",
+            "HyperCoast",
+            Qgis.MessageLevel.Info,
+        )
+
+    def _image_cube_launch_context(self):
+        """Return paths and options for launching the external cube viewer.
+
+        Returns:
+            Launch context dictionary.
+        """
+        cache_dir = self._image_cube_cache_dir()
+        token = uuid.uuid4().hex[:10]
+        dataset_path = os.path.join(cache_dir, f"image_cube_{token}.nc")
+        options_path = os.path.join(cache_dir, f"image_cube_{token}.json")
+        script_path = os.path.join(cache_dir, f"image_cube_viewer_{token}.py")
+        stdout_path = os.path.join(cache_dir, f"image_cube_{token}.out.log")
+        stderr_path = os.path.join(cache_dir, f"image_cube_{token}.err.log")
+
+        python_path = self._viewer_python_path()
+        cmd = [python_path, script_path, dataset_path, options_path]
+        env = self._viewer_environment(python_path)
+        popen_kwargs = self._viewer_popen_kwargs()
+        return {
+            "cache_dir": cache_dir,
+            "dataset_path": dataset_path,
+            "options_path": options_path,
+            "script_path": script_path,
+            "stdout_path": stdout_path,
+            "stderr_path": stderr_path,
+            "cmd": cmd,
+            "env": env,
+            "popen_kwargs": popen_kwargs,
+        }
+
+    def _image_cube_cache_dir(self):
+        """Return the cache directory for temporary image cube viewer files.
+
+        Returns:
+            Absolute cache directory path.
+        """
+        cache_dir = os.path.join(
+            generated_raster_cache_dir(QgsProject.instance()), "image_cube"
+        )
+        os.makedirs(cache_dir, exist_ok=True)
+        return cache_dir
+
+    def _write_cube_dataset(self, dataset, path):
+        """Write a prepared cube dataset to NetCDF.
+
+        Args:
+            dataset: Xarray dataset.
+            path: Output NetCDF path.
+        """
+        _write_cube_dataset_file(dataset, path)
+
+    def _json_safe_options(self, options):
+        """Return image cube options that can be serialized to JSON.
+
+        Args:
+            options: Raw keyword arguments for ``hypercoast.image_cube``.
+
+        Returns:
+            JSON-serializable dictionary.
+        """
+        return _json_safe_options(options)
+
+    def _viewer_python_path(self):
+        """Return the Python interpreter used to launch the cube viewer.
+
+        Returns:
+            Absolute Python executable path, or ``python`` as a fallback.
+        """
+        conda_prefix = os.environ.get("CONDA_PREFIX")
+        if conda_prefix:
+            executable = "python.exe" if os.name == "nt" else "python"
+            conda_python = os.path.join(conda_prefix, executable)
+            if os.path.isfile(conda_python):
+                return conda_python
+
+        try:
+            from ..core.venv_manager import get_venv_python_path
+
+            venv_python = get_venv_python_path()
+            if os.path.isfile(venv_python):
+                return venv_python
+        except Exception:
+            pass  # nosec B110
+
+        if sys.executable and os.path.isfile(sys.executable):
+            return sys.executable
+        return "python"
+
+    def _viewer_environment(self, python_path):
+        """Return a subprocess environment for the standalone cube viewer.
+
+        Args:
+            python_path: Python executable used by the viewer.
+
+        Returns:
+            Environment dictionary.
+        """
+        env = os.environ.copy()
+        for name in (
+            "PYTHONHOME",
+            "PYTHONPATH",
+            "QGIS_PREFIX_PATH",
+            "QGIS_PLUGINPATH",
+            "PYQGIS_STARTUP",
+        ):
+            env.pop(name, None)
+        env["PYTHONIOENCODING"] = "utf-8"
+        source_root = self._source_package_root()
+        if source_root:
+            env["PYTHONPATH"] = source_root
+        python_dir = os.path.dirname(python_path)
+        if python_dir:
+            env["PATH"] = python_dir + os.pathsep + env.get("PATH", "")
+        return env
+
+    def _source_package_root(self):
+        """Return the repository root when running from a source checkout.
+
+        Returns:
+            Repository root path, or None when the HyperCoast package is not
+            available beside the QGIS plugin checkout.
+        """
+        root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..")
+        )
+        return root if os.path.isdir(os.path.join(root, "hypercoast")) else None
+
+    def _viewer_popen_kwargs(self):
+        """Return platform-specific arguments for launching the viewer.
+
+        Returns:
+            Dictionary of ``subprocess.Popen`` keyword arguments.
+        """
+        if os.name == "nt":
+            creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            return {"creationflags": creationflags}
+        return {"start_new_session": True}
+
+    def _viewer_script(self):
+        """Return the standalone image cube viewer script.
+
+        Returns:
+            Python source code for the viewer process.
+        """
+        return _viewer_script_source()
+
+    def _subset_dataset(self, dataset, variable, bbox):
+        """Subset a dataset to a WGS84 bounding box.
+
+        Args:
+            dataset: Xarray dataset.
+            variable: Data variable name.
+            bbox: Optional ``[xmin, ymin, xmax, ymax]`` bbox in EPSG:4326.
+
+        Returns:
+            Spatially subset dataset, or the original dataset when no bbox is
+            supplied.
+
+        Raises:
+            ValueError: If a bbox is supplied but cannot be applied.
+        """
+        if not bbox:
+            return dataset
+        subset = self._subset_by_2d_latlon(dataset, bbox)
+        if subset is not None:
+            return subset
+        subset = self._subset_by_1d_coords(dataset, bbox)
+        if subset is not None:
+            return subset
+        if variable in dataset.data_vars:
+            subset = self._subset_by_1d_coords(dataset[variable].to_dataset(), bbox)
+            if subset is not None:
+                return subset
+        raise ValueError(
+            "The selected dataset does not expose latitude/longitude coordinates "
+            "that can be subset from the drawn rectangle."
+        )
+
+    def _subset_by_2d_latlon(self, dataset, bbox):
+        """Subset a dataset with 2D latitude and longitude coordinates.
+
+        Args:
+            dataset: Xarray dataset.
+            bbox: ``[xmin, ymin, xmax, ymax]`` in EPSG:4326.
+
+        Returns:
+            Subset dataset, or None when 2D lat/lon coordinates are unavailable.
+        """
+        if "latitude" not in dataset or "longitude" not in dataset:
+            return None
+        lat = dataset["latitude"]
+        lon = dataset["longitude"]
+        if lat.ndim != 2 or lon.ndim != 2:
+            return None
+
+        import numpy as np
+
+        xmin, ymin, xmax, ymax = bbox
+        mask = (
+            (lon.values >= xmin)
+            & (lon.values <= xmax)
+            & (lat.values >= ymin)
+            & (lat.values <= ymax)
+        )
+        if not np.any(mask):
+            raise ValueError("The drawn rectangle does not intersect the dataset.")
+        rows, cols = np.where(mask)
+        y_dim, x_dim = lat.dims
+        return dataset.isel(
+            {
+                y_dim: slice(int(rows.min()), int(rows.max()) + 1),
+                x_dim: slice(int(cols.min()), int(cols.max()) + 1),
+            }
+        )
+
+    def _subset_by_1d_coords(self, dataset, bbox):
+        """Subset a dataset with 1D latitude/longitude or x/y coordinates.
+
+        Args:
+            dataset: Xarray dataset.
+            bbox: ``[xmin, ymin, xmax, ymax]`` in EPSG:4326.
+
+        Returns:
+            Subset dataset, or None when usable 1D coordinates are unavailable.
+        """
+        x_name, y_name = self._xy_coord_names(dataset)
+        if x_name is None or y_name is None:
+            return None
+        x_coord = dataset.coords.get(x_name)
+        y_coord = dataset.coords.get(y_name)
+        if x_coord is None or y_coord is None or x_coord.ndim != 1 or y_coord.ndim != 1:
+            return None
+
+        xmin, ymin, xmax, ymax = bbox
+        indexers = {
+            x_name: self._coord_slice(x_coord.values, xmin, xmax),
+            y_name: self._coord_slice(y_coord.values, ymin, ymax),
+        }
+        subset = dataset.sel(indexers)
+        if subset.sizes.get(x_name, 0) == 0 or subset.sizes.get(y_name, 0) == 0:
+            raise ValueError("The drawn rectangle does not intersect the dataset.")
+        return subset
+
+    def _xy_coord_names(self, dataset):
+        """Return likely horizontal coordinate names.
+
+        Args:
+            dataset: Xarray dataset.
+
+        Returns:
+            Tuple of x and y coordinate names, or ``(None, None)``.
+        """
+        for x_name, y_name in (
+            ("longitude", "latitude"),
+            ("lon", "lat"),
+            ("x", "y"),
+        ):
+            if x_name in dataset.coords and y_name in dataset.coords:
+                return x_name, y_name
+        return None, None
+
+    def _coord_slice(self, values, minimum, maximum):
+        """Return a coordinate slice that respects axis order.
+
+        Args:
+            values: 1D coordinate values.
+            minimum: Minimum requested coordinate.
+            maximum: Maximum requested coordinate.
+
+        Returns:
+            Slice for xarray selection.
+        """
+        if len(values) > 1 and values[0] > values[-1]:
+            return slice(maximum, minimum)
+        return slice(minimum, maximum)
+
+    def _validate_cube_size(self, dataset, variable):
+        """Return whether a cube is small enough to render safely.
+
+        Args:
+            dataset: Xarray dataset.
+            variable: Data variable name.
+
+        Returns:
+            True when rendering may proceed.
+        """
+        if variable not in dataset.data_vars:
+            return True
+        point_count = 1
+        for size in dataset[variable].shape:
+            point_count *= int(size)
+        if point_count <= MAX_CUBE_POINTS:
+            return True
+
+        message = (
+            f"The requested cube has {point_count:,} values after subsetting and "
+            "stride. Draw a smaller subset or increase the spatial/spectral stride "
+            "before creating a 3D cube."
+        )
+        QMessageBox.warning(self, "3D Image Cube", message)
+        self.status_label.setText("3D image cube too large")
+        return False
+
+    def _selected_variable_name(self, dataset_obj):
+        """Return the selected data variable name.
+
+        Args:
+            dataset_obj: HyperCoast dataset wrapper.
+
+        Returns:
+            Data variable name, or None.
+        """
+        variable = self.variable_combo.currentData()
+        if variable:
+            return variable
+        data_var = dataset_obj.get_data_variable()
+        return getattr(data_var, "name", None)
+
+    def _image_cube_kwargs(self, dataset, variable):
+        """Return keyword arguments for ``hypercoast.image_cube``.
+
+        Args:
+            dataset: Xarray dataset to visualize.
+            variable: Data variable name.
+
+        Returns:
+            Dictionary of image cube options.
+        """
+        kwargs = {
+            "variable": variable,
+            "cmap": self.cmap_combo.currentText(),
+            "clim": (self.vmin_spin.value(), self.vmax_spin.value()),
+            "title": self._cube_title(variable),
+            "rgb_gamma": self.gamma_spin.value(),
+            "widget": self.widget_combo.currentData(),
+            "crop": self.crop_spin.value() or None,
+            "nodata": (
+                self.nodata_spin.value() if self.nodata_check.isChecked() else None
+            ),
+        }
+        if self._has_wavelength_axis(dataset):
+            kwargs["rgb_wavelengths"] = [
+                self.red_spin.value(),
+                self.green_spin.value(),
+                self.blue_spin.value(),
+            ]
+        return kwargs
+
+    def _cube_title(self, variable):
+        """Return a readable scalar bar title.
+
+        Args:
+            variable: Data variable name.
+
+        Returns:
+            Display title.
+        """
+        if "reflectance" in variable.lower():
+            return "Reflectance"
+        if "radiance" in variable.lower():
+            return "Radiance"
+        return variable
+
+    def _downsample_dataset(self, dataset, spatial_stride, spectral_stride):
+        """Downsample a dataset before 3D rendering.
+
+        Args:
+            dataset: Xarray dataset.
+            spatial_stride: Stride for the first two spatial dimensions.
+            spectral_stride: Stride for spectral dimensions.
+
+        Returns:
+            Downsampled dataset.
+        """
+        indexers = {}
+        spatial_dims = [
+            dim
+            for dim in dataset.sizes
+            if dim not in SPECTRAL_DIMS and dataset.sizes[dim] > 1
+        ]
+        if spatial_stride > 1:
+            for dim in spatial_dims[:2]:
+                indexers[dim] = slice(None, None, spatial_stride)
+        if spectral_stride > 1:
+            for dim in dataset.sizes:
+                if dim in SPECTRAL_DIMS:
+                    indexers[dim] = slice(None, None, spectral_stride)
+        return dataset.isel(indexers) if indexers else dataset
+
+    def _prepare_image_cube_dataset(self, dataset, variable):
+        """Return a dataset with the selected cube's spectral axis last.
+
+        ``hypercoast.image_cube`` expects RGB wavelength selections to produce
+        an array shaped as rows, columns, and RGB channels. Some products, such
+        as Tanager HDF5 assets, can store the spectral axis first, which would
+        otherwise make the RGB overlay invalid.
+
+        Args:
+            dataset: Xarray dataset.
+            variable: Data variable name.
+
+        Returns:
+            Dataset with the selected variable transposed when needed.
+        """
+        if variable not in dataset.data_vars:
+            return dataset
+        data_var = dataset[variable]
+        spectral_dims = [dim for dim in data_var.dims if dim in SPECTRAL_DIMS]
+        if not spectral_dims:
+            return dataset
+        spectral_dim = spectral_dims[0]
+        if data_var.dims[-1] == spectral_dim:
+            return dataset
+
+        ordered_dims = [dim for dim in data_var.dims if dim != spectral_dim]
+        ordered_dims.append(spectral_dim)
+        prepared = dataset.copy(deep=False)
+        prepared[variable] = data_var.transpose(*ordered_dims)
+        return prepared
+
+    def _has_wavelength_axis(self, dataset):
+        """Return whether ``image_cube`` can add an RGB wavelength overlay.
+
+        Args:
+            dataset: Xarray dataset.
+
+        Returns:
+            True when a ``wavelength`` dimension or coordinate is present.
+        """
+        return "wavelength" in dataset.dims or "wavelength" in dataset.coords
+
+    def _show_plotter(self, plotter):
+        """Show a PyVista plotter with a non-closing preference.
+
+        Args:
+            plotter: PyVista plotter-like object.
+        """
+        show = getattr(plotter, "show", None)
+        if not callable(show):
+            return
+        for kwargs in (
+            {"auto_close": False, "interactive_update": True},
+            {"auto_close": False},
+            {},
+        ):
+            try:
+                show(**kwargs)
+                return
+            except TypeError:
+                continue
+
+    def _sync_nodata_state(self, *args):
+        """Enable or disable the NoData value spin box."""
+        self.nodata_spin.setEnabled(self.nodata_check.isChecked())
+
+    def _project_layer(self, layer_id):
+        """Return a QGIS project layer.
+
+        Args:
+            layer_id: QGIS layer ID.
+
+        Returns:
+            QGIS layer object, or None.
+        """
+        try:
+            return QgsProject.instance().mapLayer(layer_id)
+        except Exception:
+            return None

--- a/qgis_plugin/hypercoast_qgis/dialogs/image_cube_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/image_cube_dialog.py
@@ -552,6 +552,7 @@ class ImageCubeDialog(QDockWidget):
 
         try:
             cube_dataset = self._subset_dataset(dataset, variable, self._subset_bbox)
+            cube_dataset = cube_dataset[[variable]]
             cube_dataset = self._downsample_dataset(
                 cube_dataset,
                 self.spatial_stride_spin.value(),

--- a/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
@@ -351,7 +351,10 @@ class LoadDataDialog(QDockWidget):
         """Open file browser dialog."""
         file_filter = create_file_filter()
         filepath, _ = QFileDialog.getOpenFileName(
-            self, "Select Hyperspectral Data File", "", file_filter
+            self,
+            "Select Hyperspectral Data File",
+            self._default_browse_dir(),
+            file_filter,
         )
 
         if filepath:
@@ -368,6 +371,14 @@ class LoadDataDialog(QDockWidget):
             self._apply_data_type_value_range(
                 self._resolved_value_range_data_type(filepath)
             )
+
+    def _default_browse_dir(self):
+        """Return the default directory for selecting hyperspectral files.
+
+        Returns:
+            User home directory path.
+        """
+        return os.path.expanduser("~")
 
     def _clear_dataset_preview(self, *args):
         """Clear loaded preview state after the requested data type changes."""

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -24,6 +24,7 @@ try:
     from .dialogs.load_data_dialog import LoadDataDialog
     from .dialogs.tanager_search_dialog import TanagerSearchDialog
     from .dialogs.band_combination_dialog import BandCombinationDialog
+    from .dialogs.image_cube_dialog import ImageCubeDialog
     from .dialogs.spectral_inspector_tool import SpectralInspectorTool
     from .dialogs.spectral_plot_dialog import SpectralPlotDialog
 
@@ -39,6 +40,7 @@ DOCK_OBJECT_NAMES = {
     "HyperCoastLoadDataDock",
     "HyperCoastTanagerSearchDock",
     "HyperCoastBandCombinationDock",
+    "HyperCoastImageCubeDock",
     "HyperCoastSpectralPlotDock",
     "HyperCoastAboutDock",
     "HyperCoastUpdateDock",
@@ -71,6 +73,7 @@ class HyperCoastPlugin:
         self.load_dialog = None
         self.tanager_search_dialog = None
         self.band_dialog = None
+        self.image_cube_dialog = None
         self.spectral_tool = None
         self.spectral_plot_dialog = None
         self.about_dialog = None
@@ -187,6 +190,16 @@ class HyperCoastPlugin:
             callback=self.toggle_spectral_inspector,
             parent=self.iface.mainWindow(),
             status_tip=self.tr("Inspect spectral signatures interactively"),
+            checkable=True,
+        )
+
+        # 3D image cube action
+        self.image_cube_action = self.add_action(
+            os.path.join(icons_dir, "image_cube.svg"),
+            text=self.tr("3D Image Cube"),
+            callback=self.show_image_cube_dialog,
+            parent=self.iface.mainWindow(),
+            status_tip=self.tr("Create a PyVista 3D hyperspectral image cube"),
             checkable=True,
         )
 
@@ -459,6 +472,7 @@ class HyperCoastPlugin:
             "load_dialog",
             "tanager_search_dialog",
             "band_dialog",
+            "image_cube_dialog",
             "spectral_plot_dialog",
             "about_dialog",
             "update_dialog",
@@ -556,6 +570,7 @@ class HyperCoastPlugin:
                 load_data_dialog,
                 tanager_search_dialog,
                 band_combination_dialog,
+                image_cube_dialog,
                 spectral_plot_dialog,
             )
 
@@ -563,6 +578,7 @@ class HyperCoastPlugin:
             importlib.reload(load_data_dialog)
             importlib.reload(tanager_search_dialog)
             importlib.reload(band_combination_dialog)
+            importlib.reload(image_cube_dialog)
             importlib.reload(spectral_plot_dialog)
         except Exception as e:
             QgsMessageLog.logMessage(
@@ -576,6 +592,7 @@ class HyperCoastPlugin:
         self.load_dialog = None
         self.tanager_search_dialog = None
         self.band_dialog = None
+        self.image_cube_dialog = None
         self.spectral_tool = None
         self.spectral_plot_dialog = None
 
@@ -589,6 +606,7 @@ class HyperCoastPlugin:
                 from .dialogs.band_combination_dialog import (  # noqa: F811
                     BandCombinationDialog,
                 )
+                from .dialogs.image_cube_dialog import ImageCubeDialog  # noqa: F811
                 from .dialogs.spectral_inspector_tool import (  # noqa: F811
                     SpectralInspectorTool,
                 )
@@ -654,13 +672,14 @@ class HyperCoastPlugin:
     def _set_data_actions_enabled(self, enabled):
         """Enable or disable data-related actions.
 
-        The first 4 actions are data-dependent:
-        Load Data, Tanager Search, Band Combination, Spectral Inspector.
+        The first 5 actions are data-dependent:
+        Tanager Search, Load Data, Band Combination, Spectral Inspector,
+        and 3D Image Cube.
 
         :param enabled: Whether to enable the actions.
         """
         for i, action in enumerate(self.actions):
-            if i < 4:
+            if i < 5:
                 action.setEnabled(enabled)
 
     def toggle_settings_dock(self):
@@ -752,6 +771,21 @@ class HyperCoastPlugin:
             "band_dialog",
             lambda: BandCombinationDialog(self.iface, self, self.iface.mainWindow()),
             self.band_action,
+            before_show=lambda dock: dock.refresh_layers(),
+        )
+
+    def show_image_cube_dialog(self):
+        """Show the 3D image cube dialog."""
+        if not self._deps_available:
+            self._show_deps_required_warning()
+            self.image_cube_action.setChecked(False)
+            return
+        from .dialogs.image_cube_dialog import ImageCubeDialog
+
+        self._toggle_dock(
+            "image_cube_dialog",
+            lambda: ImageCubeDialog(self.iface, self, self.iface.mainWindow()),
+            self.image_cube_action,
             before_show=lambda dock: dock.refresh_layers(),
         )
 

--- a/qgis_plugin/hypercoast_qgis/icons/image_cube.svg
+++ b/qgis_plugin/hypercoast_qgis/icons/image_cube.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="top" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#5eead4"/>
+      <stop offset="0.45" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="left" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0f766e"/>
+      <stop offset="1" stop-color="#164e63"/>
+    </linearGradient>
+    <linearGradient id="right" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1d4ed8"/>
+      <stop offset="1" stop-color="#312e81"/>
+    </linearGradient>
+  </defs>
+  <rect x="1.5" y="1.5" width="61" height="61" rx="8" fill="#111827"/>
+  <path d="M32 7 56 19 32 31 8 19Z" fill="url(#top)" stroke="#dbeafe" stroke-width="2"/>
+  <path d="M8 19 32 31v26L8 45Z" fill="url(#left)" stroke="#dbeafe" stroke-width="2"/>
+  <path d="M56 19 32 31v26l24-12Z" fill="url(#right)" stroke="#dbeafe" stroke-width="2"/>
+  <path d="M12 27 32 37l20-10" fill="none" stroke="#facc15" stroke-width="2.5" opacity="0.95"/>
+  <path d="M12 35 32 45l20-10" fill="none" stroke="#fb7185" stroke-width="2.5" opacity="0.9"/>
+  <path d="M12 43 32 53l20-10" fill="none" stroke="#22d3ee" stroke-width="2.5" opacity="0.9"/>
+  <path d="M18 19c4-5 8 5 12 0s8 5 16-1" fill="none" stroke="#111827" stroke-width="2.5" opacity="0.65"/>
+</svg>

--- a/qgis_plugin/qt6_tests/test_dock_panels.py
+++ b/qgis_plugin/qt6_tests/test_dock_panels.py
@@ -11,6 +11,8 @@ from qgis.PyQt.QtWidgets import QDockWidget
 from hypercoast_qgis.dialogs.about_dialog import AboutDialog
 from hypercoast_qgis.dialogs.band_combination_dialog import BandCombinationDialog
 from hypercoast_qgis.dialogs.dependency_installer import DependencyInstallerDialog
+from hypercoast_qgis.dialogs.image_cube_dialog import ImageCubeDialog
+import hypercoast_qgis.dialogs.load_data_dialog as load_data_dialog_module
 from hypercoast_qgis.dialogs.load_data_dialog import LoadDataDialog
 from hypercoast_qgis.dialogs.settings_dock import SettingsDockWidget
 from hypercoast_qgis.dialogs.spectral_plot_dialog import SpectralPlotDialog
@@ -33,6 +35,7 @@ def test_plugin_windows_are_dock_widgets():
         AboutDialog,
         BandCombinationDialog,
         DependencyInstallerDialog,
+        ImageCubeDialog,
         LoadDataDialog,
         SettingsDockWidget,
         SpectralPlotDialog,
@@ -65,6 +68,37 @@ def test_tanager_auto_detect_sets_reflectance_value_range(qapp, tmp_path):
     dialog._clear_dataset_preview()
 
     assert dialog.vmax_spin.value() == 0.5
+
+
+def test_load_data_browse_starts_in_user_directory(qapp, monkeypatch):
+    """Load Data Browse should open from the user home directory."""
+
+    class _Iface:
+        """Small iface-like object."""
+
+        def mainWindow(self):
+            """Return no parent window."""
+            return None
+
+    recorded = {}
+    monkeypatch.setattr(
+        load_data_dialog_module.os.path, "expanduser", lambda path: "/home/tester"
+    )
+    monkeypatch.setattr(
+        load_data_dialog_module.QFileDialog,
+        "getOpenFileName",
+        staticmethod(
+            lambda parent, title, directory, file_filter: recorded.update(
+                directory=directory
+            )
+            or ("", "")
+        ),
+    )
+
+    dialog = LoadDataDialog(_Iface(), object())
+    dialog.browse_file()
+
+    assert recorded["directory"] == "/home/tester"
 
 
 def test_spectral_plot_uses_tanager_reflectance_defaults(qapp):

--- a/qgis_plugin/qt6_tests/test_image_cube_dialog.py
+++ b/qgis_plugin/qt6_tests/test_image_cube_dialog.py
@@ -1,0 +1,337 @@
+"""Tests for the 3D image cube dock helpers."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+import pytest
+from qgis.PyQt.QtWidgets import QApplication
+
+import hypercoast_qgis.dialogs.image_cube_dialog as dialog_module
+from hypercoast_qgis.dialogs.image_cube_dialog import ImageCubeDialog
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Return a QApplication for widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class _Iface:
+    """Small QGIS iface-like object."""
+
+    def mainWindow(self):
+        """Return no parent window."""
+        return None
+
+
+class _Layer:
+    """Small QGIS layer-like object."""
+
+    def name(self):
+        """Return a layer name."""
+        return "Layer One"
+
+
+class _DatasetWrapper:
+    """Small HyperCoast dataset wrapper."""
+
+    def __init__(self, dataset):
+        """Initialize the wrapper.
+
+        Args:
+            dataset: Xarray dataset.
+        """
+        self.dataset = dataset
+
+    def get_data_variable(self):
+        """Return the default data variable."""
+        return self.dataset["reflectance"]
+
+
+class _Plugin:
+    """Small plugin-like object for image cube tests."""
+
+    def __init__(self, dataset):
+        """Initialize the plugin.
+
+        Args:
+            dataset: Xarray dataset.
+        """
+        self.wrapper = _DatasetWrapper(dataset)
+        self.data_info = {
+            "dataset": self.wrapper,
+            "rgb_wavelengths": [650, 550, 450],
+            "selected_variable": "reflectance",
+        }
+
+    def get_all_hyperspectral_layers(self):
+        """Return registered layer metadata."""
+        return {"layer-1": self.data_info}
+
+    def get_hyperspectral_data(self, layer_id):
+        """Return metadata for a layer.
+
+        Args:
+            layer_id: QGIS layer ID.
+
+        Returns:
+            Layer metadata.
+        """
+        return self.data_info if layer_id == "layer-1" else None
+
+    def ensure_hyperspectral_dataset(self, layer_id):
+        """Return a loaded dataset wrapper.
+
+        Args:
+            layer_id: QGIS layer ID.
+
+        Returns:
+            Dataset wrapper.
+        """
+        return self.wrapper if layer_id == "layer-1" else None
+
+
+def _dataset():
+    """Return a small xarray hyperspectral cube."""
+    xr = pytest.importorskip("xarray")
+    return xr.Dataset(
+        {
+            "reflectance": (
+                ("y", "x", "wavelength"),
+                np.ones((8, 10, 4), dtype="float32"),
+            )
+        },
+        coords={"wavelength": [450.0, 550.0, 650.0, 750.0]},
+    )
+
+
+def _spectral_first_dataset():
+    """Return a Tanager-like cube with the spectral axis first."""
+    xr = pytest.importorskip("xarray")
+    return xr.Dataset(
+        {
+            "surface_reflectance": (
+                ("wavelength", "y", "x"),
+                np.ones((4, 8, 10), dtype="float32"),
+            )
+        },
+        coords={"wavelength": [450.0, 550.0, 650.0, 750.0]},
+    )
+
+
+def _latlon_dataset():
+    """Return a small cube with 2D latitude and longitude coordinates."""
+    xr = pytest.importorskip("xarray")
+    y = np.linspace(36.0, 39.0, 8)
+    x = np.linspace(-123.0, -120.0, 10)
+    lon, lat = np.meshgrid(x, y)
+    return xr.Dataset(
+        {
+            "reflectance": (
+                ("y", "x", "wavelength"),
+                np.ones((8, 10, 4), dtype="float32"),
+            )
+        },
+        coords={
+            "wavelength": [450.0, 550.0, 650.0, 750.0],
+            "latitude": (("y", "x"), lat),
+            "longitude": (("y", "x"), lon),
+        },
+    )
+
+
+def test_image_cube_dialog_populates_layers_and_variables(qapp, monkeypatch):
+    """The image cube dock should list HyperCoast layers and variables."""
+    dialog = ImageCubeDialog(_Iface(), _Plugin(_dataset()))
+    monkeypatch.setattr(dialog, "_project_layer", lambda layer_id: _Layer())
+
+    dialog.refresh_layers()
+
+    assert dialog.layer_combo.currentData() == "layer-1"
+    assert dialog.layer_combo.currentText() == "Layer One"
+    assert dialog.variable_combo.currentData() == "reflectance"
+    assert dialog.red_spin.value() == 650.0
+
+
+def test_image_cube_dialog_downsamples_spatial_and_spectral_axes(qapp):
+    """Downsampling should stride spatial and spectral dimensions."""
+    dialog = ImageCubeDialog(_Iface(), _Plugin(_dataset()))
+
+    downsampled = dialog._downsample_dataset(_dataset(), 2, 2)
+
+    assert downsampled.sizes["y"] == 4
+    assert downsampled.sizes["x"] == 5
+    assert downsampled.sizes["wavelength"] == 2
+
+
+def test_image_cube_dialog_subsets_2d_latlon_bbox(qapp):
+    """Drawn WGS84 bboxes should subset 2D latitude/longitude cubes."""
+    dataset = _latlon_dataset()
+    dialog = ImageCubeDialog(_Iface(), _Plugin(dataset))
+
+    subset = dialog._subset_dataset(
+        dataset, "reflectance", [-122.5, 36.5, -121.0, 38.0]
+    )
+
+    assert subset.sizes["y"] < dataset.sizes["y"]
+    assert subset.sizes["x"] < dataset.sizes["x"]
+    assert float(subset["longitude"].min()) >= -123.0
+    assert float(subset["latitude"].max()) <= 39.0
+
+
+def test_image_cube_dialog_stores_drawn_subset_bbox(qapp):
+    """Drawn subset bboxes should be stored and displayed."""
+    dialog = ImageCubeDialog(_Iface(), _Plugin(_dataset()))
+
+    dialog._on_subset_bbox_drawn([-122.5, 36.5, -121.0, 38.0])
+
+    assert dialog._subset_bbox == [-122.5, 36.5, -121.0, 38.0]
+    assert (
+        dialog.subset_bbox_edit.text()
+        == "-122.50000000, 36.50000000, -121.00000000, 38.00000000"
+    )
+
+
+def test_image_cube_dialog_blocks_oversized_cube(qapp, monkeypatch):
+    """Oversized cubes should be blocked before PyVista rendering."""
+    dialog = ImageCubeDialog(_Iface(), _Plugin(_dataset()))
+    monkeypatch.setattr(dialog_module, "MAX_CUBE_POINTS", 1)
+    warnings = []
+    monkeypatch.setattr(
+        dialog_module.QMessageBox,
+        "warning",
+        staticmethod(lambda *args: warnings.append(args)),
+    )
+
+    assert not dialog._validate_cube_size(_dataset(), "reflectance")
+    assert warnings
+    assert dialog.status_label.text() == "3D image cube too large"
+
+
+def test_image_cube_dialog_moves_spectral_axis_last(qapp):
+    """Tanager-style spectral-first cubes should render RGB overlays correctly."""
+    dataset = _spectral_first_dataset()
+    dialog = ImageCubeDialog(_Iface(), _Plugin(dataset))
+
+    prepared = dialog._prepare_image_cube_dataset(dataset, "surface_reflectance")
+
+    assert prepared["surface_reflectance"].dims == ("y", "x", "wavelength")
+
+
+def test_image_cube_dialog_launches_image_cube_viewer(qapp, monkeypatch):
+    """Create Cube should launch the external image cube viewer."""
+    plugin = _Plugin(_dataset())
+    dialog = ImageCubeDialog(_Iface(), plugin)
+    monkeypatch.setattr(dialog, "_project_layer", lambda layer_id: _Layer())
+    dialog.refresh_layers()
+    dialog.spatial_stride_spin.setValue(2)
+    dialog.widget_combo.setCurrentIndex(dialog.widget_combo.findData("slice"))
+    recorded = {}
+
+    def _record_start(dataset, kwargs):
+        """Record external viewer worker arguments."""
+        recorded["sizes"] = dict(dataset.sizes)
+        recorded["kwargs"] = kwargs
+        dialog._set_cube_busy(False, "3D image cube viewer launched")
+
+    monkeypatch.setattr(dialog, "_start_image_cube_worker", _record_start)
+
+    dialog.create_cube()
+
+    assert recorded["sizes"]["y"] == 4
+    assert recorded["kwargs"]["variable"] == "reflectance"
+    assert recorded["kwargs"]["widget"] == "slice"
+    assert recorded["kwargs"]["rgb_wavelengths"] == [650.0, 550.0, 450.0]
+    assert dialog.status_label.text() == "3D image cube viewer launched"
+
+
+def test_image_cube_dialog_launches_viewer_with_spectral_axis_last(qapp, monkeypatch):
+    """Create Cube should normalize Tanager-like cubes before launch."""
+    dataset = _spectral_first_dataset()
+    plugin = _Plugin(dataset)
+    plugin.data_info["selected_variable"] = "surface_reflectance"
+    dialog = ImageCubeDialog(_Iface(), plugin)
+    dialog.variable_combo.setCurrentIndex(
+        dialog.variable_combo.findData("surface_reflectance")
+    )
+    recorded = {}
+
+    def _record_start(dataset, kwargs):
+        """Record external viewer worker arguments."""
+        variable = kwargs["variable"]
+        recorded["dims"] = dataset[variable].dims
+        recorded["kwargs"] = kwargs
+
+    monkeypatch.setattr(dialog, "_start_image_cube_worker", _record_start)
+
+    dialog.create_cube()
+
+    assert recorded["dims"] == ("y", "x", "wavelength")
+    assert recorded["kwargs"]["variable"] == "surface_reflectance"
+    assert recorded["kwargs"]["rgb_wavelengths"] == [650.0, 550.0, 450.0]
+
+
+def test_image_cube_dialog_launch_writes_files_and_starts_process(
+    qapp, monkeypatch, tmp_path
+):
+    """External viewer launch should write cube files and start Python."""
+    dialog = ImageCubeDialog(_Iface(), _Plugin(_dataset()))
+    monkeypatch.setattr(dialog, "_image_cube_cache_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(dialog, "_viewer_python_path", lambda: "/usr/bin/python")
+    monkeypatch.setattr(dialog, "_viewer_popen_kwargs", lambda: {})
+    recorded = {}
+
+    class _Process:
+        """Small subprocess-like object."""
+
+    def _popen(cmd, cwd, env, stdout, stderr, **kwargs):
+        """Record subprocess arguments."""
+        recorded["cmd"] = cmd
+        recorded["cwd"] = cwd
+        recorded["env"] = env
+        recorded["kwargs"] = kwargs
+        recorded["stdout"] = stdout.name
+        recorded["stderr"] = stderr.name
+        return _Process()
+
+    monkeypatch.setattr(dialog_module.subprocess, "Popen", _popen)
+
+    dialog._launch_image_cube_viewer(
+        _dataset(),
+        {
+            "variable": "reflectance",
+            "clim": (0.0, 0.5),
+            "widget": None,
+            "rgb_wavelengths": [650.0, 550.0, 450.0],
+        },
+    )
+
+    assert recorded["cmd"][0] == "/usr/bin/python"
+    assert recorded["cwd"] == str(tmp_path)
+    assert os.path.exists(recorded["cmd"][1])
+    assert os.path.exists(recorded["cmd"][2])
+    assert os.path.exists(recorded["cmd"][3])
+    assert recorded["env"]["PYTHONPATH"].endswith("HyperCoast")
+    assert dialog._viewer_processes
+
+
+def test_image_cube_dialog_busy_progress_state(qapp):
+    """Busy state should show progress and disable cube creation."""
+    dialog = ImageCubeDialog(_Iface(), _Plugin(_dataset()))
+
+    dialog._set_cube_busy(True, "Creating 3D image cube...")
+
+    assert not dialog.progress_bar.isHidden()
+    assert not dialog.create_btn.isEnabled()
+    assert dialog.status_label.text() == "Creating 3D image cube..."
+
+    dialog._set_cube_busy(False, "3D image cube viewer launched")
+
+    assert dialog.progress_bar.isHidden()
+    assert dialog.create_btn.isEnabled()
+    assert dialog.status_label.text() == "3D image cube viewer launched"

--- a/tests/test_hypercoast.py
+++ b/tests/test_hypercoast.py
@@ -2,9 +2,13 @@
 
 """Tests for `hypercoast` package."""
 
+import sys
+import types
 import unittest
 
 import hypercoast
+import numpy as np
+import pytest
 
 
 class TestHypercoast(unittest.TestCase):
@@ -18,3 +22,75 @@ class TestHypercoast(unittest.TestCase):
 
     def test_000_something(self):
         """Test something."""
+
+
+class _FakeImageData:
+    """Small PyVista ImageData test double."""
+
+    def __init__(self, dimensions=None):
+        """Initialize image data.
+
+        Args:
+            dimensions: Optional grid dimensions.
+        """
+        self.dimensions = dimensions or (1, 1, 1)
+        self.origin = (0, 0, 0)
+        self.spacing = (1, 1, 1)
+        self.point_data = {}
+
+    @property
+    def bounds(self):
+        """Return PyVista-like grid bounds."""
+        x_max = self.origin[0] + (self.dimensions[0] - 1) * self.spacing[0]
+        y_max = self.origin[1] + (self.dimensions[1] - 1) * self.spacing[1]
+        z_max = self.origin[2] + (self.dimensions[2] - 1) * self.spacing[2]
+        return (self.origin[0], x_max, self.origin[1], y_max, self.origin[2], z_max)
+
+
+class _FakePlotter:
+    """Small PyVista Plotter test double."""
+
+    def __init__(self, **kwargs):
+        """Initialize the plotter.
+
+        Args:
+            **kwargs: Ignored plotter keyword arguments.
+        """
+        self.meshes = []
+
+    def add_mesh(self, mesh, **kwargs):
+        """Record a mesh.
+
+        Args:
+            mesh: Mesh added to the plotter.
+            **kwargs: Ignored mesh keyword arguments.
+        """
+        self.meshes.append(mesh)
+
+    def show_axes(self):
+        """Ignore axes display calls."""
+
+
+def test_image_cube_offsets_rgb_overlay(monkeypatch):
+    """RGB overlay should be slightly above the cube top face."""
+    xr = pytest.importorskip("xarray")
+    fake_pyvista = types.SimpleNamespace(ImageData=_FakeImageData, Plotter=_FakePlotter)
+    monkeypatch.setitem(sys.modules, "pyvista", fake_pyvista)
+    dataset = xr.Dataset(
+        {
+            "reflectance": (
+                ("y", "x", "wavelength"),
+                np.ones((4, 5, 4), dtype="float32"),
+            )
+        },
+        coords={"wavelength": [450.0, 550.0, 650.0, 750.0]},
+    )
+
+    plotter = hypercoast.image_cube(
+        dataset,
+        variable="reflectance",
+        rgb_wavelengths=[650.0, 550.0, 450.0],
+    )
+
+    cube_mesh, rgb_mesh = plotter.meshes
+    assert rgb_mesh.origin[2] > cube_mesh.bounds[5]


### PR DESCRIPTION
## Summary
- Add a dockable 3D Image Cube panel to the QGIS plugin for creating PyVista-based hyperspectral cubes with subset drawing, spatial/spectral stride controls, and optional slicing/threshold widgets.
- Fix RGB overlay z-fighting in `hypercoast.image_cube` by introducing a configurable `rgb_z_offset` parameter.
- Add Qt6-compatible tests for the new dialog and update documentation.

## Test plan
- [ ] Load a hyperspectral layer in QGIS and open the 3D Image Cube panel
- [ ] Verify subset bbox drawing and clearing works
- [ ] Create a cube with various widget modes (slice, orthogonal, threshold)
- [ ] Run `python -m pytest qgis_plugin/qt6_tests/test_image_cube_dialog.py`
- [ ] Run `python -m pytest tests/test_hypercoast.py` to confirm no regressions