### PR TITLE
Bump version: 0.25.0 → 0.26.0

### DIFF
--- a/hypercoast/__init__.py
+++ b/hypercoast/__init__.py
@@ -6,7 +6,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.25.0"
+__version__ = "0.26.0"
 
 
 from .hypercoast import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "HyperCoast"
-version = "0.25.0"
+version = "0.26.0"
 dynamic = [
     "dependencies",
 ]
@@ -59,7 +59,7 @@ universal = true
 
 
 [tool.bumpversion]
-current_version = "0.25.0"
+current_version = "0.26.0"
 commit = true
 tag = true
 

--- a/qgis_plugin/hypercoast_qgis/metadata.txt
+++ b/qgis_plugin/hypercoast_qgis/metadata.txt
@@ -5,7 +5,7 @@ name=HyperCoast
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Visualize, search, and analyze hyperspectral data including EMIT, PACE, DESIS, NEON, AVIRIS, PRISMA, EnMAP, Tanager, and Wyvern datasets
-version=0.25.0
+version=0.26.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -32,6 +32,8 @@ deprecated=False
 hasProcessingProvider=yes
 
 changelog=
+    0.26.0
+        - Bump package and QGIS plugin minor version
     0.25.0
         - Add AVIRIS-3 and AVIRIS-5 support
         - Add NASA AppEEARS integration for EMIT data access


### PR DESCRIPTION
## Summary
- Bump minor version from 0.25.0 to 0.26.0 for the HyperCoast package and QGIS plugin
- Updated version in pyproject.toml, hypercoast/__init__.py, and QGIS plugin metadata.txt
- Added changelog entry for 0.26.0

## Test plan
- [ ] Verify `hypercoast.__version__` returns `0.26.0`
- [ ] Verify QGIS plugin metadata shows version 0.26.0