### PR TITLE
feat: add ml/summary modules, restructure dependencies, and improve QGIS plugin

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -8,6 +8,8 @@ on:
 jobs:
     test-docs-build:
         runs-on: ubuntu-latest
+        env:
+            PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         strategy:
             matrix:
                 python-version: ["3.12"]

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -8,8 +8,6 @@ on:
 jobs:
     test-docs-build:
         runs-on: ubuntu-latest
-        env:
-            PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         strategy:
             matrix:
                 python-version: ["3.12"]
@@ -52,7 +50,7 @@ jobs:
 
             - name: Running pytest
               run: |
-                  .venv/bin/pytest . --verbose
+                  .venv/bin/pytest tests/ --verbose
 
             - name: Install mkdocs
               run: .venv/bin/mkdocs build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        env:
+            PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         strategy:
             matrix:
                 python-version: ["3.12"]

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,4 +27,5 @@ jobs:
                   TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
               run: |
                   python -m build
+                  twine check dist/*
                   twine upload dist/*

--- a/.github/workflows/qgis-plugin.yml
+++ b/.github/workflows/qgis-plugin.yml
@@ -31,22 +31,21 @@ jobs:
     pyqt6-smoke:
         name: PyQt6 import smoke
         runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                python-version: ["3.11", "3.12", "3.13"]
         steps:
             - uses: actions/checkout@v6
-            - uses: actions/setup-python@v6
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
               with:
-                  python-version: ${{ matrix.python-version }}
+                  version: "0.4.16"
+            - name: Set up Python
+              run: uv python install 3.12
             - name: Install Qt6 runtime libs
               run: |
                   sudo apt-get update
                   sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
             - name: Install PyQt6, pytest, and plugin runtime deps
               run: |
-                  python -m pip install --upgrade pip
-                  pip install PyQt6 PyQt6-QScintilla pytest pytest-cov numpy Pillow pandas xarray
+                  uv venv --python 3.12
+                  uv pip install PyQt6 PyQt6-QScintilla pytest numpy Pillow pandas xarray
             - name: Run import smoke tests
-              run: pytest qgis_plugin/qt6_tests -v --cov=qgis_plugin/hypercoast_qgis --cov-report=term-missing
+              run: uv run pytest qgis_plugin/qt6_tests -v

--- a/.github/workflows/qgis-plugin.yml
+++ b/.github/workflows/qgis-plugin.yml
@@ -1,4 +1,6 @@
 name: QGIS plugin
+env:
+    PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
 
 on:
     push:
@@ -47,6 +49,6 @@ jobs:
             - name: Install PyQt6, pytest, and plugin runtime deps
               run: |
                   python -m pip install --upgrade pip
-                  pip install PyQt6 PyQt6-QScintilla pytest numpy Pillow
+                  pip install PyQt6 PyQt6-QScintilla pytest pytest-cov numpy Pillow pandas xarray
             - name: Run import smoke tests
-              run: pytest qgis_plugin/qt6_tests -v
+              run: pytest qgis_plugin/qt6_tests -v --cov=qgis_plugin/hypercoast_qgis --cov-report=term-missing

--- a/.github/workflows/qgis-plugin.yml
+++ b/.github/workflows/qgis-plugin.yml
@@ -1,6 +1,4 @@
 name: QGIS plugin
-env:
-    PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
 
 on:
     push:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,8 +9,6 @@ on:
             - master
 
 name: Linux build
-env:
-    PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
 jobs:
     test-ubuntu:
         runs-on: ubuntu-latest
@@ -49,7 +47,7 @@ jobs:
                   uv run gdalinfo --version
 
             - name: Running pytest
-              run: uv run pytest . --verbose --cov=hypercoast --cov-report=term-missing
+              run: uv run pytest tests/ --verbose --cov=hypercoast --cov-report=term-missing
 
             - name: Build wheel and test console script
               run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,6 +9,8 @@ on:
             - master
 
 name: Linux build
+env:
+    PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
 jobs:
     test-ubuntu:
         runs-on: ubuntu-latest
@@ -38,7 +40,7 @@ jobs:
             - name: Install optional dependencies
               run: |
                   uv pip install --find-links https://girder.github.io/large_image_wheels gdal pyproj
-                  uv pip install build pytest
+                  uv pip install build pytest pytest-cov
 
             - name: Test import
               run: |
@@ -47,7 +49,7 @@ jobs:
                   uv run gdalinfo --version
 
             - name: Running pytest
-              run: uv run pytest . --verbose
+              run: uv run pytest . --verbose --cov=hypercoast --cov-report=term-missing
 
             - name: Build wheel and test console script
               run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,12 @@ repos:
           - id: black-jupyter
             language_version: python3
 
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.13.0
+      hooks:
+          - id: ruff
+            args: ["--fix"]
+
     - repo: https://github.com/codespell-project/codespell
       rev: v2.4.2
       hooks:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -85,7 +85,7 @@ Ready to contribute? Here's how to set up HyperCoast for local development.
     $ pip install pre-commit
     $ pre-commit install
     $ pre-commit run --all-files
-    $ python -m unittest discover tests/
+    $ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests qgis_plugin/qt6_tests
     ```
 
 6.  Commit your changes and push your branch to GitHub:

--- a/docs/examples/dataset_summary_cli.ipynb
+++ b/docs/examples/dataset_summary_cli.ipynb
@@ -1,0 +1,184 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/HyperCoast/blob/main/docs/examples/dataset_summary_cli.ipynb)\n",
+    "\n",
+    "# Dataset Summary and CLI Utilities\n",
+    "\n",
+    "This notebook demonstrates the new local dataset summary and subsetting helpers. It uses a small synthetic hyperspectral cube so the example runs without downloading external data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install hypercoast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from tempfile import TemporaryDirectory\n",
+    "\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "\n",
+    "import hypercoast"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Create a small local cube"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wavelengths = np.array([450.0, 550.0, 650.0, 750.0], dtype=\"float32\")\n",
+    "cube = xr.Dataset(\n",
+    "    {\n",
+    "        \"reflectance\": (\n",
+    "            (\"wavelength\", \"y\", \"x\"),\n",
+    "            np.arange(4 * 5 * 6, dtype=\"float32\").reshape(4, 5, 6) / 100.0,\n",
+    "        )\n",
+    "    },\n",
+    "    coords={\n",
+    "        \"wavelength\": wavelengths,\n",
+    "        \"y\": np.linspace(28.0, 29.0, 5),\n",
+    "        \"x\": np.linspace(-91.0, -90.0, 6),\n",
+    "    },\n",
+    "    attrs={\"crs\": \"EPSG:4326\"},\n",
+    ")\n",
+    "cube"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Summarize metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with TemporaryDirectory() as tmpdir:\n",
+    "    path = Path(tmpdir) / \"synthetic_cube.nc\"\n",
+    "    cube.to_netcdf(path)\n",
+    "\n",
+    "    summary = hypercoast.summarize_dataset(path, variable=\"reflectance\")\n",
+    "    summary.as_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "The same metadata is available from the command line:\n",
+    "\n",
+    "```bash\n",
+    "hypercoast summarize synthetic_cube.nc --variable reflectance --json\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Subset by bounding box"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with TemporaryDirectory() as tmpdir:\n",
+    "    input_path = Path(tmpdir) / \"synthetic_cube.nc\"\n",
+    "    output_path = Path(tmpdir) / \"subset.nc\"\n",
+    "    cube.to_netcdf(input_path)\n",
+    "\n",
+    "    hypercoast.subset_dataset(\n",
+    "        input_path,\n",
+    "        output_path,\n",
+    "        bbox=(-90.8, 28.25, -90.2, 28.75),\n",
+    "        variable=\"reflectance\",\n",
+    "    )\n",
+    "    subset = xr.open_dataset(output_path)\n",
+    "    subset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "The equivalent CLI command is:\n",
+    "\n",
+    "```bash\n",
+    "hypercoast subset synthetic_cube.nc subset.nc --bbox -90.8 28.25 -90.2 28.75 --variable reflectance\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## Batch spectra command shape\n",
+    "\n",
+    "For sensor readers that provide point extraction, the `spectra` command writes long-form spectral rows from a point CSV:\n",
+    "\n",
+    "```bash\n",
+    "hypercoast spectra pace PACE_scene.nc --points stations.csv --output spectra.csv --x-column lon --y-column lat --crs EPSG:4326\n",
+    "```\n",
+    "\n",
+    "The output columns are `feature_id`, `x`, `y`, `crs`, `wavelength`, `value`, `layer`, and `variable`."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,myst"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -1,6 +1,8 @@
 # Overview
 
 -   [Search and download NASA hyperspectral data](https://hypercoast.org/examples/search_data)
+-   [Summarize and subset local hyperspectral datasets](https://hypercoast.org/examples/dataset_summary_cli)
+-   [Run QGIS workflow and batch extraction concepts](https://hypercoast.org/examples/qgis_workflow_processing)
 -   [Search and download NASA ECOSTRESS data](https://hypercoast.org/examples/ecostress)
 -   [Visualize Hyperspectral Data in 3D](https://hypercoast.org/examples/image_cube)
 -   [Interactive slicing and thresholding of hyperspectral data](https://hypercoast.org/examples/image_slicing)

--- a/docs/examples/qgis_workflow_processing.ipynb
+++ b/docs/examples/qgis_workflow_processing.ipynb
@@ -1,0 +1,225 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/HyperCoast/blob/main/docs/examples/qgis_workflow_processing.ipynb)\n",
+    "\n",
+    "# QGIS Workflow and Batch Extraction Concepts\n",
+    "\n",
+    "This notebook demonstrates the Python workflow logic used by the QGIS Workflow Builder and the long-form output structure used by the batch spectral extraction Processing tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install hypercoast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import xarray as xr\n",
+    "\n",
+    "import hypercoast"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Create a workflow-ready cube"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = xr.Dataset(\n",
+    "    {\n",
+    "        \"reflectance\": (\n",
+    "            (\"wavelength\", \"y\", \"x\"),\n",
+    "            np.array(\n",
+    "                [\n",
+    "                    [[0.05, 0.08, 0.12], [0.04, 0.07, 0.10]],\n",
+    "                    [[0.12, 0.14, 0.18], [0.10, 0.13, 0.16]],\n",
+    "                    [[0.03, 0.04, 0.06], [0.02, 0.03, 0.05]],\n",
+    "                    [[0.01, 0.02, 0.04], [0.01, 0.02, 0.03]],\n",
+    "                ],\n",
+    "                dtype=\"float32\",\n",
+    "            ),\n",
+    "        )\n",
+    "    },\n",
+    "    coords={\"wavelength\": [412.0, 560.0, 665.0, 860.0], \"y\": [0, 1], \"x\": [0, 1, 2]},\n",
+    ")\n",
+    "dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Run the same presets exposed in QGIS\n",
+    "\n",
+    "The QGIS Workflow Builder uses the same `hypercoast.apply_workflow()` presets exposed to Python and the CLI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hypercoast.list_workflows()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ndwi = hypercoast.apply_workflow(dataset, \"ndwi\", variable=\"reflectance\")\n",
+    "turbidity = hypercoast.apply_workflow(dataset, \"turbidity\", variable=\"reflectance\")\n",
+    "cdom = hypercoast.apply_workflow(dataset, \"cdom\", variable=\"reflectance\")\n",
+    "\n",
+    "ndwi.name, turbidity.name, cdom.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ndwi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "The QGIS dock writes this 2D workflow output to a GeoTIFF and adds it back to the current project."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "## Override workflow wavelengths\n",
+    "\n",
+    "The Workflow Builder includes optional wavelength override fields. In Python, pass a `wavelengths` dictionary with `a` and `b` values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_ratio = hypercoast.apply_workflow(\n",
+    "    dataset,\n",
+    "    \"turbidity\",\n",
+    "    variable=\"reflectance\",\n",
+    "    wavelengths={\"a\": 665.0, \"b\": 860.0},\n",
+    ")\n",
+    "custom_ratio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Batch extraction output structure\n",
+    "\n",
+    "The QGIS Processing batch extractor writes one row per feature and wavelength. The table below shows the expected long-form shape."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "points = pd.DataFrame(\n",
+    "    {\n",
+    "        \"feature_id\": [0, 1],\n",
+    "        \"x\": [-90.6, -90.4],\n",
+    "        \"y\": [28.7, 28.8],\n",
+    "        \"crs\": [\"EPSG:4326\", \"EPSG:4326\"],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "rows = []\n",
+    "for _, point in points.iterrows():\n",
+    "    # In QGIS this vector is returned by HyperspectralDataset.extract_spectral_signature().\n",
+    "    values = np.array([0.05, 0.12, 0.03, 0.01]) + point.feature_id * 0.01\n",
+    "    for wavelength, value in zip(dataset.wavelength.values, values):\n",
+    "        rows.append(\n",
+    "            {\n",
+    "                \"feature_id\": point.feature_id,\n",
+    "                \"x\": point.x,\n",
+    "                \"y\": point.y,\n",
+    "                \"crs\": point.crs,\n",
+    "                \"wavelength\": wavelength,\n",
+    "                \"value\": value,\n",
+    "                \"layer\": \"synthetic_cube\",\n",
+    "                \"variable\": \"reflectance\",\n",
+    "            }\n",
+    "        )\n",
+    "\n",
+    "spectra = pd.DataFrame(rows)\n",
+    "spectra"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "In QGIS, use **Processing** > **Toolbox** > **HyperCoast** > **Batch Extract Spectra** with a point CSV and an output CSV path."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,myst"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,10 +26,26 @@ uv run jupyter lab
 pip install hypercoast
 ```
 
-HyperCoast has some optional dependencies that are not installed by default, such as cartopy, earthaccess, mapclassify, and pyvista. To install all optional dependencies all at once, run the following command:
+HyperCoast groups optional dependencies by feature area:
+
+-   `core`: local NetCDF/HDF and xarray workflows.
+-   `viz`: maps, plotting, PyVista, and raster visualization.
+-   `cloud`: NASA Earthdata and cloud storage helpers.
+-   `qgis`: QGIS plugin runtime helpers.
+-   `ml`: optional MoE/VAE machine-learning workflows.
+-   `docs`: documentation build tools.
+
+To install all optional dependencies all at once, run the following command:
 
 ```bash
-pip install "hypercoast[extra]"
+pip install "hypercoast[all]"
+```
+
+For a smaller install, choose only the extras you need, for example:
+
+```bash
+pip install "hypercoast[core,cloud]"
+pip install "hypercoast[viz,ml]"
 ```
 
 ## Install from conda-forge

--- a/docs/ml.md
+++ b/docs/ml.md
@@ -1,0 +1,3 @@
+# ML module
+
+::: hypercoast.ml

--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -21,6 +21,8 @@ Check out this [short video demo](https://youtu.be/EEUAC5BxqtM) and [full video 
 -   Change RGB band combinations by wavelength and use presets such as true color, color infrared, agriculture, vegetation, water, geology, and chlorophyll-a.
 -   Extract and compare spectral signatures by clicking hyperspectral layers on the map.
 -   Create PyVista-based 3D hyperspectral image cubes with optional slicing and threshold widgets.
+-   Run water-quality workflow presets from a dockable Workflow Builder panel.
+-   Batch extract spectral signatures from point CSV inputs with Processing tools.
 -   Use dockable QGIS panels and batch-friendly Processing tools.
 
 ## Installation
@@ -86,9 +88,17 @@ For development installation, packaging, and troubleshooting details, see the [Q
 5. Adjust spatial or spectral stride to reduce memory use.
 6. Click **Create 3D Cube**.
 
+### Running Workflow Builder
+
+1. Load a hyperspectral layer.
+2. Click the **Workflow Builder** button.
+3. Select the layer, data variable, workflow preset, and output GeoTIFF path.
+4. Optionally override the workflow wavelengths.
+5. Click **Run Workflow**.
+
 ### Running Processing Tools
 
-Open **Processing** > **Toolbox** > **HyperCoast** to run batch tools for RGB composites, single-band export, spectral index rasters, and PCA components.
+Open **Processing** > **Toolbox** > **HyperCoast** to run batch tools for RGB composites, single-band export, spectral index rasters, workflow presets, PCA components, dataset summaries, and batch spectral extraction.
 
 ## Supported File Formats
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -9,6 +9,7 @@ presets, and reusable search workspaces.
 hypercoast registry --json
 hypercoast inspect scene.nc --json
 hypercoast validate pace scene.nc
+hypercoast summarize scene.nc --json
 ```
 
 ## Run a coastal workflow
@@ -27,6 +28,58 @@ import hypercoast
 
 dataset = xr.open_dataset("scene.nc")
 ndwi = hypercoast.apply_workflow(dataset, "ndwi", variable="reflectance")
+```
+
+## Subset and extract spectra from the CLI
+
+```bash
+hypercoast subset scene.nc subset.nc --bbox -91.5 28.5 -90.5 29.5
+hypercoast spectra pace scene.nc --points stations.csv --output spectra.csv
+```
+
+The point CSV should include `x` and `y` columns by default. Use
+`--x-column`, `--y-column`, and `--crs` when your coordinate columns use
+different names or a projected CRS.
+
+## Search, download, and visualize by sensor
+
+PACE:
+
+```bash
+hypercoast search pace --bbox -91 28 -90 29 --temporal 2024-06-01/2024-06-30 --workspace-output pace.json
+hypercoast download pace pace.json --out-dir data/pace
+hypercoast summarize data/pace/scene.nc --sensor pace --json
+```
+
+EMIT:
+
+```bash
+hypercoast search emit --bbox -91 28 -90 29 --temporal 2024-06-01/2024-06-30 --workspace-output emit.json
+hypercoast download emit emit.json --out-dir data/emit
+hypercoast workflow ndwi data/emit/scene.nc emit-ndwi.nc --sensor emit
+```
+
+Tanager:
+
+```bash
+hypercoast search tanager --bbox -91 28 -90 29 --count 10 --workspace-output tanager.json
+hypercoast download tanager tanager.json --out-dir data/tanager
+hypercoast summarize data/tanager/scene.h5 --sensor tanager --json
+```
+
+AVIRIS:
+
+```bash
+hypercoast search aviris --bbox -122 36 -121 37 --count 5 --workspace-output aviris.json
+hypercoast download aviris aviris.json --out-dir data/aviris
+hypercoast summarize data/aviris/scene.nc --sensor aviris --json
+```
+
+Generic NetCDF or GeoTIFF:
+
+```bash
+hypercoast summarize scene.nc --json
+hypercoast workflow anomaly scene.nc anomaly.nc
 ```
 
 ## Save and reload search results

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -1,0 +1,3 @@
+# Summary module
+
+::: hypercoast.summary

--- a/hypercoast/__init__.py
+++ b/hypercoast/__init__.py
@@ -9,7 +9,12 @@ __email__ = "giswqs@gmail.com"
 __version__ = "0.26.0"
 
 
+from . import ml
 from .hypercoast import *
-from . import moe_vae
+
+try:
+    from . import moe_vae
+except ImportError:
+    moe_vae = None
 
 __all__ = [name for name in globals() if not name.startswith("_")]

--- a/hypercoast/aviris.py
+++ b/hypercoast/aviris.py
@@ -17,11 +17,11 @@ SPDX-License-Identifier = "MIT"
 """
 
 import os
+from typing import Any, List, Optional, Union
 
-import rioxarray
 import numpy as np
 import xarray as xr
-from typing import List, Union, Optional, Any
+
 from .common import convert_coords
 
 AVIRIS_NETCDF_SUFFIXES = (".nc", ".nc4", ".cdf")

--- a/hypercoast/aviris.py
+++ b/hypercoast/aviris.py
@@ -20,6 +20,7 @@ import os
 from typing import Any, List, Optional, Union
 
 import numpy as np
+import rioxarray  # noqa: F401 -- registers .rio accessor
 import xarray as xr
 
 from .common import convert_coords

--- a/hypercoast/catalog.py
+++ b/hypercoast/catalog.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 

--- a/hypercoast/chla.py
+++ b/hypercoast/chla.py
@@ -2,23 +2,21 @@
 Module for training and evaluating the VAE model for Chl-a concentration estimation.
 """
 
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import rasterio
+import seaborn as sns
 import torch
 import torch.nn as nn
-import numpy as np
-from torch.utils.data import DataLoader, TensorDataset, random_split
 import torch.nn.functional as F
-from sklearn.preprocessing import MinMaxScaler, StandardScaler
-import matplotlib.pyplot as plt
-import seaborn as sns
-import os
-import scipy.io
-import pandas as pd
-import netCDF4 as nc
-import rasterio
 from rasterio.transform import from_origin
-from rasterio.warp import reproject, Resampling
 from scipy.interpolate import griddata
 from scipy.spatial import cKDTree
+from sklearn.preprocessing import MinMaxScaler
+from torch.utils.data import DataLoader, TensorDataset, random_split
 
 
 class VAE(nn.Module):

--- a/hypercoast/cli.py
+++ b/hypercoast/cli.py
@@ -26,6 +26,7 @@ from .registry import (
     search_sensor,
     sensor_to_image,
 )
+from .summary import extract_spectra_to_csv, subset_dataset, summarize_dataset
 from .workflows import apply_workflow, list_workflows
 
 
@@ -137,6 +138,33 @@ def _build_parser() -> argparse.ArgumentParser:
     inspect.add_argument("--json", action="store_true", help="Print JSON output.")
     inspect.set_defaults(func=_cmd_inspect)
 
+    summarize = subparsers.add_parser(
+        "summarize",
+        help="Summarize a local hyperspectral dataset.",
+    )
+    summarize.add_argument("input", help="Input dataset path.")
+    summarize.add_argument("--sensor", help="Optional sensor reader to use.")
+    summarize.add_argument("--variable", help="Optional data variable.")
+    summarize.add_argument("--json", action="store_true", help="Print JSON output.")
+    summarize.set_defaults(func=_cmd_summarize)
+
+    subset = subparsers.add_parser(
+        "subset",
+        help="Subset a local rectilinear dataset by bounding box.",
+    )
+    subset.add_argument("input", help="Input dataset path.")
+    subset.add_argument("output", help="Output NetCDF path.")
+    subset.add_argument(
+        "--bbox",
+        nargs=4,
+        type=float,
+        required=True,
+        metavar=("XMIN", "YMIN", "XMAX", "YMAX"),
+    )
+    subset.add_argument("--sensor", help="Optional sensor reader to use.")
+    subset.add_argument("--variable", help="Optional data variable.")
+    subset.set_defaults(func=_cmd_subset)
+
     workflows = subparsers.add_parser(
         "workflows",
         help="List workflow presets.",
@@ -170,6 +198,19 @@ def _build_parser() -> argparse.ArgumentParser:
     extract.add_argument("--lon", type=float, required=True, help="Longitude.")
     extract.add_argument("--output", required=True, help="Output CSV path.")
     extract.set_defaults(func=_cmd_extract_spectrum)
+
+    spectra = subparsers.add_parser(
+        "spectra",
+        help="Extract spectra for point coordinates from a CSV file.",
+    )
+    _add_sensor_arg(spectra)
+    spectra.add_argument("input", help="Input dataset path.")
+    spectra.add_argument("--points", required=True, help="Input point CSV path.")
+    spectra.add_argument("--output", required=True, help="Output long-form CSV path.")
+    spectra.add_argument("--x-column", default="x", help="Point x/lon column.")
+    spectra.add_argument("--y-column", default="y", help="Point y/lat column.")
+    spectra.add_argument("--crs", default="EPSG:4326", help="Point coordinate CRS.")
+    spectra.set_defaults(func=_cmd_spectra)
 
     pca_parser = subparsers.add_parser("pca", help="Run PCA on an input image.")
     pca_parser.add_argument("input", help="Input raster path.")
@@ -257,6 +298,8 @@ def _cmd_download(args: argparse.Namespace) -> int:
     except json.JSONDecodeError as exc:
         print(f"Error: invalid JSON in {args.input}: {exc}", file=sys.stderr)
         return 1
+    if isinstance(items, dict) and "items" in items:
+        items = items["items"]
 
     if get_sensor(args.sensor).name == "tanager":
         result = download_sensor(
@@ -353,6 +396,51 @@ def _cmd_inspect(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_summarize(args: argparse.Namespace) -> int:
+    """Summarize a local dataset."""
+    try:
+        summary = summarize_dataset(
+            args.input,
+            sensor=args.sensor,
+            variable=args.variable,
+        )
+    except KeyError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    payload = summary.as_dict()
+    if args.json:
+        print(_json_default(payload))
+    else:
+        print(f"Path: {payload['path']}")
+        print(f"Exists: {payload['exists']}")
+        print(f"Sensor: {payload['sensor'] or 'auto'}")
+        print("Variables: " + (", ".join(payload["variables"]) or "none"))
+        print(f"Selected variable: {payload['selected_variable'] or 'none'}")
+        print(f"CRS: {payload['crs'] or 'unknown'}")
+        print(f"Bounds: {payload['bounds'] or 'unknown'}")
+        print(f"Wavelengths: {payload['wavelength_count']}")
+        if payload["warnings"]:
+            print("Warnings: " + "; ".join(payload["warnings"]))
+    return 0
+
+
+def _cmd_subset(args: argparse.Namespace) -> int:
+    """Subset a local dataset."""
+    try:
+        output = subset_dataset(
+            args.input,
+            args.output,
+            bbox=tuple(args.bbox),
+            sensor=args.sensor,
+            variable=args.variable,
+        )
+    except Exception as exc:
+        print(f"Error: subset failed: {exc}", file=sys.stderr)
+        return 1
+    print(output)
+    return 0
+
+
 def _cmd_workflows(args: argparse.Namespace) -> int:
     """Print workflow preset metadata."""
     workflows = list_workflows()
@@ -398,6 +486,25 @@ def _cmd_extract_spectrum(args: argparse.Namespace) -> int:
     spectrum = extract_sensor(args.sensor, args.input, lat=args.lat, lon=args.lon)
     _write_spectrum_csv(spectrum, args.output)
     print(args.output)
+    return 0
+
+
+def _cmd_spectra(args: argparse.Namespace) -> int:
+    """Extract spectra for CSV point coordinates."""
+    try:
+        output = extract_spectra_to_csv(
+            args.sensor,
+            args.input,
+            points_csv=args.points,
+            output=args.output,
+            x_column=args.x_column,
+            y_column=args.y_column,
+            crs=args.crs,
+        )
+    except Exception as exc:
+        print(f"Error: spectra extraction failed: {exc}", file=sys.stderr)
+        return 1
+    print(output)
     return 0
 
 

--- a/hypercoast/common.py
+++ b/hypercoast/common.py
@@ -6,9 +6,10 @@
 
 import os
 import sys
+from typing import Any, Dict, List, Optional, Tuple, Union
+
 import leafmap
 import xarray as xr
-from typing import List, Union, Dict, Optional, Tuple, Any
 
 
 def github_raw_url(url: str) -> str:
@@ -62,8 +63,9 @@ def download_file(
     Returns:
         str: The output file path.
     """
-    import zipfile
     import tarfile
+    import zipfile
+
     import gdown
 
     if output is None:
@@ -560,8 +562,8 @@ def nasa_earth_login(strategy: str = "all", persist: bool = True, **kwargs) -> N
         strategy (str, optional): The login strategy. Defaults to "all".
         persist (bool, optional): Whether to persist the login. Defaults to True.
     """
-    from leafmap import get_api_key
     import earthaccess
+    from leafmap import get_api_key
 
     USERNAME = get_api_key("EARTHDATA_USERNAME")
     PASSWORD = get_api_key("EARTHDATA_PASSWORD")
@@ -924,6 +926,7 @@ def extract_date_from_filename(filename: str):
         None
     """
     import re
+
     import pandas as pd
 
     # Assuming the date format in filename is 'YYYYMMDD'
@@ -977,8 +980,9 @@ def download_acolite(outdir: str = ".", platform: Optional[str] = None) -> str:
         Exception: If the platform is unsupported or the download fails.
     """
     import platform as pf
-    import requests
     import tarfile
+
+    import requests
     from tqdm import tqdm
 
     base_url = "https://github.com/acolite/acolite/releases/download/20231023.0/"
@@ -1259,9 +1263,9 @@ def show_field_data(
     Returns:
         Map: An ipyleaflet Map with the added markers and popups.
     """
-    import pandas as pd
     import matplotlib.pyplot as plt
-    from ipyleaflet import Map, Marker, Popup, MarkerCluster
+    import pandas as pd
+    from ipyleaflet import Map, Marker, MarkerCluster, Popup
     from ipywidgets import Output, VBox
 
     # Read the CSV file

--- a/hypercoast/desis.py
+++ b/hypercoast/desis.py
@@ -9,6 +9,7 @@ This Module has the functions related to working with a DESIS dataset.
 from typing import Optional, Union
 
 import pandas as pd
+import rioxarray  # noqa: F401 -- registers .rio accessor
 import xarray as xr
 
 from .common import convert_coords

--- a/hypercoast/desis.py
+++ b/hypercoast/desis.py
@@ -6,11 +6,12 @@
 This Module has the functions related to working with a DESIS dataset.
 """
 
-import rioxarray
-import xarray as xr
-import pandas as pd
-from .common import convert_coords
 from typing import Optional, Union
+
+import pandas as pd
+import xarray as xr
+
+from .common import convert_coords
 
 
 def read_desis(

--- a/hypercoast/emit.py
+++ b/hypercoast/emit.py
@@ -15,10 +15,11 @@ Credits to the original authors, including Erik Bolch, Alex Leigh, and others.
 """
 
 import os
-import xarray as xr
-import numpy as np
-import geopandas as gpd
 from typing import Optional, Union
+
+import geopandas as gpd
+import numpy as np
+import xarray as xr
 
 
 def read_emit(
@@ -304,8 +305,8 @@ def emit_xarray(
         xarray.Dataset: An xarray.Dataset constructed based on the parameters provided.
     """
     # Grab granule filename to check product
-    from s3fs.core import S3File
     from fsspec.implementations.http import HTTPFile
+    from s3fs.core import S3File
 
     if isinstance(filepath, S3File):
         granule_id = filepath.info()["name"].split("/", -1)[-1].split(".", -1)[0]

--- a/hypercoast/emit_utils/MoE_VAE.py
+++ b/hypercoast/emit_utils/MoE_VAE.py
@@ -5,9 +5,8 @@ estimation from hyperspectral remote sensing data. It includes sparse dispatchin
 for efficient expert routing and training/evaluation utilities.
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Union
-
 import os
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 

--- a/hypercoast/emit_utils/__init__.py
+++ b/hypercoast/emit_utils/__init__.py
@@ -5,8 +5,8 @@ Investigation) hyperspectral data, including data loading, preprocessing, model 
 and visualization.
 """
 
-from .MoE_VAE import *
 from .data_loading import *
 from .model_inference import *
+from .MoE_VAE import *
 from .plot_and_save import *
 from .preprocess import *

--- a/hypercoast/emit_utils/data_loading.py
+++ b/hypercoast/emit_utils/data_loading.py
@@ -13,6 +13,7 @@ try:
     import torch
     from sklearn.preprocessing import MinMaxScaler
     from torch.utils.data import DataLoader, Subset, TensorDataset
+
     from .preprocess import LogScaler, RobustMinMaxScaler
 except ImportError:
     pass

--- a/hypercoast/emit_utils/model_inference.py
+++ b/hypercoast/emit_utils/model_inference.py
@@ -5,10 +5,9 @@ data, visualizing results with RGB backgrounds, and converting predictions to
 GeoTIFF format.
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Union
-
 import os
 import re
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -476,12 +475,12 @@ def preprocess_emit_data_Robust(
     mask = np.all(~np.isnan(filtered_Rrs), axis=2)
 
     target_443 = (
-        f"Rrs_443"
+        "Rrs_443"
         if "Rrs_443" in bands_to_extract
         else find_closest_band(443, bands_to_extract)
     )
     target_560 = (
-        f"Rrs_560"
+        "Rrs_560"
         if "Rrs_560" in bands_to_extract
         else find_closest_band(560, bands_to_extract)
     )

--- a/hypercoast/emit_utils/plot_and_save.py
+++ b/hypercoast/emit_utils/plot_and_save.py
@@ -4,9 +4,8 @@ This module provides functions for visualizing model predictions, computing
 performance metrics, and saving results to Excel files.
 """
 
-from typing import List, Optional, Tuple
-
 import os
+from typing import List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/hypercoast/enmap.py
+++ b/hypercoast/enmap.py
@@ -2,13 +2,15 @@
 #
 # SPDX-License-Identifier: MIT
 
-from typing import List, Union, Optional, Any
-import xarray as xr
-import numpy as np
-import os
 import glob
+import os
 import xml.etree.ElementTree as ET
+from typing import Any, List, Optional, Union
+
+import numpy as np
+import xarray as xr
 from leafmap import array_to_image
+
 from .common import convert_coords
 
 
@@ -17,7 +19,6 @@ def _extract_enmap_wavelengths_from_xml(metadata_xml_path: str) -> List[float]:
     Extracts EnMAP spectral center wavelengths (in nm) from the metadata XML file.
     Looks for <wavelengthCenterOfBand> inside each <bandID> block.
     """
-    import xml.etree.ElementTree as ET
 
     tree = ET.parse(metadata_xml_path)
     root = tree.getroot()

--- a/hypercoast/hypercoast.py
+++ b/hypercoast/hypercoast.py
@@ -4,70 +4,15 @@
 
 """Main module."""
 
+import os
+import tempfile
+from typing import Union
+
 import ipyleaflet
 import leafmap
-import xarray as xr
 import numpy as np
-import tempfile
-import os
-from typing import Union
-from .aviris import (
-    aviris_to_image,
-    read_aviris,
-    extract_aviris,
-    get_aviris_asset_url,
-    get_aviris_bounds,
-    get_aviris_collection_concept_id,
-    get_aviris_granule_ur,
-)
-from .desis import desis_to_image, read_desis, extract_desis, filter_desis
-from .prisma import read_prisma, prisma_to_image, extract_prisma
-from .enmap import read_enmap, enmap_to_image, extract_enmap
-from .emit import (
-    emit_to_image,
-    read_emit,
-    plot_emit,
-    viz_emit,
-    emit_to_netcdf,
-)
-from .neon import extract_neon, neon_to_image, read_neon
-from .pace import (
-    pace_to_image,
-    read_pace,
-    read_pace_aop,
-    read_pace_bgc,
-    read_pace_chla,
-    view_pace_pixel_locations,
-    viz_pace,
-    viz_pace_chla,
-    filter_pace,
-    extract_pace,
-    grid_pace,
-    grid_pace_bgc,
-    pace_to_image,
-    pace_chla_to_image,
-)
-from .tanager import (
-    read_tanager,
-    read_tanager_stac,
-    search_tanager,
-    tanager_footprints,
-    download_tanager,
-    get_tanager_asset_url,
-    tanager_to_image,
-    extract_tanager,
-    grid_tanager,
-)
-from .wyvern import read_wyvern, wyvern_to_image, extract_wyvern, filter_wyvern
-from .cesl import (
-    search_cesl,
-    get_cesl_metadata,
-    get_cesl_spectrum,
-    plot_cesl_spectrum,
-    get_cesl_sites,
-    cesl_to_gdf,
-    cesl_to_geojson,
-)
+import xarray as xr
+
 from .appeears import (
     AppEEARSClient,
     appeears_area_task,
@@ -81,31 +26,74 @@ from .appeears import (
     appeears_wait,
     read_appeears,
 )
-from .ui import SpectralWidget
-from .common import (
-    download_file,
-    search_datasets,
-    search_nasa_data,
-    download_nasa_data,
-    search_pace,
-    search_pace_chla,
-    search_emit,
-    search_aviris,
-    search_ecostress,
-    download_pace,
-    download_emit,
-    download_aviris,
-    download_ecostress,
-    nasa_earth_login,
-    image_cube,
-    open_dataset,
-    download_acolite,
-    run_acolite,
-    pca,
-    show_field_data,
+from .aviris import (
+    aviris_to_image,
+    extract_aviris,
+    get_aviris_asset_url,
+    get_aviris_bounds,
+    get_aviris_collection_concept_id,
+    get_aviris_granule_ur,
+    read_aviris,
 )
 from .catalog import SearchResult, load_search_result
+from .cesl import (
+    cesl_to_gdf,
+    cesl_to_geojson,
+    get_cesl_metadata,
+    get_cesl_sites,
+    get_cesl_spectrum,
+    plot_cesl_spectrum,
+    search_cesl,
+)
 from .cloud import open_cloud_dataset, suggest_chunks, to_cog, to_zarr
+from .common import (
+    download_acolite,
+    download_aviris,
+    download_ecostress,
+    download_emit,
+    download_file,
+    download_nasa_data,
+    download_pace,
+    image_cube,
+    nasa_earth_login,
+    open_dataset,
+    pca,
+    run_acolite,
+    search_aviris,
+    search_datasets,
+    search_ecostress,
+    search_emit,
+    search_nasa_data,
+    search_pace,
+    search_pace_chla,
+    show_field_data,
+)
+from .desis import desis_to_image, extract_desis, filter_desis, read_desis
+from .emit import (
+    emit_to_image,
+    emit_to_netcdf,
+    plot_emit,
+    read_emit,
+    viz_emit,
+)
+from .enmap import enmap_to_image, extract_enmap, read_enmap
+from .neon import extract_neon, neon_to_image, read_neon
+from .pace import (
+    extract_pace,
+    filter_pace,
+    grid_pace,
+    grid_pace_bgc,
+    pace_chla_to_image,
+    pace_to_image,
+    read_pace,
+    read_pace_aop,
+    read_pace_bgc,
+    read_pace_chla,
+    view_pace_pixel_locations,
+    viz_pace,
+    viz_pace_chla,
+)
+from .prisma import extract_prisma, prisma_to_image, read_prisma
 from .registry import (
     SENSOR_REGISTRY,
     SensorHandler,
@@ -115,8 +103,8 @@ from .registry import (
     list_sensors,
     qgis_data_types,
     read_sensor,
-    registry_as_dict,
     register_sensor,
+    registry_as_dict,
     search_sensor,
     sensor_to_image,
 )
@@ -130,6 +118,24 @@ from .spectral import (
     spectral_information_divergence,
     write_spectral_library,
 )
+from .summary import (
+    DatasetSummary,
+    extract_spectra_to_csv,
+    subset_dataset,
+    summarize_dataset,
+)
+from .tanager import (
+    download_tanager,
+    extract_tanager,
+    get_tanager_asset_url,
+    grid_tanager,
+    read_tanager,
+    read_tanager_stac,
+    search_tanager,
+    tanager_footprints,
+    tanager_to_image,
+)
+from .ui import SpectralWidget
 from .workflows import (
     WORKFLOW_PRESETS,
     WorkflowPreset,
@@ -139,6 +145,7 @@ from .workflows import (
     normalized_difference,
     spectral_anomaly,
 )
+from .wyvern import extract_wyvern, filter_wyvern, read_wyvern, wyvern_to_image
 
 __all__ = [
     "AppEEARSClient",
@@ -179,6 +186,8 @@ __all__ = [
     "emit_to_image",
     "emit_to_netcdf",
     "enmap_to_image",
+    "DatasetSummary",
+    "extract_spectra_to_csv",
     "extract_aviris",
     "extract_desis",
     "extract_enmap",
@@ -256,6 +265,8 @@ __all__ = [
     "normalized_difference",
     "open_cloud_dataset",
     "suggest_chunks",
+    "subset_dataset",
+    "summarize_dataset",
     "tanager_to_image",
     "to_cog",
     "to_zarr",

--- a/hypercoast/ml.py
+++ b/hypercoast/ml.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Optional machine-learning helpers for HyperCoast."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from importlib.util import find_spec
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    """Describe an optional HyperCoast model family.
+
+    Args:
+        name: Model family name.
+        task: Supported inference task.
+        required_extra: Package extra needed to use the model.
+        module: Import path that provides the implementation.
+    """
+
+    name: str
+    task: str
+    required_extra: str
+    module: str
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return serializable model metadata.
+
+        Returns:
+            dict: Model metadata.
+        """
+        return asdict(self)
+
+
+MODEL_REGISTRY = {
+    "moe_vae": ModelInfo(
+        name="moe_vae",
+        task="water-quality inference",
+        required_extra="ml",
+        module="hypercoast.moe_vae",
+    ),
+}
+
+
+def list_models() -> dict[str, dict[str, Any]]:
+    """Return optional model metadata.
+
+    Returns:
+        dict: Mapping of model names to metadata.
+    """
+    return {name: info.as_dict() for name, info in MODEL_REGISTRY.items()}
+
+
+def require_ml_dependencies() -> None:
+    """Raise a clear error when optional ML dependencies are unavailable.
+
+    Raises:
+        ImportError: If PyTorch is not installed.
+    """
+    missing = [name for name in ("torch",) if find_spec(name) is None]
+    if missing:
+        packages = ", ".join(missing)
+        raise ImportError(
+            f"HyperCoast ML features require optional dependencies: {packages}. "
+            "Install HyperCoast with the 'ml' extra."
+        )
+
+
+def load_moe_vae_modules():
+    """Import and return the optional MoE/VAE package namespace.
+
+    Returns:
+        module: ``hypercoast.moe_vae`` package.
+    """
+    require_ml_dependencies()
+    from . import moe_vae
+
+    return moe_vae
+
+
+__all__ = ["MODEL_REGISTRY", "ModelInfo", "list_models", "load_moe_vae_modules"]

--- a/hypercoast/moe_vae/__init__.py
+++ b/hypercoast/moe_vae/__init__.py
@@ -12,8 +12,8 @@ The module includes:
     - Custom scalers for robust data preprocessing
 """
 
-from .model import *
 from .data_loading import *
+from .model import *
 from .model_inference import *
 from .plot_and_save import *
 from .preprocess import *

--- a/hypercoast/moe_vae/data_loading.py
+++ b/hypercoast/moe_vae/data_loading.py
@@ -10,14 +10,13 @@ import pandas as pd
 
 try:
     import torch
-    from torch.utils.data import DataLoader, TensorDataset
     from sklearn.preprocessing import MinMaxScaler
-    from torch.utils.data import DataLoader, TensorDataset, Subset
+    from torch.utils.data import DataLoader, Subset, TensorDataset
 except ImportError:
     pass
 
 try:
-    from .preprocess import RobustMinMaxScaler, LogScaler
+    from .preprocess import LogScaler, RobustMinMaxScaler
 except ImportError:
     pass
 

--- a/hypercoast/moe_vae/model.py
+++ b/hypercoast/moe_vae/model.py
@@ -5,6 +5,7 @@ analysis, including sparse gating mechanisms and training utilities.
 """
 
 import os
+
 import numpy as np
 
 try:

--- a/hypercoast/moe_vae/model_inference.py
+++ b/hypercoast/moe_vae/model_inference.py
@@ -4,20 +4,20 @@ This module provides functions for preprocessing and inference using MoE-VAE mod
 """
 
 import os
-import numpy as np
+
 import matplotlib.pyplot as plt
 import netCDF4 as nc
+import numpy as np
 from netCDF4 import Dataset as nc
 
 try:
-    import torch
-    from torch.utils.data import DataLoader, TensorDataset
-    import torch.nn.functional as F
-    from sklearn.preprocessing import MinMaxScaler
-    from scipy.interpolate import griddata
-    from torch.utils.data import DataLoader, TensorDataset
     import rasterio
+    import torch
+    import torch.nn.functional as F
     from rasterio.transform import from_origin
+    from scipy.interpolate import griddata
+    from sklearn.preprocessing import MinMaxScaler
+    from torch.utils.data import DataLoader, TensorDataset
 except ImportError:
     pass
 
@@ -741,12 +741,12 @@ def preprocess_emit_data_Robust(
     mask = np.all(~np.isnan(filtered_Rrs), axis=2)
 
     target_443 = (
-        f"Rrs_443"
+        "Rrs_443"
         if "Rrs_443" in bands_to_extract
         else find_closest_band(443, bands_to_extract)
     )
     target_560 = (
-        f"Rrs_560"
+        "Rrs_560"
         if "Rrs_560" in bands_to_extract
         else find_closest_band(560, bands_to_extract)
     )

--- a/hypercoast/moe_vae/plot_and_save.py
+++ b/hypercoast/moe_vae/plot_and_save.py
@@ -1,10 +1,12 @@
-import numpy as np
-import matplotlib.pyplot as plt
-import seaborn as sns
-import os
-import pandas as pd
 import inspect
-from .model import MoE_VAE, SparseDispatcher, VAE
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+
+from .model import VAE, MoE_VAE, SparseDispatcher
 
 
 def save_model_structure_from_classes(save_path):

--- a/hypercoast/neon.py
+++ b/hypercoast/neon.py
@@ -8,11 +8,12 @@ The source code is adapted from https://bit.ly/3KwyZkn. Credit goes to the
 original authors.
 """
 
+from typing import Any, List, Optional, Union
+
 import h5py
-import rioxarray
 import numpy as np
 import xarray as xr
-from typing import List, Union, Dict, Optional, Tuple, Any
+
 from .common import convert_coords
 
 

--- a/hypercoast/pace.py
+++ b/hypercoast/pace.py
@@ -11,9 +11,11 @@ try:
 except ImportError:
     from typing import Any as ArrayLike
 import os
-import xarray as xr
+from typing import Any, Callable, List, Optional, Tuple, Union
+
 import matplotlib.pyplot as plt
-from typing import List, Tuple, Union, Optional, Any, Callable
+import xarray as xr
+
 from .common import extract_date_from_filename
 
 
@@ -188,9 +190,8 @@ def read_pace_chla(
         >>> chla_data = read_pace_chla(['path/to/file1.nc', 'path/to/file2.nc'], combine='by_coords')
     """
 
-    import os
     import glob
-    import rioxarray
+    import os
 
     date = None
     if isinstance(filepaths, str) and os.path.isfile(filepaths):
@@ -313,9 +314,10 @@ def viz_pace(
         **kwargs: Additional keyword arguments to pass to the `plt.subplots` function.
     """
 
+    import math
+
     import matplotlib.pyplot as plt
     import numpy as np
-    import math
 
     if isinstance(dataset, str):
         dataset = read_pace(dataset, wavelengths, method)
@@ -368,7 +370,7 @@ def viz_pace(
     else:
 
         import cartopy
-        from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+        from cartopy.mpl.ticker import LatitudeFormatter, LongitudeFormatter
 
         if crs == "default":
             crs = cartopy.crs.PlateCarree()
@@ -635,7 +637,6 @@ def grid_pace_bgc(
         >>> gridded_data = grid_pace_bgc(dataset, variable="chlor_a", method="nearest")
         >>> print(gridded_data)
     """
-    import rioxarray
     from scipy.interpolate import griddata
 
     lat = dataset.latitude
@@ -829,13 +830,12 @@ def apply_kmeans(
         tuple[np.ndarray, np.ndarray, np.ndarray]: The cluster labels, latitudes, and longitudes.
     """
 
-    import numpy as np
-    from sklearn.cluster import KMeans
-
-    import matplotlib.pyplot as plt
-    import matplotlib.colors as mcolors
     import cartopy.crs as ccrs
     import cartopy.feature as cfeature
+    import matplotlib.colors as mcolors
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from sklearn.cluster import KMeans
 
     if isinstance(dataset, str):
         dataset = read_pace(dataset)
@@ -1035,13 +1035,14 @@ def apply_sam(
         Tuple[np.ndarray, np.ndarray, np.ndarray]: The best match classification, latitudes, and longitudes.
     """
     import glob
-    import pandas as pd
-    from sklearn.cluster import KMeans
-    import matplotlib.colors as mcolors
+
     import cartopy.crs as ccrs
     import cartopy.feature as cfeature
-    from sklearn.decomposition import PCA
+    import matplotlib.colors as mcolors
+    import pandas as pd
     from scipy.interpolate import interp1d
+    from sklearn.cluster import KMeans
+    from sklearn.decomposition import PCA
 
     if isinstance(dataset, str):
         dataset = read_pace(dataset)
@@ -1262,10 +1263,11 @@ def apply_sam_spectral(
         Tuple[np.ndarray, np.ndarray, np.ndarray]: The best match classification, latitudes, and longitudes.
     """
     import glob
-    import pandas as pd
-    import matplotlib.colors as mcolors
+
     import cartopy.crs as ccrs
     import cartopy.feature as cfeature
+    import matplotlib.colors as mcolors
+    import pandas as pd
     from scipy.interpolate import interp1d
 
     if isinstance(dataset, str):

--- a/hypercoast/prisma.py
+++ b/hypercoast/prisma.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, Tuple, Union
 
 import h5py
 import numpy as np
+import rioxarray  # noqa: F401 -- registers .rio accessor
 import xarray as xr
 from affine import Affine
 from leafmap import array_to_image

--- a/hypercoast/prisma.py
+++ b/hypercoast/prisma.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
+from typing import Any, List, Optional, Tuple, Union
+
+import h5py
 import numpy as np
 import xarray as xr
-from typing import List, Optional, Any, Union, Tuple
 from affine import Affine
-import h5py
-import pyproj
 from leafmap import array_to_image
+
 from .common import convert_coords
 
 

--- a/hypercoast/summary.py
+++ b/hypercoast/summary.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Dataset summary and batch extraction helpers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from .registry import get_sensor, read_sensor
+
+SPECTRAL_DIMS = ("wavelength", "wavelengths", "band", "bands")
+
+
+@dataclass
+class DatasetSummary:
+    """Describe a local hyperspectral dataset.
+
+    Args:
+        path: Dataset path.
+        exists: Whether the path exists.
+        sensor: Sensor name used to read the dataset.
+        variables: Data variable names.
+        selected_variable: Selected data variable.
+        crs: Dataset CRS when discoverable.
+        bounds: Dataset bounds when discoverable.
+        wavelength_count: Number of spectral coordinates.
+        wavelength_min: Minimum wavelength or band coordinate.
+        wavelength_max: Maximum wavelength or band coordinate.
+        dimensions: Dataset dimensions.
+        default_rgb: Default RGB wavelengths from the sensor registry.
+        warnings: Non-fatal summary warnings.
+    """
+
+    path: str
+    exists: bool
+    sensor: Optional[str] = None
+    variables: list[str] = field(default_factory=list)
+    selected_variable: Optional[str] = None
+    crs: Optional[str] = None
+    bounds: Optional[tuple[float, float, float, float]] = None
+    wavelength_count: int = 0
+    wavelength_min: Optional[float] = None
+    wavelength_max: Optional[float] = None
+    dimensions: dict[str, int] = field(default_factory=dict)
+    default_rgb: list[float] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable summary dictionary.
+
+        Returns:
+            dict: Summary fields.
+        """
+        return asdict(self)
+
+
+def summarize_dataset(
+    path: str | Path,
+    sensor: Optional[str] = None,
+    variable: Optional[str] = None,
+) -> DatasetSummary:
+    """Summarize a local dataset.
+
+    Args:
+        path: Local dataset path.
+        sensor: Optional sensor name or alias.
+        variable: Optional selected data variable.
+
+    Returns:
+        DatasetSummary: Dataset metadata and warnings.
+    """
+    dataset_path = Path(path)
+    summary = DatasetSummary(path=str(dataset_path), exists=dataset_path.exists())
+    if not dataset_path.exists():
+        summary.warnings.append(f"File not found: {dataset_path}")
+        return summary
+
+    handler = None
+    if sensor:
+        handler = get_sensor(sensor)
+        summary.sensor = handler.name
+        summary.default_rgb = [float(value) for value in handler.default_rgb]
+
+    try:
+        ds = (
+            read_sensor(sensor, dataset_path)
+            if sensor
+            else xr.open_dataset(dataset_path)
+        )
+    except Exception as exc:
+        summary.warnings.append(f"Could not open dataset: {exc}")
+        return summary
+
+    try:
+        summary.variables = list(ds.data_vars)
+        summary.dimensions = {name: int(size) for name, size in ds.sizes.items()}
+        summary.selected_variable = _select_variable(ds, variable)
+        summary.crs = _dataset_crs(ds)
+        summary.bounds = _dataset_bounds(ds)
+        wavelengths = _wavelength_values(ds, summary.selected_variable)
+        if wavelengths is not None and wavelengths.size > 0:
+            finite = wavelengths[np.isfinite(wavelengths)]
+            summary.wavelength_count = int(wavelengths.size)
+            if finite.size > 0:
+                summary.wavelength_min = float(np.nanmin(finite))
+                summary.wavelength_max = float(np.nanmax(finite))
+    finally:
+        close = getattr(ds, "close", None)
+        if callable(close):
+            close()
+
+    if variable and summary.selected_variable != variable:
+        summary.warnings.append(f"Variable not found or not selectable: {variable}")
+    return summary
+
+
+def subset_dataset(
+    path: str | Path,
+    output: str | Path,
+    bbox: tuple[float, float, float, float],
+    sensor: Optional[str] = None,
+    variable: Optional[str] = None,
+) -> str:
+    """Subset a rectilinear local dataset by bounding box and write NetCDF.
+
+    Args:
+        path: Input dataset path.
+        output: Output NetCDF path.
+        bbox: Bounding box as ``(xmin, ymin, xmax, ymax)``.
+        sensor: Optional sensor name or alias.
+        variable: Optional data variable to keep.
+
+    Returns:
+        str: Output path.
+    """
+    ds = read_sensor(sensor, path) if sensor else xr.open_dataset(path)
+    try:
+        selected = _select_variable(ds, variable)
+        if variable and selected:
+            ds = ds[[selected]]
+        xmin, ymin, xmax, ymax = bbox
+        ds = _subset_by_bbox(ds, xmin, ymin, xmax, ymax)
+        output_path = Path(output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        ds.to_netcdf(output_path)
+        return str(output_path)
+    finally:
+        close = getattr(ds, "close", None)
+        if callable(close):
+            close()
+
+
+def extract_spectra_to_csv(
+    sensor: str,
+    path: str | Path,
+    points_csv: str | Path,
+    output: str | Path,
+    x_column: str = "x",
+    y_column: str = "y",
+    crs: str = "EPSG:4326",
+) -> str:
+    """Extract spectra for CSV point coordinates.
+
+    Args:
+        sensor: Sensor name or alias.
+        path: Input dataset path.
+        points_csv: CSV file containing point coordinates.
+        output: Output long-form CSV path.
+        x_column: X or longitude column.
+        y_column: Y or latitude column.
+        crs: Coordinate reference system for point coordinates.
+
+    Returns:
+        str: Output CSV path.
+    """
+    from .registry import extract_sensor
+
+    points = pd.read_csv(points_csv)
+    if x_column not in points.columns or y_column not in points.columns:
+        raise ValueError(f"Point CSV must contain '{x_column}' and '{y_column}'.")
+
+    dataset = read_sensor(sensor, path)
+    rows: list[dict[str, Any]] = []
+    try:
+        for feature_id, row in points.iterrows():
+            lon, lat = _to_lon_lat(float(row[x_column]), float(row[y_column]), crs)
+            spectrum = extract_sensor(sensor, dataset, lat=lat, lon=lon)
+            wavelengths, values = _spectrum_values(spectrum)
+            for wavelength, value in zip(wavelengths, values):
+                rows.append(
+                    {
+                        "feature_id": feature_id,
+                        "x": row[x_column],
+                        "y": row[y_column],
+                        "crs": crs,
+                        "wavelength": wavelength,
+                        "value": value,
+                        "layer": str(path),
+                        "variable": getattr(spectrum, "name", None),
+                    }
+                )
+    finally:
+        close = getattr(dataset, "close", None)
+        if callable(close):
+            close()
+
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(output_path, index=False)
+    return str(output_path)
+
+
+def _select_variable(ds: xr.Dataset, variable: Optional[str]) -> Optional[str]:
+    """Return a selected or inferred data variable name."""
+    if variable and variable in ds.data_vars:
+        return variable
+    for candidate in ("reflectance", "Rrs", "toa_radiance", "surface_reflectance"):
+        if candidate in ds.data_vars:
+            return candidate
+    return next(iter(ds.data_vars), None)
+
+
+def _wavelength_values(
+    ds: xr.Dataset,
+    variable: Optional[str],
+) -> Optional[np.ndarray]:
+    """Return spectral coordinate values when available."""
+    candidates: list[str] = []
+    if variable and variable in ds:
+        candidates.extend(dim for dim in ds[variable].dims if dim in SPECTRAL_DIMS)
+    candidates.extend(name for name in SPECTRAL_DIMS if name in ds.coords)
+    for name in candidates:
+        if name in ds.coords:
+            return np.asarray(ds.coords[name].values, dtype=float)
+    return None
+
+
+def _dataset_crs(ds: xr.Dataset) -> Optional[str]:
+    """Return dataset CRS when discoverable."""
+    try:
+        rio = getattr(ds, "rio", None)
+        crs = getattr(rio, "crs", None)
+        if crs:
+            return str(crs)
+    except Exception:
+        pass
+    crs = ds.attrs.get("crs") or ds.attrs.get("spatial_ref")
+    return str(crs) if crs else None
+
+
+def _dataset_bounds(ds: xr.Dataset) -> Optional[tuple[float, float, float, float]]:
+    """Return dataset bounds from common coordinate names."""
+    try:
+        rio = getattr(ds, "rio", None)
+        bounds = rio.bounds() if rio is not None else None
+        if bounds:
+            return tuple(float(value) for value in bounds)
+    except Exception:
+        pass
+    x_coord = _first_coord(ds, ("x", "longitude", "lon"))
+    y_coord = _first_coord(ds, ("y", "latitude", "lat"))
+    if x_coord is None or y_coord is None:
+        return None
+    x_values = np.asarray(x_coord.values, dtype=float)
+    y_values = np.asarray(y_coord.values, dtype=float)
+    if x_values.size == 0 or y_values.size == 0:
+        return None
+    return (
+        float(np.nanmin(x_values)),
+        float(np.nanmin(y_values)),
+        float(np.nanmax(x_values)),
+        float(np.nanmax(y_values)),
+    )
+
+
+def _first_coord(ds: xr.Dataset, names: tuple[str, ...]) -> Optional[xr.DataArray]:
+    """Return the first present coordinate."""
+    for name in names:
+        if name in ds.coords:
+            return ds.coords[name]
+    return None
+
+
+def _subset_by_bbox(
+    ds: xr.Dataset,
+    xmin: float,
+    ymin: float,
+    xmax: float,
+    ymax: float,
+) -> xr.Dataset:
+    """Subset a dataset using common rectilinear coordinates."""
+    x_name = (
+        "x" if "x" in ds.coords else "longitude" if "longitude" in ds.coords else None
+    )
+    y_name = (
+        "y" if "y" in ds.coords else "latitude" if "latitude" in ds.coords else None
+    )
+    if x_name is None or y_name is None:
+        raise ValueError("Dataset must contain x/y or longitude/latitude coordinates.")
+    return ds.sel(
+        {
+            x_name: _coord_slice(ds.coords[x_name], xmin, xmax),
+            y_name: _coord_slice(ds.coords[y_name], ymin, ymax),
+        }
+    )
+
+
+def _coord_slice(coord: xr.DataArray, low: float, high: float) -> slice:
+    """Return an orientation-aware coordinate slice."""
+    values = np.asarray(coord.values)
+    if values.size > 1 and values[0] > values[-1]:
+        return slice(high, low)
+    return slice(low, high)
+
+
+def _to_lon_lat(x: float, y: float, crs: str) -> tuple[float, float]:
+    """Return coordinates as lon/lat."""
+    if crs.upper() in {"EPSG:4326", "CRS84", "OGC:CRS84"}:
+        return x, y
+    try:
+        from pyproj import Transformer
+
+        transformer = Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
+        lon, lat = transformer.transform(x, y)
+        return float(lon), float(lat)
+    except Exception as exc:
+        raise ValueError(f"Could not transform points from {crs}: {exc}") from exc
+
+
+def _spectrum_values(spectrum: Any) -> tuple[np.ndarray, np.ndarray]:
+    """Return wavelength and value arrays from an extracted spectrum."""
+    values = np.asarray(getattr(spectrum, "values", spectrum), dtype=float).ravel()
+    coords = getattr(spectrum, "coords", {})
+    for name in SPECTRAL_DIMS:
+        if name in coords:
+            return np.asarray(coords[name].values, dtype=float).ravel(), values
+    return np.arange(values.size, dtype=float), values
+
+
+__all__ = [
+    "DatasetSummary",
+    "extract_spectra_to_csv",
+    "subset_dataset",
+    "summarize_dataset",
+]

--- a/hypercoast/summary.py
+++ b/hypercoast/summary.py
@@ -144,6 +144,10 @@ def subset_dataset(
     ds = read_sensor(sensor, path) if sensor else xr.open_dataset(path)
     try:
         selected = _select_variable(ds, variable)
+        if variable and selected != variable:
+            raise ValueError(
+                f"Variable {variable!r} not found. " f"Available: {list(ds.data_vars)}"
+            )
         if variable and selected:
             ds = ds[[selected]]
         xmin, ymin, xmax, ymax = bbox

--- a/hypercoast/tanager.py
+++ b/hypercoast/tanager.py
@@ -7,17 +7,18 @@ wavelength metadata from inside the file when available, falling back to a
 caller-supplied STAC URL only when necessary.
 """
 
-import warnings
 import os
 import re
+import warnings
 from datetime import datetime, timezone
+from typing import List, Optional, Tuple, Union
 
 import h5py
-import xarray as xr
+import matplotlib.pyplot as plt
 import numpy as np
 import requests
-import matplotlib.pyplot as plt
-from typing import List, Tuple, Union, Optional
+import xarray as xr
+
 from .common import download_file
 
 TANAGER_STAC_CATALOG_URL = (

--- a/hypercoast/ui.py
+++ b/hypercoast/ui.py
@@ -5,21 +5,23 @@
 """This module contains the user interface for the hypercoast package."""
 
 import os
-import ipyleaflet
+
 import bqplot
+import ipyleaflet
 import ipywidgets as widgets
 import numpy as np
 import xarray as xr
 from bqplot import pyplot as plt
 from ipyfilechooser import FileChooser
-from .pace import extract_pace
-from .desis import extract_desis
-from .neon import extract_neon
+
 from .aviris import extract_aviris
 from .common import extract_spectral
-from .tanager import extract_tanager
-from .prisma import extract_prisma
+from .desis import extract_desis
 from .enmap import extract_enmap
+from .neon import extract_neon
+from .pace import extract_pace
+from .prisma import extract_prisma
+from .tanager import extract_tanager
 from .wyvern import extract_wyvern
 
 

--- a/hypercoast/workflows.py
+++ b/hypercoast/workflows.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from typing import Any, Dict, Optional
 
 import numpy as np

--- a/hypercoast/wyvern.py
+++ b/hypercoast/wyvern.py
@@ -6,11 +6,13 @@
 This Module has the functions related to working with a Wyvern dataset.
 """
 
+from typing import Optional, Union
+
+import pandas as pd
 import rioxarray
 import xarray as xr
-import pandas as pd
+
 from .common import convert_coords
-from typing import Optional, Union
 
 
 def read_wyvern(
@@ -83,8 +85,8 @@ def wyvern_to_image(
             `output` is provided, the image will be saved to the specified file
             and the function will return None.
     """
-    from leafmap import array_to_image
     import numpy as np
+    from leafmap import array_to_image
 
     if isinstance(dataset, str):
         dataset = read_wyvern(dataset, method=method)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,7 +100,9 @@ nav:
           - examples/acolite_emit.ipynb
           - examples/search_data.ipynb
           - examples/search_workspace.ipynb
+          - examples/dataset_summary_cli.ipynb
           - examples/registry_workflows.ipynb
+          - examples/qgis_workflow_processing.ipynb
           - examples/spectral_cloud_tools.ipynb
           - examples/image_cube.ipynb
           - examples/image_slicing.ipynb
@@ -155,9 +157,11 @@ nav:
           - prisma module: prisma.md
           - registry module: registry.md
           - spectral module: spectral.md
+          - summary module: summary.md
           - tanager module: tanager.md
           - enmap module: enmap.md
           - workflows module: workflows.md
+          - ml module: ml.md
           - ui module: ui.md
           - moe_vae modules:
                 - data_loading module: moe_vae/data_loading.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,20 +27,68 @@ hypercoast = "hypercoast.cli:main"
 
 [project.optional-dependencies]
 all = [
-    "HyperCoast[extra]",
-    "HyperCoast[torch]",
+    "HyperCoast[cloud]",
+    "HyperCoast[docs]",
+    "HyperCoast[ml]",
+    "HyperCoast[qgis]",
+    "HyperCoast[viz]",
+]
+
+core = [
+    "h5netcdf",
+    "h5py",
+    "netcdf4",
+    "numpy",
+    "pandas",
+    "requests",
+    "scipy",
+    "xarray",
+]
+
+viz = [
+    "cartopy",
+    "geopandas",
+    "hvplot",
+    "leafmap>=0.62.0",
+    "localtileserver",
+    "mapclassify",
+    "openpyxl",
+    "pyvista[jupyter]",
+    "rioxarray",
+    "scikit-learn",
+    "seaborn",
+]
+
+cloud = [
+    "dask",
+    "earthaccess",
+    "s3fs",
+]
+
+qgis = [
+    "PyQt6",
+    "PyQt6-QScintilla",
+    "rasterio",
+]
+
+ml = ["torch", "seaborn", "pytorch-lightning"]
+
+docs = [
+    "mkdocs",
+    "mkdocs-git-revision-date-localized-plugin",
+    "mkdocs-git-revision-date-plugin",
+    "mkdocs-jupyter>=0.26.3",
+    "mkdocs-material>=9.1.3",
+    "mkdocstrings",
+    "mkdocstrings-python-legacy",
+    "pymdown-extensions",
 ]
 
 extra = [
-    "cartopy",
-    "fiona",
-    "geopandas",
-    "openpyxl",
-    "pyvista[jupyter]",
-    "scikit-learn",
+    "HyperCoast[viz]",
 ]
 
-torch = ["torch", "seaborn", "pytorch-lightning"]
+torch = ["HyperCoast[ml]"]
 
 [tool]
 [tool.setuptools.packages.find]
@@ -71,6 +119,13 @@ exclude = [
     "docs",
 ]
 max-line-length = 88
+
+[tool.ruff]
+line-length = 88
+exclude = ["docs", "site", "dist"]
+
+[tool.ruff.lint]
+select = ["I"]
 
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ cloud = [
 ]
 
 qgis = [
+    "HyperCoast[core]",
     "PyQt6",
     "PyQt6-QScintilla",
     "rasterio",

--- a/qgis_plugin/README.md
+++ b/qgis_plugin/README.md
@@ -31,6 +31,8 @@ Check out this [short video demo](https://youtu.be/EEUAC5BxqtM) and [full video 
 
 -   **Processing Tools**: Run batch-friendly Processing algorithms for RGB composites, single-band exports, spectral indices, and PCA components.
 
+-   **Workflow Builder**: Run coastal workflow presets such as NDWI, chlorophyll-a proxy, turbidity proxy, CDOM proxy, cyanobacteria proxy, and spectral anomaly on loaded layers.
+
 Before using the plugin, please create a new conda environment to install QGIS and HyperCoast:
 
 ```bash
@@ -120,7 +122,7 @@ When QGIS is launched from this Conda environment, the plugin automatically dete
 
 ### Running Processing Tools
 
-Open **Processing** → **Toolbox** → **HyperCoast** to run batch tools for RGB composites, single-band export, spectral index rasters, and PCA components.
+Open **Processing** → **Toolbox** → **HyperCoast** to run batch tools for RGB composites, single-band export, spectral index rasters, workflow presets, PCA components, dataset summaries, and batch spectral extraction.
 
 ## Supported File Formats
 

--- a/qgis_plugin/hypercoast_qgis/_hypercoast_lib.py
+++ b/qgis_plugin/hypercoast_qgis/_hypercoast_lib.py
@@ -9,15 +9,14 @@ Why this exists:
 
 from __future__ import annotations
 
-from pathlib import Path
-from types import ModuleType
-from typing import Optional
-
 import importlib
 import importlib.metadata
 import importlib.util
 import os
 import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Optional
 
 _CACHED: Optional[ModuleType] = None
 

--- a/qgis_plugin/hypercoast_qgis/core/python_manager.py
+++ b/qgis_plugin/hypercoast_qgis/core/python_manager.py
@@ -21,7 +21,7 @@ import tarfile
 import tempfile
 import zipfile
 
-from qgis.core import QgsBlockingNetworkRequest, QgsMessageLog, Qgis
+from qgis.core import Qgis, QgsBlockingNetworkRequest, QgsMessageLog
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtNetwork import QNetworkRequest
 

--- a/qgis_plugin/hypercoast_qgis/core/uv_manager.py
+++ b/qgis_plugin/hypercoast_qgis/core/uv_manager.py
@@ -21,7 +21,7 @@ import tarfile
 import tempfile
 import zipfile
 
-from qgis.core import QgsBlockingNetworkRequest, QgsMessageLog, Qgis
+from qgis.core import Qgis, QgsBlockingNetworkRequest, QgsMessageLog
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtNetwork import QNetworkRequest
 

--- a/qgis_plugin/hypercoast_qgis/core/venv_manager.py
+++ b/qgis_plugin/hypercoast_qgis/core/venv_manager.py
@@ -25,7 +25,7 @@ import sys
 import tempfile
 import time
 
-from qgis.core import QgsMessageLog, Qgis
+from qgis.core import Qgis, QgsMessageLog
 
 CACHE_DIR = os.path.expanduser("~/.qgis_hypercoast")
 VENV_DIR = os.path.join(CACHE_DIR, "venv")
@@ -715,7 +715,7 @@ def _get_system_python():
     Raises:
         RuntimeError: If no usable Python is found.
     """
-    from .python_manager import standalone_python_exists, get_standalone_python_path
+    from .python_manager import get_standalone_python_path, standalone_python_exists
 
     if standalone_python_exists():
         python_path = get_standalone_python_path()
@@ -797,7 +797,7 @@ def create_venv(venv_dir=None, progress_callback=None):
     if system_python:
         _log(f"Using Python: {system_python}")
 
-    from .uv_manager import uv_exists, get_uv_path
+    from .uv_manager import get_uv_path, uv_exists
 
     use_uv = uv_exists()
 
@@ -1427,7 +1427,7 @@ def install_dependencies(plugin_dir, progress_callback=None, cancel_check=None):
     env = _get_clean_env_for_venv()
     kwargs = _get_subprocess_kwargs()
 
-    from .uv_manager import uv_exists, get_uv_path
+    from .uv_manager import get_uv_path, uv_exists
 
     use_uv = uv_exists()
     if use_uv:
@@ -1848,8 +1848,9 @@ def create_venv_and_install(plugin_dir, progress_callback=None, cancel_check=Non
     Returns:
         A tuple of (success: bool, message: str).
     """
-    from .python_manager import standalone_python_exists, download_python_standalone
-    from .uv_manager import uv_exists as _uv_exists, download_uv
+    from .python_manager import download_python_standalone, standalone_python_exists
+    from .uv_manager import download_uv
+    from .uv_manager import uv_exists as _uv_exists
 
     if using_conda_env_with_deps(plugin_dir):
         msg = "Using Conda environment, no venv needed."

--- a/qgis_plugin/hypercoast_qgis/dialogs/__init__.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/__init__.py
@@ -15,11 +15,12 @@ from .update_checker import UpdateCheckerDialog
 # Data-related dialogs depend on numpy (via hyperspectral_provider),
 # so they may fail to import if dependencies are not installed yet.
 try:
-    from .load_data_dialog import LoadDataDialog
     from .band_combination_dialog import BandCombinationDialog
     from .image_cube_dialog import ImageCubeDialog
+    from .load_data_dialog import LoadDataDialog
     from .spectral_inspector_tool import SpectralInspectorTool
     from .spectral_plot_dialog import SpectralPlotDialog
+    from .workflow_builder_dialog import WorkflowBuilderDialog
 
     _DATA_DIALOGS_AVAILABLE = True
 except ImportError:
@@ -33,5 +34,6 @@ __all__ = [
     "SpectralInspectorTool",
     "SpectralPlotDialog",
     "UpdateCheckerDialog",
+    "WorkflowBuilderDialog",
     "_DATA_DIALOGS_AVAILABLE",
 ]

--- a/qgis_plugin/hypercoast_qgis/dialogs/about_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/about_dialog.py
@@ -7,15 +7,16 @@ SPDX-License-Identifier: MIT
 """
 
 import os
+
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QPixmap
 from qgis.PyQt.QtWidgets import (
     QDockWidget,
-    QVBoxLayout,
+    QFrame,
     QHBoxLayout,
     QLabel,
     QPushButton,
-    QFrame,
+    QVBoxLayout,
     QWidget,
 )
 

--- a/qgis_plugin/hypercoast_qgis/dialogs/band_combination_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/band_combination_dialog.py
@@ -7,36 +7,36 @@ SPDX-License-Identifier: MIT
 """
 
 import numpy as np
+from qgis.core import (
+    QgsColorRampShader,
+    QgsContrastEnhancement,
+    QgsCoordinateReferenceSystem,
+    QgsMultiBandColorRenderer,
+    QgsProject,
+    QgsRasterLayer,
+    QgsRasterShader,
+    QgsSingleBandGrayRenderer,
+    QgsSingleBandPseudoColorRenderer,
+)
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtWidgets import (
+    QCheckBox,
+    QComboBox,
     QDockWidget,
-    QVBoxLayout,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
-    QPushButton,
-    QComboBox,
-    QGroupBox,
-    QDoubleSpinBox,
-    QSlider,
-    QCheckBox,
-    QFormLayout,
     QMessageBox,
     QProgressBar,
+    QPushButton,
     QRadioButton,
     QSizePolicy,
+    QSlider,
+    QVBoxLayout,
     QWidget,
-)
-from qgis.core import (
-    QgsCoordinateReferenceSystem,
-    QgsProject,
-    QgsRasterLayer,
-    QgsContrastEnhancement,
-    QgsMultiBandColorRenderer,
-    QgsSingleBandGrayRenderer,
-    QgsColorRampShader,
-    QgsRasterShader,
-    QgsSingleBandPseudoColorRenderer,
 )
 
 from ..cache_manager import create_generated_raster_path

--- a/qgis_plugin/hypercoast_qgis/dialogs/image_cube_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/image_cube_dialog.py
@@ -12,7 +12,8 @@ import subprocess
 import sys
 import uuid
 
-from qgis.PyQt.QtCore import QObject, Qt, QThread, pyqtSignal
+from qgis.core import Qgis, QgsMessageLog, QgsProject
+from qgis.PyQt.QtCore import QObject, QThread, pyqtSignal
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -30,7 +31,6 @@ from qgis.PyQt.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from qgis.core import QgsMessageLog, QgsProject, Qgis
 
 from ..cache_manager import generated_raster_cache_dir
 from .tanager_search_dialog import TanagerBboxMapTool

--- a/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/load_data_dialog.py
@@ -7,45 +7,46 @@ SPDX-License-Identifier: MIT
 """
 
 import os
+
+from qgis.core import (
+    Qgis,
+    QgsContrastEnhancement,
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsMessageLog,
+    QgsMultiBandColorRenderer,
+    QgsProject,
+    QgsRasterLayer,
+    QgsSingleBandGrayRenderer,
+)
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
 from qgis.PyQt.QtWidgets import (
+    QComboBox,
     QDockWidget,
-    QVBoxLayout,
+    QDoubleSpinBox,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
-    QPushButton,
-    QComboBox,
     QLineEdit,
-    QFileDialog,
-    QGroupBox,
-    QDoubleSpinBox,
-    QProgressBar,
-    QMessageBox,
-    QFormLayout,
     QListWidget,
     QListWidgetItem,
-    QTextEdit,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
     QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
     QWidget,
 )
-from qgis.core import (
-    QgsRasterLayer,
-    QgsProject,
-    QgsMessageLog,
-    QgsCoordinateTransform,
-    QgsCoordinateReferenceSystem,
-    QgsContrastEnhancement,
-    QgsMultiBandColorRenderer,
-    QgsSingleBandGrayRenderer,
-    Qgis,
-)
 
+from ..cache_manager import create_generated_raster_path
 from ..hyperspectral_provider import (
-    HyperspectralDataset,
     DATA_TYPES,
+    HyperspectralDataset,
     create_file_filter,
 )
-from ..cache_manager import create_generated_raster_path
 
 DEFAULT_VALUE_RANGE = (0.0, 0.5)
 TANAGER_VALUE_RANGE = (0.0, 0.5)

--- a/qgis_plugin/hypercoast_qgis/dialogs/spectral_inspector_tool.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/spectral_inspector_tool.py
@@ -6,17 +6,17 @@ SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
 SPDX-License-Identifier: MIT
 """
 
-from qgis.PyQt.QtCore import Qt, pyqtSignal
-from qgis.PyQt.QtGui import QCursor
-from qgis.gui import QgsMapToolEmitPoint, QgsRubberBand
 from qgis.core import (
-    QgsProject,
+    Qgis,
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,
-    QgsWkbTypes,
     QgsMessageLog,
-    Qgis,
+    QgsProject,
+    QgsWkbTypes,
 )
+from qgis.gui import QgsMapToolEmitPoint, QgsRubberBand
+from qgis.PyQt.QtCore import Qt, pyqtSignal
+from qgis.PyQt.QtGui import QCursor
 
 
 class SpectralInspectorTool(QgsMapToolEmitPoint):
@@ -191,7 +191,6 @@ class SpectralInspectorTool(QgsMapToolEmitPoint):
 
         :param point: QgsPointXY
         """
-        from qgis.PyQt.QtCore import Qt
         from qgis.PyQt.QtGui import QColor
 
         rb = QgsRubberBand(self.canvas, QgsWkbTypes.GeometryType.PointGeometry)

--- a/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/spectral_plot_dialog.py
@@ -7,28 +7,29 @@ SPDX-License-Identifier: MIT
 """
 
 import csv
+
 import numpy as np
 from qgis.PyQt.QtCore import Qt, QTimer
 from qgis.PyQt.QtWidgets import (
-    QDockWidget,
-    QVBoxLayout,
-    QHBoxLayout,
-    QLabel,
-    QPushButton,
-    QComboBox,
-    QGroupBox,
     QCheckBox,
+    QComboBox,
+    QDockWidget,
     QDoubleSpinBox,
+    QFileDialog,
     QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QSizePolicy,
+    QSplitter,
     QTableWidget,
     QTableWidgetItem,
-    QHeaderView,
-    QSizePolicy,
-    QFileDialog,
-    QMessageBox,
-    QSplitter,
-    QWidget,
     QTabWidget,
+    QVBoxLayout,
+    QWidget,
 )
 
 try:
@@ -42,8 +43,8 @@ try:
         from matplotlib.backends.backend_qt5agg import (
             NavigationToolbar2QT as NavigationToolbar,
         )
-    from matplotlib.figure import Figure
     import matplotlib.pyplot as plt
+    from matplotlib.figure import Figure
 
     HAS_MATPLOTLIB = True
 except ImportError:

--- a/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/tanager_search_dialog.py
@@ -6,15 +6,16 @@ SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
 SPDX-License-Identifier: MIT
 """
 
-import os
 import ast
 import json
-from urllib.parse import unquote, urlparse
+import os
 import urllib.request
+from urllib.parse import unquote, urlparse
 
+from qgis.gui import QgsMapTool as _QgsMapTool
+from qgis.gui import QgsRubberBand
 from qgis.PyQt.QtCore import QObject, Qt, QThread, QUrl, pyqtSignal
 from qgis.PyQt.QtGui import QColor, QCursor, QDesktopServices
-from qgis.gui import QgsMapTool as _QgsMapTool, QgsRubberBand
 
 try:
     from qgis.PyQt.QtCore import QVariant
@@ -27,6 +28,22 @@ except ImportError:  # pragma: no cover - PyQt6 test shim
         Double = float
 
 
+from qgis.core import (
+    Qgis,
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsFeature,
+    QgsField,
+    QgsFillSymbol,
+    QgsGeometry,
+    QgsMessageLog,
+    QgsPointXY,
+    QgsProject,
+    QgsRasterLayer,
+    QgsRectangle,
+    QgsVectorLayer,
+    QgsWkbTypes,
+)
 from qgis.PyQt.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
@@ -49,22 +66,6 @@ from qgis.PyQt.QtWidgets import (
     QTableWidgetItem,
     QVBoxLayout,
     QWidget,
-)
-from qgis.core import (
-    QgsCoordinateReferenceSystem,
-    QgsCoordinateTransform,
-    QgsFeature,
-    QgsField,
-    QgsFillSymbol,
-    QgsGeometry,
-    QgsMessageLog,
-    QgsPointXY,
-    QgsProject,
-    QgsRasterLayer,
-    QgsRectangle,
-    QgsVectorLayer,
-    QgsWkbTypes,
-    Qgis,
 )
 
 if isinstance(_QgsMapTool, type):

--- a/qgis_plugin/hypercoast_qgis/dialogs/update_checker.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/update_checker.py
@@ -14,24 +14,24 @@ import re
 import shutil
 import tempfile
 import zipfile
+from urllib.error import HTTPError, URLError
 from urllib.request import urlopen, urlretrieve
-from urllib.error import URLError, HTTPError
 
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
+from qgis.PyQt.QtGui import QFont
 from qgis.PyQt.QtWidgets import (
     QDockWidget,
-    QVBoxLayout,
+    QFormLayout,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
-    QPushButton,
-    QProgressBar,
     QMessageBox,
-    QGroupBox,
-    QFormLayout,
+    QProgressBar,
+    QPushButton,
     QTextEdit,
+    QVBoxLayout,
     QWidget,
 )
-from qgis.PyQt.QtGui import QFont
 
 # GitHub URLs for the plugin
 GITHUB_REPO = "opengeos/HyperCoast"

--- a/qgis_plugin/hypercoast_qgis/dialogs/workflow_builder_dialog.py
+++ b/qgis_plugin/hypercoast_qgis/dialogs/workflow_builder_dialog.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+"""
+HyperCoast QGIS Plugin - Workflow Builder Dialog
+
+SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+SPDX-License-Identifier: MIT
+"""
+
+import os
+
+import numpy as np
+from qgis.core import QgsProject, QgsRasterLayer
+from qgis.PyQt.QtWidgets import (
+    QComboBox,
+    QDockWidget,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QWidget,
+)
+
+from ..cache_manager import create_generated_raster_path
+from ..hyperspectral_provider import HAS_RASTERIO
+
+WORKFLOW_LABELS = {
+    "NDWI water mask": "ndwi",
+    "Chlorophyll-a proxy": "chlorophyll",
+    "Turbidity proxy": "turbidity",
+    "CDOM proxy": "cdom",
+    "Cyanobacteria proxy": "cyanobacteria",
+    "Spectral anomaly": "anomaly",
+}
+
+
+class WorkflowBuilderDialog(QDockWidget):
+    """Dockable panel for running workflow presets on loaded layers."""
+
+    def __init__(self, iface, plugin, parent=None):
+        """Initialize the workflow builder dialog.
+
+        Args:
+            iface: QGIS interface.
+            plugin: HyperCoast plugin instance.
+            parent: Optional parent widget.
+        """
+        super().__init__(parent)
+        self.iface = iface
+        self.plugin = plugin
+        self.setWindowTitle("Workflow Builder")
+        self.setObjectName("HyperCoastWorkflowBuilderDock")
+
+        widget = QWidget()
+        layout = QFormLayout(widget)
+
+        self.layer_combo = QComboBox()
+        self.variable_combo = QComboBox()
+        self.workflow_combo = QComboBox()
+        self.workflow_combo.addItems(list(WORKFLOW_LABELS))
+        self.first_wavelength_edit = QLineEdit()
+        self.second_wavelength_edit = QLineEdit()
+        self.output_edit = QLineEdit()
+
+        output_row = QHBoxLayout()
+        output_row.addWidget(self.output_edit)
+        browse_btn = QPushButton("...")
+        browse_btn.clicked.connect(self.browse_output)
+        output_row.addWidget(browse_btn)
+
+        self.run_btn = QPushButton("Run Workflow")
+        self.run_btn.clicked.connect(self.run_workflow)
+        self.status_label = QLabel("")
+
+        layout.addRow("Layer:", self.layer_combo)
+        layout.addRow("Variable:", self.variable_combo)
+        layout.addRow("Workflow:", self.workflow_combo)
+        layout.addRow("First wavelength:", self.first_wavelength_edit)
+        layout.addRow("Second wavelength:", self.second_wavelength_edit)
+        layout.addRow("Output GeoTIFF:", output_row)
+        layout.addRow("", self.run_btn)
+        layout.addRow("", self.status_label)
+
+        self.setWidget(widget)
+        self.layer_combo.currentIndexChanged.connect(self.populate_variables)
+        self.workflow_combo.currentTextChanged.connect(self._set_default_wavelengths)
+        self.refresh_layers()
+        self._set_default_wavelengths(self.workflow_combo.currentText())
+
+    def refresh_layers(self):
+        """Refresh the loaded HyperCoast layer list."""
+        current = self.layer_combo.currentData()
+        self.layer_combo.clear()
+        for layer_id, data_info in self.plugin.get_all_hyperspectral_layers().items():
+            layer = QgsProject.instance().mapLayer(layer_id)
+            name = (
+                layer.name()
+                if layer is not None and hasattr(layer, "name")
+                else layer_id
+            )
+            self.layer_combo.addItem(name, layer_id)
+        if current:
+            index = self.layer_combo.findData(current)
+            if index >= 0:
+                self.layer_combo.setCurrentIndex(index)
+        self.populate_variables()
+
+    def populate_variables(self):
+        """Populate data variables for the selected layer."""
+        self.variable_combo.clear()
+        layer_id = self.layer_combo.currentData()
+        if not layer_id:
+            return
+        dataset = self.plugin.ensure_hyperspectral_dataset(layer_id)
+        if dataset is None:
+            return
+        variables = dataset.list_data_variables()
+        self.variable_combo.addItems(variables)
+        data_info = self.plugin.get_hyperspectral_data(layer_id) or {}
+        selected = data_info.get("selected_variable")
+        if selected:
+            index = self.variable_combo.findText(selected)
+            if index >= 0:
+                self.variable_combo.setCurrentIndex(index)
+
+    def browse_output(self):
+        """Choose an output GeoTIFF path."""
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save Workflow Raster",
+            "",
+            "GeoTIFF Files (*.tif *.tiff);;All Files (*.*)",
+        )
+        if path:
+            self.output_edit.setText(path)
+
+    def run_workflow(self):
+        """Run the selected workflow and add the output layer."""
+        if not HAS_RASTERIO:
+            QMessageBox.critical(self, "HyperCoast", "rasterio is required.")
+            return
+        layer_id = self.layer_combo.currentData()
+        if not layer_id:
+            QMessageBox.warning(self, "HyperCoast", "Select a HyperCoast layer.")
+            return
+        dataset = self.plugin.ensure_hyperspectral_dataset(layer_id)
+        if dataset is None or dataset.dataset is None:
+            QMessageBox.warning(
+                self, "HyperCoast", "Could not load the selected dataset."
+            )
+            return
+
+        variable = self.variable_combo.currentText() or None
+        dataset.set_selected_variable(variable)
+        workflow = WORKFLOW_LABELS[self.workflow_combo.currentText()]
+        output_path = self.output_edit.text().strip() or self._default_output_path()
+        self.output_edit.setText(output_path)
+
+        try:
+            from hypercoast.workflows import apply_workflow
+
+            overrides = self._wavelength_overrides()
+            result = apply_workflow(
+                dataset.dataset,
+                workflow,
+                variable=variable,
+                wavelengths=overrides,
+            )
+            self._write_workflow_raster(dataset, result, output_path)
+            raster_layer = QgsRasterLayer(output_path, os.path.basename(output_path))
+            if raster_layer.isValid():
+                QgsProject.instance().addMapLayer(raster_layer)
+            self.status_label.setText("Workflow completed")
+        except Exception as exc:
+            QMessageBox.critical(self, "HyperCoast", f"Workflow failed: {exc}")
+
+    def _set_default_wavelengths(self, label):
+        """Populate default wavelength override fields."""
+        defaults = {
+            "NDWI water mask": ("560", "860"),
+            "Chlorophyll-a proxy": ("560", "665"),
+            "Turbidity proxy": ("665", "860"),
+            "CDOM proxy": ("412", "555"),
+            "Cyanobacteria proxy": ("709", "665"),
+            "Spectral anomaly": ("", ""),
+        }
+        first, second = defaults.get(label, ("", ""))
+        self.first_wavelength_edit.setText(first)
+        self.second_wavelength_edit.setText(second)
+
+    def _wavelength_overrides(self):
+        """Return optional workflow wavelength overrides."""
+        if self.workflow_combo.currentText() == "Spectral anomaly":
+            return {}
+        first = self.first_wavelength_edit.text().strip()
+        second = self.second_wavelength_edit.text().strip()
+        overrides = {}
+        if first:
+            overrides["a"] = float(first)
+        if second:
+            overrides["b"] = float(second)
+        return overrides
+
+    def _default_output_path(self):
+        """Return a project cache output path."""
+        layer_name = self.layer_combo.currentText() or "workflow"
+        suffix = WORKFLOW_LABELS[self.workflow_combo.currentText()]
+        return create_generated_raster_path(
+            layer_name,
+            suffix,
+            project=QgsProject.instance(),
+        )
+
+    def _write_workflow_raster(self, dataset, result, output_path):
+        """Write a workflow DataArray to GeoTIFF."""
+        import rasterio
+        from rasterio.transform import from_bounds
+
+        arr = np.asarray(result.values, dtype="float32")
+        if arr.ndim != 2:
+            arr = np.squeeze(arr)
+        if arr.ndim != 2:
+            raise ValueError(f"Expected 2D workflow output, got shape {arr.shape}")
+        height, width = arr.shape
+        bounds = dataset.bounds or (0, 0, width, height)
+        transform = from_bounds(*bounds, width, height)
+        nodata = -9999.0
+        with rasterio.open(
+            output_path,
+            "w",
+            driver="GTiff",
+            height=height,
+            width=width,
+            count=1,
+            dtype="float32",
+            crs=dataset.crs or "EPSG:4326",
+            transform=transform,
+            nodata=nodata,
+            tiled=True,
+            compress="deflate",
+        ) as dst:
+            dst.write(np.nan_to_num(arr, nan=nodata).astype("float32"), 1)
+            dst.set_band_description(1, result.name or "workflow")
+
+    def showEvent(self, event):
+        """Refresh layers when the dock is shown."""
+        super().showEvent(event)
+        self.refresh_layers()

--- a/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
+++ b/qgis_plugin/hypercoast_qgis/hypercoast_plugin.py
@@ -8,10 +8,10 @@ SPDX-License-Identifier: MIT
 
 import os
 
+from qgis.core import Qgis, QgsApplication, QgsMessageLog, QgsProject
 from qgis.PyQt.QtCore import QCoreApplication, Qt, QTimer
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QDockWidget, QMessageBox, QToolBar
-from qgis.core import QgsApplication, QgsMessageLog, QgsProject, Qgis
 
 # About and update checker have no heavy deps, always available
 from .dialogs.about_dialog import AboutDialog
@@ -21,12 +21,13 @@ from .dialogs.update_checker import UpdateCheckerDialog
 # so they may fail to import if dependencies are not installed yet.
 _DATA_DIALOGS_AVAILABLE = False
 try:
-    from .dialogs.load_data_dialog import LoadDataDialog
-    from .dialogs.tanager_search_dialog import TanagerSearchDialog
     from .dialogs.band_combination_dialog import BandCombinationDialog
     from .dialogs.image_cube_dialog import ImageCubeDialog
+    from .dialogs.load_data_dialog import LoadDataDialog
     from .dialogs.spectral_inspector_tool import SpectralInspectorTool
     from .dialogs.spectral_plot_dialog import SpectralPlotDialog
+    from .dialogs.tanager_search_dialog import TanagerSearchDialog
+    from .dialogs.workflow_builder_dialog import WorkflowBuilderDialog
 
     _DATA_DIALOGS_AVAILABLE = True
 except ImportError:
@@ -42,6 +43,7 @@ DOCK_OBJECT_NAMES = {
     "HyperCoastBandCombinationDock",
     "HyperCoastImageCubeDock",
     "HyperCoastSpectralPlotDock",
+    "HyperCoastWorkflowBuilderDock",
     "HyperCoastAboutDock",
     "HyperCoastUpdateDock",
     "HyperCoastDependencyInstallerDock",
@@ -74,6 +76,7 @@ class HyperCoastPlugin:
         self.tanager_search_dialog = None
         self.band_dialog = None
         self.image_cube_dialog = None
+        self.workflow_builder_dialog = None
         self.spectral_tool = None
         self.spectral_plot_dialog = None
         self.about_dialog = None
@@ -200,6 +203,16 @@ class HyperCoastPlugin:
             callback=self.show_image_cube_dialog,
             parent=self.iface.mainWindow(),
             status_tip=self.tr("Create a PyVista 3D hyperspectral image cube"),
+            checkable=True,
+        )
+
+        # Workflow builder action
+        self.workflow_action = self.add_action(
+            os.path.join(icons_dir, "hypercoast.png"),
+            text=self.tr("Workflow Builder"),
+            callback=self.show_workflow_builder_dialog,
+            parent=self.iface.mainWindow(),
+            status_tip=self.tr("Run coastal workflow presets on loaded layers"),
             checkable=True,
         )
 
@@ -567,11 +580,12 @@ class HyperCoastPlugin:
         try:
             from . import hyperspectral_provider
             from .dialogs import (
-                load_data_dialog,
-                tanager_search_dialog,
                 band_combination_dialog,
                 image_cube_dialog,
+                load_data_dialog,
                 spectral_plot_dialog,
+                tanager_search_dialog,
+                workflow_builder_dialog,
             )
 
             importlib.reload(hyperspectral_provider)
@@ -580,6 +594,7 @@ class HyperCoastPlugin:
             importlib.reload(band_combination_dialog)
             importlib.reload(image_cube_dialog)
             importlib.reload(spectral_plot_dialog)
+            importlib.reload(workflow_builder_dialog)
         except Exception as e:
             QgsMessageLog.logMessage(
                 f"Error reloading data modules: {e}",
@@ -593,25 +608,29 @@ class HyperCoastPlugin:
         self.tanager_search_dialog = None
         self.band_dialog = None
         self.image_cube_dialog = None
+        self.workflow_builder_dialog = None
         self.spectral_tool = None
         self.spectral_plot_dialog = None
 
         if not _DATA_DIALOGS_AVAILABLE:
             # Try importing again now that venv packages are on sys.path
             try:
-                from .dialogs.load_data_dialog import LoadDataDialog  # noqa: F811
-                from .dialogs.tanager_search_dialog import (  # noqa: F811
-                    TanagerSearchDialog,
-                )
                 from .dialogs.band_combination_dialog import (  # noqa: F811
                     BandCombinationDialog,
                 )
                 from .dialogs.image_cube_dialog import ImageCubeDialog  # noqa: F811
+                from .dialogs.load_data_dialog import LoadDataDialog  # noqa: F811
                 from .dialogs.spectral_inspector_tool import (  # noqa: F811
                     SpectralInspectorTool,
                 )
                 from .dialogs.spectral_plot_dialog import (  # noqa: F811
                     SpectralPlotDialog,
+                )
+                from .dialogs.tanager_search_dialog import (  # noqa: F811
+                    TanagerSearchDialog,
+                )
+                from .dialogs.workflow_builder_dialog import (  # noqa: F811
+                    WorkflowBuilderDialog,
                 )
 
                 _DATA_DIALOGS_AVAILABLE = True
@@ -672,14 +691,14 @@ class HyperCoastPlugin:
     def _set_data_actions_enabled(self, enabled):
         """Enable or disable data-related actions.
 
-        The first 5 actions are data-dependent:
+        The first 6 actions are data-dependent:
         Tanager Search, Load Data, Band Combination, Spectral Inspector,
-        and 3D Image Cube.
+        3D Image Cube, and Workflow Builder.
 
         :param enabled: Whether to enable the actions.
         """
         for i, action in enumerate(self.actions):
-            if i < 5:
+            if i < 6:
                 action.setEnabled(enabled)
 
     def toggle_settings_dock(self):
@@ -786,6 +805,21 @@ class HyperCoastPlugin:
             "image_cube_dialog",
             lambda: ImageCubeDialog(self.iface, self, self.iface.mainWindow()),
             self.image_cube_action,
+            before_show=lambda dock: dock.refresh_layers(),
+        )
+
+    def show_workflow_builder_dialog(self):
+        """Show the workflow builder dialog."""
+        if not self._deps_available:
+            self._show_deps_required_warning()
+            self.workflow_action.setChecked(False)
+            return
+        from .dialogs.workflow_builder_dialog import WorkflowBuilderDialog
+
+        self._toggle_dock(
+            "workflow_builder_dialog",
+            lambda: WorkflowBuilderDialog(self.iface, self, self.iface.mainWindow()),
+            self.workflow_action,
             before_show=lambda dock: dock.refresh_layers(),
         )
 

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -13,7 +13,15 @@ import os
 import platform
 import sys
 import traceback
+
 import numpy as np
+
+from .provider.detection import detect_data_type
+from .provider.metadata import (
+    coordinate_bounds,
+    geolocation_bounds,
+    spectral_coordinates,
+)
 
 try:
     import xarray as xr
@@ -39,11 +47,11 @@ except ImportError:
 
 try:
     from qgis.core import (
+        Qgis,
         QgsCoordinateReferenceSystem,
         QgsCoordinateTransform,
         QgsMessageLog,
         QgsProject,
-        Qgis,
     )
 
     HAS_QGIS = True
@@ -183,37 +191,7 @@ class HyperspectralDataset:
 
     def _detect_type(self):
         """Auto-detect the data type based on file extension and content."""
-        _, ext = os.path.splitext(self.filepath.lower())
-        filename = os.path.basename(self.filepath).upper()
-
-        if "EMIT" in filename:
-            return "EMIT"
-        elif "PACE" in filename or "OCI" in filename:
-            return "PACE"
-        elif "DESIS" in filename:
-            return "DESIS"
-        elif "NEON" in filename:
-            return "NEON"
-        elif "AVIRIS" in filename:
-            return "AVIRIS"
-        elif "PRISMA" in filename or "PRS" in filename:
-            return "PRISMA"
-        elif "ENMAP" in filename:
-            return "EnMAP"
-        elif (
-            "TANAGER" in filename
-            or "ORTHO_RADIANCE_HDF5" in filename
-            or "BASIC_RADIANCE_HDF5" in filename
-            or "ORTHO_SR_HDF5" in filename
-            or "BASIC_SR_HDF5" in filename
-        ):
-            return "Tanager"
-        elif "WYVERN" in filename:
-            return "Wyvern"
-        elif ext in [".h5", ".hdf5"] and self._is_tanager_hdf5_file():
-            return "Tanager"
-        else:
-            return "Generic"
+        return detect_data_type(self.filepath, self._is_tanager_hdf5_file)
 
     def _is_tanager_hdf5_file(self):
         """Return whether an HDF5 file looks like a Tanager product.
@@ -751,12 +729,7 @@ class HyperspectralDataset:
         if "latitude" in ds.coords and "longitude" in ds.coords:
             lat = ds.coords["latitude"].values
             lon = ds.coords["longitude"].values
-            self.bounds = (
-                float(np.nanmin(lon)),
-                float(np.nanmin(lat)),
-                float(np.nanmax(lon)),
-                float(np.nanmax(lat)),
-            )
+            self.bounds = geolocation_bounds(lon, lat)
 
         self.crs = "EPSG:4326"
 
@@ -785,12 +758,7 @@ class HyperspectralDataset:
         if "latitude" in ds.coords:
             lat = ds["latitude"].values
             lon = ds["longitude"].values
-            self.bounds = (
-                float(np.nanmin(lon)),
-                float(np.nanmin(lat)),
-                float(np.nanmax(lon)),
-                float(np.nanmax(lat)),
-            )
+            self.bounds = geolocation_bounds(lon, lat)
 
         self.crs = "EPSG:4326"
         return True
@@ -800,7 +768,7 @@ class HyperspectralDataset:
         ds = self.dataset
 
         if "wavelength" in ds.coords:
-            self.wavelengths = np.array(ds.coords["wavelength"].values)
+            self.wavelengths = spectral_coordinates(ds)
 
         try:
             self.crs = ds.attrs.get("crs", "EPSG:4326")
@@ -822,12 +790,7 @@ class HyperspectralDataset:
         if "x" in ds.coords and "y" in ds.coords:
             x = ds.coords["x"].values
             y = ds.coords["y"].values
-            self.bounds = (
-                float(np.min(x)),
-                float(np.min(y)),
-                float(np.max(x)),
-                float(np.max(y)),
-            )
+            self.bounds = coordinate_bounds(x, y)
 
     def _extract_tanager_metadata(self):
         """Extract metadata from Tanager dataset.
@@ -852,12 +815,7 @@ class HyperspectralDataset:
         if "latitude" in ds.coords:
             lat = ds["latitude"].values
             lon = ds["longitude"].values
-            self.bounds = (
-                float(np.nanmin(lon)),
-                float(np.nanmin(lat)),
-                float(np.nanmax(lon)),
-                float(np.nanmax(lat)),
-            )
+            self.bounds = geolocation_bounds(lon, lat)
 
         self.crs = "EPSG:4326"
         self._is_swath = True
@@ -868,10 +826,7 @@ class HyperspectralDataset:
         ds = self.dataset
 
         # Try to find wavelength coordinate
-        for coord_name in ["wavelength", "wavelengths", "band", "bands"]:
-            if coord_name in ds.coords:
-                self.wavelengths = np.array(ds.coords[coord_name].values)
-                break
+        self.wavelengths = spectral_coordinates(ds)
 
         # Try to get CRS and bounds
         try:
@@ -1122,7 +1077,6 @@ class HyperspectralDataset:
             _, ext = os.path.splitext(self.filepath.lower())
 
             if ext in [".tif", ".tiff"]:
-                import rioxarray
 
                 ds = xr.open_dataset(self.filepath, engine="rasterio")
 

--- a/qgis_plugin/hypercoast_qgis/processing_provider.py
+++ b/qgis_plugin/hypercoast_qgis/processing_provider.py
@@ -6,10 +6,10 @@ SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
 SPDX-License-Identifier: MIT
 """
 
+import json
 import os
 
 import numpy as np
-from qgis.PyQt.QtGui import QIcon
 from qgis.core import (
     QgsProcessingAlgorithm,
     QgsProcessingException,
@@ -20,6 +20,7 @@ from qgis.core import (
     QgsProcessingParameterString,
     QgsProcessingProvider,
 )
+from qgis.PyQt.QtGui import QIcon
 
 from .hyperspectral_provider import DATA_TYPES, HyperspectralDataset
 
@@ -68,6 +69,8 @@ class HyperCoastProcessingProvider(QgsProcessingProvider):
         self.addAlgorithm(SpectralIndexAlgorithm())
         self.addAlgorithm(WaterQualityWorkflowAlgorithm())
         self.addAlgorithm(PCAAlgorithm())
+        self.addAlgorithm(SummarizeDatasetAlgorithm())
+        self.addAlgorithm(BatchExtractSpectraAlgorithm())
 
     def id(self):
         """Return the provider ID."""
@@ -729,3 +732,175 @@ class PCAAlgorithm(BaseHyperCoastAlgorithm):
     def createInstance(self):
         """Create a new algorithm instance."""
         return PCAAlgorithm()
+
+
+class SummarizeDatasetAlgorithm(BaseHyperCoastAlgorithm):
+    """Write a JSON summary for a hyperspectral dataset."""
+
+    OUTPUT_JSON = "OUTPUT_JSON"
+
+    def name(self):
+        """Return the algorithm ID."""
+        return "summarize_dataset"
+
+    def displayName(self):
+        """Return the algorithm display name."""
+        return "Summarize Dataset"
+
+    def shortHelpString(self):
+        """Return help text."""
+        return "Writes a JSON summary for a local hyperspectral dataset."
+
+    def initAlgorithm(self, config=None):
+        """Define algorithm parameters."""
+        self._add_common_inputs()
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.OUTPUT_JSON,
+                "Output JSON path",
+                defaultValue="",
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        """Run dataset summary export."""
+        input_path = self.parameterAsFile(parameters, self.INPUT, context)
+        output_path = self.parameterAsString(parameters, self.OUTPUT_JSON, context)
+        if not output_path:
+            raise QgsProcessingException("Output JSON path is required")
+        data_type_index = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
+        data_type = DATA_TYPE_OPTIONS[data_type_index]
+        variable = self._selected_variable(parameters, context)
+        sensor = None if data_type == "auto" else data_type.lower()
+        try:
+            from hypercoast.summary import summarize_dataset
+
+            summary = summarize_dataset(input_path, sensor=sensor, variable=variable)
+        except Exception:
+            dataset = self._load_dataset(parameters, context)
+            summary = {
+                "path": input_path,
+                "exists": os.path.exists(input_path),
+                "sensor": dataset.data_type,
+                "variables": dataset.list_data_variables(),
+                "selected_variable": dataset.selected_variable,
+                "crs": dataset.crs,
+                "bounds": dataset.bounds,
+                "wavelength_count": int(
+                    len(dataset.wavelengths) if dataset.wavelengths is not None else 0
+                ),
+                "default_rgb": [],
+                "warnings": [],
+            }
+        else:
+            summary = summary.as_dict()
+
+        with open(output_path, "w", encoding="utf-8") as dst:
+            json.dump(summary, dst, indent=2, default=str)
+        if feedback:
+            feedback.setProgress(100)
+        return {self.OUTPUT_JSON: output_path}
+
+    def createInstance(self):
+        """Create a new algorithm instance."""
+        return SummarizeDatasetAlgorithm()
+
+
+class BatchExtractSpectraAlgorithm(BaseHyperCoastAlgorithm):
+    """Extract spectra for CSV point coordinates."""
+
+    POINTS = "POINTS"
+    X_COLUMN = "X_COLUMN"
+    Y_COLUMN = "Y_COLUMN"
+    CRS = "CRS"
+    OUTPUT_CSV = "OUTPUT_CSV"
+
+    def name(self):
+        """Return the algorithm ID."""
+        return "batch_extract_spectra"
+
+    def displayName(self):
+        """Return the algorithm display name."""
+        return "Batch Extract Spectra"
+
+    def shortHelpString(self):
+        """Return help text."""
+        return "Extracts spectra for point coordinates from a CSV file."
+
+    def initAlgorithm(self, config=None):
+        """Define algorithm parameters."""
+        self._add_common_inputs()
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.POINTS,
+                "Input point CSV",
+                behavior=_file_behavior_file(),
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterString(self.X_COLUMN, "X column", defaultValue="x")
+        )
+        self.addParameter(
+            QgsProcessingParameterString(self.Y_COLUMN, "Y column", defaultValue="y")
+        )
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.CRS, "Point CRS", defaultValue="EPSG:4326"
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.OUTPUT_CSV,
+                "Output CSV path",
+                defaultValue="",
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        """Run batch spectral extraction."""
+        dataset = self._load_dataset(parameters, context)
+        points_path = self.parameterAsFile(parameters, self.POINTS, context)
+        output_path = self.parameterAsString(parameters, self.OUTPUT_CSV, context)
+        x_column = self.parameterAsString(parameters, self.X_COLUMN, context)
+        y_column = self.parameterAsString(parameters, self.Y_COLUMN, context)
+        crs = self.parameterAsString(parameters, self.CRS, context) or "EPSG:4326"
+        if not output_path:
+            raise QgsProcessingException("Output CSV path is required")
+        import pandas as pd
+
+        points = pd.read_csv(points_path)
+        if x_column not in points.columns or y_column not in points.columns:
+            raise QgsProcessingException(
+                f"Point CSV must contain '{x_column}' and '{y_column}'"
+            )
+
+        rows = []
+        for feature_id, row in points.iterrows():
+            wavelengths, values = dataset.extract_spectral_signature(
+                float(row[x_column]),
+                float(row[y_column]),
+                crs=crs,
+            )
+            if wavelengths is None or values is None:
+                continue
+            for wavelength, value in zip(wavelengths, values):
+                rows.append(
+                    {
+                        "feature_id": feature_id,
+                        "x": row[x_column],
+                        "y": row[y_column],
+                        "crs": crs,
+                        "wavelength": wavelength,
+                        "value": value,
+                        "layer": dataset.filepath,
+                        "variable": dataset.selected_variable,
+                    }
+                )
+        pd.DataFrame(rows).to_csv(output_path, index=False)
+        if feedback:
+            feedback.setProgress(100)
+        return {self.OUTPUT_CSV: output_path}
+
+    def createInstance(self):
+        """Create a new algorithm instance."""
+        return BatchExtractSpectraAlgorithm()

--- a/qgis_plugin/hypercoast_qgis/processing_provider.py
+++ b/qgis_plugin/hypercoast_qgis/processing_provider.py
@@ -776,7 +776,7 @@ class SummarizeDatasetAlgorithm(BaseHyperCoastAlgorithm):
             from hypercoast.summary import summarize_dataset
 
             summary = summarize_dataset(input_path, sensor=sensor, variable=variable)
-        except Exception:
+        except (ImportError, OSError):
             dataset = self._load_dataset(parameters, context)
             summary = {
                 "path": input_path,

--- a/qgis_plugin/hypercoast_qgis/provider/__init__.py
+++ b/qgis_plugin/hypercoast_qgis/provider/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""Small helper modules for the HyperCoast QGIS data provider."""
+
+from .detection import detect_data_type
+from .metadata import coordinate_bounds, geolocation_bounds, spectral_coordinates
+
+__all__ = [
+    "coordinate_bounds",
+    "detect_data_type",
+    "geolocation_bounds",
+    "spectral_coordinates",
+]

--- a/qgis_plugin/hypercoast_qgis/provider/detection.py
+++ b/qgis_plugin/hypercoast_qgis/provider/detection.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+Dataset type detection helpers for the HyperCoast QGIS provider.
+
+SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+SPDX-License-Identifier: MIT
+"""
+
+import os
+
+
+def detect_data_type(filepath, tanager_hdf5_checker=None):
+    """Detect a supported HyperCoast data type from a file path.
+
+    Args:
+        filepath: Input file path.
+        tanager_hdf5_checker: Optional callable used to inspect HDF5 content.
+
+    Returns:
+        Detected data type name.
+    """
+    _, ext = os.path.splitext(str(filepath).lower())
+    filename = os.path.basename(str(filepath)).upper()
+
+    if "EMIT" in filename:
+        return "EMIT"
+    if "PACE" in filename or "OCI" in filename:
+        return "PACE"
+    if "DESIS" in filename:
+        return "DESIS"
+    if "NEON" in filename:
+        return "NEON"
+    if "AVIRIS" in filename:
+        return "AVIRIS"
+    if "PRISMA" in filename or "PRS" in filename:
+        return "PRISMA"
+    if "ENMAP" in filename:
+        return "EnMAP"
+    if (
+        "TANAGER" in filename
+        or "ORTHO_RADIANCE_HDF5" in filename
+        or "BASIC_RADIANCE_HDF5" in filename
+        or "ORTHO_SR_HDF5" in filename
+        or "BASIC_SR_HDF5" in filename
+    ):
+        return "Tanager"
+    if "WYVERN" in filename:
+        return "Wyvern"
+    if ext in [".h5", ".hdf5"] and callable(tanager_hdf5_checker):
+        if tanager_hdf5_checker():
+            return "Tanager"
+    return "Generic"

--- a/qgis_plugin/hypercoast_qgis/provider/metadata.py
+++ b/qgis_plugin/hypercoast_qgis/provider/metadata.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Metadata extraction helpers for the HyperCoast QGIS provider.
+
+SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+SPDX-License-Identifier: MIT
+"""
+
+import numpy as np
+
+
+def geolocation_bounds(lon, lat):
+    """Return bounds from longitude and latitude arrays.
+
+    Args:
+        lon: Longitude array.
+        lat: Latitude array.
+
+    Returns:
+        Tuple of ``(xmin, ymin, xmax, ymax)``.
+    """
+    lon = np.asarray(lon, dtype=float)
+    lat = np.asarray(lat, dtype=float)
+    return (
+        float(np.nanmin(lon)),
+        float(np.nanmin(lat)),
+        float(np.nanmax(lon)),
+        float(np.nanmax(lat)),
+    )
+
+
+def coordinate_bounds(x, y):
+    """Return bounds from rectilinear x and y coordinates.
+
+    Args:
+        x: X coordinate array.
+        y: Y coordinate array.
+
+    Returns:
+        Tuple of ``(xmin, ymin, xmax, ymax)``.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    return (
+        float(np.nanmin(x)),
+        float(np.nanmin(y)),
+        float(np.nanmax(x)),
+        float(np.nanmax(y)),
+    )
+
+
+def spectral_coordinates(dataset):
+    """Return the first available spectral coordinate array.
+
+    Args:
+        dataset: Xarray dataset.
+
+    Returns:
+        NumPy array or None.
+    """
+    for coord_name in ["wavelength", "wavelengths", "band", "bands"]:
+        if coord_name in dataset.coords:
+            return np.array(dataset.coords[coord_name].values)
+    return None

--- a/qgis_plugin/install_plugin.py
+++ b/qgis_plugin/install_plugin.py
@@ -9,13 +9,13 @@ Usage:
     python install_plugin.py --help       # Show help
 """
 
-import os
-import sys
-import shutil
-import zipfile
 import argparse
-import tempfile
+import os
 import platform
+import shutil
+import sys
+import tempfile
+import zipfile
 from pathlib import Path
 
 # Plugin configuration

--- a/qgis_plugin/qt6_tests/conftest.py
+++ b/qgis_plugin/qt6_tests/conftest.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-pytest.importorskip("PyQt6")
+pytest.importorskip("PyQt6.QtWidgets")
 
 import PyQt6.QtCore  # noqa: E402
 import PyQt6.QtGui  # noqa: E402

--- a/qgis_plugin/qt6_tests/test_dock_panels.py
+++ b/qgis_plugin/qt6_tests/test_dock_panels.py
@@ -4,20 +4,18 @@ import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+import hypercoast_qgis.dialogs.load_data_dialog as load_data_dialog_module
 import pytest
-from qgis.PyQt.QtWidgets import QApplication
-from qgis.PyQt.QtWidgets import QDockWidget
-
 from hypercoast_qgis.dialogs.about_dialog import AboutDialog
 from hypercoast_qgis.dialogs.band_combination_dialog import BandCombinationDialog
 from hypercoast_qgis.dialogs.dependency_installer import DependencyInstallerDialog
 from hypercoast_qgis.dialogs.image_cube_dialog import ImageCubeDialog
-import hypercoast_qgis.dialogs.load_data_dialog as load_data_dialog_module
 from hypercoast_qgis.dialogs.load_data_dialog import LoadDataDialog
 from hypercoast_qgis.dialogs.settings_dock import SettingsDockWidget
 from hypercoast_qgis.dialogs.spectral_plot_dialog import SpectralPlotDialog
 from hypercoast_qgis.dialogs.tanager_search_dialog import TanagerSearchDialog
 from hypercoast_qgis.dialogs.update_checker import UpdateCheckerDialog
+from qgis.PyQt.QtWidgets import QApplication, QDockWidget
 
 
 @pytest.fixture(scope="module")

--- a/qgis_plugin/qt6_tests/test_image_cube_dialog.py
+++ b/qgis_plugin/qt6_tests/test_image_cube_dialog.py
@@ -4,12 +4,11 @@ import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+import hypercoast_qgis.dialogs.image_cube_dialog as dialog_module
 import numpy as np
 import pytest
-from qgis.PyQt.QtWidgets import QApplication
-
-import hypercoast_qgis.dialogs.image_cube_dialog as dialog_module
 from hypercoast_qgis.dialogs.image_cube_dialog import ImageCubeDialog
+from qgis.PyQt.QtWidgets import QApplication
 
 
 @pytest.fixture(scope="module")

--- a/qgis_plugin/qt6_tests/test_processing_provider.py
+++ b/qgis_plugin/qt6_tests/test_processing_provider.py
@@ -5,14 +5,16 @@ import pytest
 
 xr = pytest.importorskip("xarray")
 
+from hypercoast_qgis.hyperspectral_provider import HyperspectralDataset
 from hypercoast_qgis.processing_provider import (
     BaseHyperCoastAlgorithm,
-    QgsProcessingException,
+    BatchExtractSpectraAlgorithm,
     HyperCoastProcessingProvider,
+    QgsProcessingException,
     RGBCompositeAlgorithm,
+    SummarizeDatasetAlgorithm,
     WaterQualityWorkflowAlgorithm,
 )
-from hypercoast_qgis.hyperspectral_provider import HyperspectralDataset
 
 
 def _loaded_dataset():
@@ -80,6 +82,8 @@ def test_processing_provider_registers_water_quality_workflow():
 
     names = [algorithm.name() for algorithm in provider.algorithms]
     assert "water_quality_workflow" in names
+    assert "summarize_dataset" in names
+    assert "batch_extract_spectra" in names
 
 
 def test_water_quality_workflow_selects_nearest_band():
@@ -89,3 +93,62 @@ def test_water_quality_workflow_selects_nearest_band():
     band = algorithm._select_nearest_band(dataset.dataset["reflectance"], 590.0)
 
     np.testing.assert_array_equal(band, np.ones((2, 2), dtype="float32"))
+
+
+def test_summarize_dataset_algorithm_writes_json(tmp_path, monkeypatch):
+    """Summarize Dataset should write a JSON metadata file."""
+    algorithm = SummarizeDatasetAlgorithm()
+    output = tmp_path / "summary.json"
+
+    monkeypatch.setattr(algorithm, "_load_dataset", lambda *args: _loaded_dataset())
+
+    result = algorithm.processAlgorithm(
+        {
+            BaseHyperCoastAlgorithm.INPUT: "generic.nc",
+            BaseHyperCoastAlgorithm.DATA_TYPE: 0,
+            BaseHyperCoastAlgorithm.VARIABLE: "",
+            algorithm.OUTPUT_JSON: str(output),
+        },
+        None,
+        None,
+    )
+
+    assert result[algorithm.OUTPUT_JSON] == str(output)
+    assert '"variables"' in output.read_text(encoding="utf-8")
+
+
+def test_batch_extract_spectra_algorithm_writes_long_csv(tmp_path, monkeypatch):
+    """Batch Extract Spectra should write long-form CSV output."""
+    algorithm = BatchExtractSpectraAlgorithm()
+    points = tmp_path / "points.csv"
+    output = tmp_path / "spectra.csv"
+    points.write_text("x,y\n0,0\n", encoding="utf-8")
+    dataset = _loaded_dataset()
+
+    monkeypatch.setattr(algorithm, "_load_dataset", lambda *args: dataset)
+    monkeypatch.setattr(
+        dataset,
+        "extract_spectral_signature",
+        lambda *args, **kwargs: (
+            np.array([500.0, 600.0]),
+            np.array([0.1, 0.2]),
+        ),
+    )
+
+    result = algorithm.processAlgorithm(
+        {
+            BaseHyperCoastAlgorithm.INPUT: "generic.nc",
+            BaseHyperCoastAlgorithm.DATA_TYPE: 0,
+            BaseHyperCoastAlgorithm.VARIABLE: "",
+            algorithm.POINTS: str(points),
+            algorithm.X_COLUMN: "x",
+            algorithm.Y_COLUMN: "y",
+            algorithm.CRS: "EPSG:4326",
+            algorithm.OUTPUT_CSV: str(output),
+        },
+        None,
+        None,
+    )
+
+    assert result[algorithm.OUTPUT_CSV] == str(output)
+    assert "wavelength,value" in output.read_text(encoding="utf-8")

--- a/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
+++ b/qgis_plugin/qt6_tests/test_tanager_search_dialog.py
@@ -5,11 +5,9 @@ from datetime import datetime
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-import pytest
-from qgis.PyQt.QtWidgets import QApplication, QHeaderView
-
-import hypercoast_qgis.hypercoast_plugin as plugin_module
 import hypercoast_qgis.dialogs.tanager_search_dialog as dialog_module
+import hypercoast_qgis.hypercoast_plugin as plugin_module
+import pytest
 from hypercoast_qgis.dialogs.tanager_search_dialog import (
     TANAGER_HDF5_ASSET,
     TANAGER_VISUAL_ASSET,
@@ -21,6 +19,7 @@ from hypercoast_qgis.dialogs.tanager_search_dialog import (
     _stac_browser_url,
 )
 from hypercoast_qgis.hypercoast_plugin import HyperCoastPlugin
+from qgis.PyQt.QtWidgets import QApplication, QHeaderView
 
 
 @pytest.fixture(scope="module")

--- a/qgis_plugin/qt6_tests/test_workflow_builder_dialog.py
+++ b/qgis_plugin/qt6_tests/test_workflow_builder_dialog.py
@@ -1,0 +1,144 @@
+"""Tests for the Workflow Builder dock."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import hypercoast_qgis.dialogs.workflow_builder_dialog as dialog_module
+import numpy as np
+import pytest
+from hypercoast_qgis.dialogs.workflow_builder_dialog import WorkflowBuilderDialog
+from qgis.PyQt.QtWidgets import QApplication
+
+xr = pytest.importorskip("xarray")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Return a QApplication for widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class _Iface:
+    """Small QGIS iface-like object."""
+
+    def mainWindow(self):
+        """Return no parent window."""
+        return None
+
+
+class _Layer:
+    """Small layer object."""
+
+    def name(self):
+        """Return a display name."""
+        return "Layer One"
+
+
+class _Project:
+    """Small project object."""
+
+    def mapLayer(self, layer_id):
+        """Return a layer for known IDs."""
+        return _Layer() if layer_id == "layer-1" else None
+
+    def addMapLayer(self, layer):
+        """Accept added layers."""
+        self.added_layer = layer
+
+
+class _DatasetWrapper:
+    """Small HyperspectralDataset-like wrapper."""
+
+    def __init__(self):
+        """Initialize the wrapper."""
+        self.dataset = xr.Dataset(
+            {
+                "reflectance": (
+                    ("wavelength", "y", "x"),
+                    np.array(
+                        [
+                            [[0.6, 0.8], [0.4, 0.2]],
+                            [[0.2, 0.2], [0.1, 0.1]],
+                        ],
+                        dtype="float32",
+                    ),
+                )
+            },
+            coords={"wavelength": [560.0, 860.0], "y": [0, 1], "x": [0, 1]},
+        )
+        self.bounds = (0, 0, 2, 2)
+        self.crs = "EPSG:4326"
+        self.selected_variable = None
+
+    def list_data_variables(self):
+        """Return exportable variables."""
+        return ["reflectance"]
+
+    def set_selected_variable(self, variable_name):
+        """Set the selected variable."""
+        self.selected_variable = variable_name
+
+
+class _Plugin:
+    """Small plugin object."""
+
+    def __init__(self):
+        """Initialize the plugin."""
+        self.wrapper = _DatasetWrapper()
+
+    def get_all_hyperspectral_layers(self):
+        """Return layer metadata."""
+        return {"layer-1": {"selected_variable": "reflectance"}}
+
+    def ensure_hyperspectral_dataset(self, layer_id):
+        """Return a dataset wrapper."""
+        return self.wrapper if layer_id == "layer-1" else None
+
+    def get_hyperspectral_data(self, layer_id):
+        """Return layer metadata."""
+        return {"selected_variable": "reflectance"} if layer_id == "layer-1" else None
+
+
+def test_workflow_builder_populates_layers_and_variables(qapp, monkeypatch):
+    """Workflow Builder should list registered layers and variables."""
+    project = _Project()
+    monkeypatch.setattr(dialog_module.QgsProject, "instance", lambda: project)
+
+    dialog = WorkflowBuilderDialog(_Iface(), _Plugin())
+
+    assert dialog.layer_combo.currentData() == "layer-1"
+    assert dialog.layer_combo.currentText() == "Layer One"
+    assert dialog.variable_combo.currentText() == "reflectance"
+
+
+def test_workflow_builder_runs_ndwi(qapp, monkeypatch, tmp_path):
+    """Workflow Builder should run a workflow and write output."""
+    project = _Project()
+    written = {}
+    monkeypatch.setattr(dialog_module.QgsProject, "instance", lambda: project)
+    monkeypatch.setattr(dialog_module, "HAS_RASTERIO", True)
+    monkeypatch.setattr(
+        dialog_module,
+        "QgsRasterLayer",
+        lambda *args, **kwargs: type("Layer", (), {"isValid": lambda self: True})(),
+    )
+
+    dialog = WorkflowBuilderDialog(_Iface(), _Plugin())
+    output = tmp_path / "ndwi.tif"
+    dialog.output_edit.setText(str(output))
+    monkeypatch.setattr(
+        dialog,
+        "_write_workflow_raster",
+        lambda dataset, result, output_path: written.update(
+            {"name": result.name, "output": output_path}
+        ),
+    )
+
+    dialog.run_workflow()
+
+    assert written["name"] == "nd_560_860"
+    assert written["output"] == str(output)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -27,9 +27,11 @@ psutil
 pygments
 pymdown-extensions
 pytest
+pytest-cov
 pytest-runner
 pyvista
 reuse>=5.1.1
+ruff
 scikit-learn
 seaborn
 sphinx

--- a/tests/test_appeears.py
+++ b/tests/test_appeears.py
@@ -9,9 +9,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import hypercoast
 import numpy as np
 import xarray as xr
+
+import hypercoast
 from hypercoast import appeears
 
 

--- a/tests/test_aviris.py
+++ b/tests/test_aviris.py
@@ -1,8 +1,10 @@
-import unittest
-import hypercoast
 import os
+import unittest
+
 import matplotlib
 import pytest
+
+import hypercoast
 
 matplotlib.use("Agg")  # Use the Agg backend to suppress plots
 

--- a/tests/test_cesl.py
+++ b/tests/test_cesl.py
@@ -1,8 +1,8 @@
-import json
 import importlib.util
-from pathlib import Path
+import json
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "hypercoast" / "cesl.py"

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -110,3 +110,83 @@ def test_cli_workflow_runs_on_local_netcdf(tmp_path, capsys):
     assert str(output_path) in output
     result = xr.open_dataarray(output_path)
     assert result.name == "nd_560_860"
+
+
+def test_cli_summarize_and_subset_local_netcdf(tmp_path, capsys):
+    """Summarize and subset should work with local xarray fixtures."""
+    np = pytest.importorskip("numpy")
+    xr = pytest.importorskip("xarray")
+    input_path = tmp_path / "cube.nc"
+    subset_path = tmp_path / "subset.nc"
+    dataset = xr.Dataset(
+        {
+            "reflectance": (
+                ("wavelength", "y", "x"),
+                np.arange(27, dtype="float32").reshape(3, 3, 3),
+            )
+        },
+        coords={
+            "wavelength": [450.0, 550.0, 650.0],
+            "y": [10.0, 11.0, 12.0],
+            "x": [100.0, 101.0, 102.0],
+        },
+    )
+    dataset.to_netcdf(input_path)
+
+    assert cli.main(["summarize", str(input_path), "--json"]) == 0
+    assert (
+        cli.main(
+            [
+                "subset",
+                str(input_path),
+                str(subset_path),
+                "--bbox",
+                "100.5",
+                "10.5",
+                "102",
+                "12",
+            ]
+        )
+        == 0
+    )
+
+    output = capsys.readouterr().out
+    assert '"wavelength_count": 3' in output
+    assert str(subset_path) in output
+    subset = xr.open_dataset(subset_path)
+    assert subset.sizes["x"] == 2
+    assert subset.sizes["y"] == 2
+
+
+def test_cli_spectra_delegates_to_batch_extractor(tmp_path, monkeypatch, capsys):
+    """The spectra command should call the batch extraction helper."""
+    points = tmp_path / "points.csv"
+    output_path = tmp_path / "spectra.csv"
+    points.write_text("x,y\n1,2\n", encoding="utf-8")
+
+    def fake_extract(sensor, input_path, **kwargs):
+        assert sensor == "pace"
+        assert input_path == "cube.nc"
+        assert kwargs["points_csv"] == str(points)
+        assert kwargs["output"] == str(output_path)
+        output_path.write_text("feature_id,wavelength,value\n0,500,0.1\n")
+        return str(output_path)
+
+    monkeypatch.setattr(cli, "extract_spectra_to_csv", fake_extract)
+
+    assert (
+        cli.main(
+            [
+                "spectra",
+                "pace",
+                "cube.nc",
+                "--points",
+                str(points),
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+
+    assert str(output_path) in capsys.readouterr().out

--- a/tests/test_emit.py
+++ b/tests/test_emit.py
@@ -1,7 +1,9 @@
-import unittest
-import hypercoast
 import os
+import unittest
+
 import pytest
+
+import hypercoast
 
 
 class TestHypercoastEmit(unittest.TestCase):

--- a/tests/test_hypercoast.py
+++ b/tests/test_hypercoast.py
@@ -6,9 +6,10 @@ import sys
 import types
 import unittest
 
-import hypercoast
 import numpy as np
 import pytest
+
+import hypercoast
 
 
 class TestHypercoast(unittest.TestCase):

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for optional ML helpers."""
+
+import pytest
+
+from hypercoast import ml
+
+
+def test_list_models_includes_moe_vae():
+    """ML metadata should advertise the optional MoE/VAE family."""
+    models = ml.list_models()
+
+    assert models["moe_vae"]["required_extra"] == "ml"
+
+
+def test_require_ml_dependencies_reports_missing_torch(monkeypatch):
+    """Missing optional ML dependencies should raise an actionable error."""
+    monkeypatch.setattr(ml, "find_spec", lambda name: None)
+
+    with pytest.raises(ImportError, match="ml"):
+        ml.require_ml_dependencies()

--- a/tests/test_neon.py
+++ b/tests/test_neon.py
@@ -1,7 +1,9 @@
-import unittest
-import hypercoast
 import os
+import unittest
+
 import pytest
+
+import hypercoast
 
 
 class TestHypercoastNeon(unittest.TestCase):

--- a/tests/test_pace.py
+++ b/tests/test_pace.py
@@ -1,8 +1,10 @@
-import unittest
-import hypercoast
 import os
+import unittest
+
 import matplotlib
 import pytest
+
+import hypercoast
 
 matplotlib.use("Agg")  # Use the Agg backend to suppress plots
 

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2024 Qiusheng Wu <giswqs@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for dataset summary helpers."""
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from hypercoast.summary import (
+    extract_spectra_to_csv,
+    subset_dataset,
+    summarize_dataset,
+)
+
+
+def _dataset():
+    """Return a small rectilinear hyperspectral dataset."""
+    return xr.Dataset(
+        {
+            "reflectance": (
+                ("wavelength", "y", "x"),
+                np.arange(27, dtype="float32").reshape(3, 3, 3),
+            )
+        },
+        coords={
+            "wavelength": [450.0, 550.0, 650.0],
+            "y": [10.0, 11.0, 12.0],
+            "x": [100.0, 101.0, 102.0],
+        },
+        attrs={"crs": "EPSG:4326"},
+    )
+
+
+def test_summarize_dataset_reports_core_metadata(tmp_path):
+    """Dataset summaries should include variables, dimensions, and wavelengths."""
+    path = tmp_path / "cube.nc"
+    _dataset().to_netcdf(path)
+
+    summary = summarize_dataset(path, variable="reflectance")
+
+    assert summary.exists is True
+    assert summary.variables == ["reflectance"]
+    assert summary.selected_variable == "reflectance"
+    assert summary.crs == "EPSG:4326"
+    assert summary.wavelength_count == 3
+    assert summary.wavelength_min == 450.0
+    assert summary.wavelength_max == 650.0
+    assert summary.as_dict()["dimensions"]["x"] == 3
+
+
+def test_summarize_dataset_missing_file_returns_warning(tmp_path):
+    """Missing paths should return a warning instead of raising."""
+    summary = summarize_dataset(tmp_path / "missing.nc")
+
+    assert summary.exists is False
+    assert summary.warnings
+
+
+def test_summarize_dataset_rejects_unknown_sensor(tmp_path):
+    """Unknown sensors should still raise registry lookup errors."""
+    path = tmp_path / "cube.nc"
+    _dataset().to_netcdf(path)
+
+    with pytest.raises(KeyError):
+        summarize_dataset(path, sensor="unknown")
+
+
+def test_subset_dataset_writes_bbox_subset(tmp_path):
+    """Subset helper should write a NetCDF clipped by x/y coordinates."""
+    input_path = tmp_path / "cube.nc"
+    output_path = tmp_path / "subset.nc"
+    _dataset().to_netcdf(input_path)
+
+    subset_dataset(input_path, output_path, bbox=(100.5, 10.5, 102.0, 12.0))
+    subset = xr.open_dataset(output_path)
+
+    assert subset.sizes["x"] == 2
+    assert subset.sizes["y"] == 2
+
+
+def test_extract_spectra_to_csv_writes_long_form_rows(tmp_path, monkeypatch):
+    """Batch spectral extraction should write one row per wavelength."""
+    import hypercoast.registry as registry
+    import hypercoast.summary as summary_module
+
+    points = tmp_path / "points.csv"
+    output = tmp_path / "spectra.csv"
+    pd.DataFrame({"x": [1.0], "y": [2.0]}).to_csv(points, index=False)
+    dataset = xr.Dataset()
+    spectrum = xr.DataArray(
+        np.array([0.1, 0.2]),
+        dims=("wavelength",),
+        coords={"wavelength": [500.0, 600.0]},
+        name="reflectance",
+    )
+
+    monkeypatch.setattr(summary_module, "read_sensor", lambda *args, **kwargs: dataset)
+    monkeypatch.setattr(registry, "extract_sensor", lambda *args, **kwargs: spectrum)
+
+    extract_spectra_to_csv("pace", "cube.nc", points, output)
+    rows = pd.read_csv(output)
+
+    assert list(rows["wavelength"]) == [500.0, 600.0]
+    assert list(rows["value"]) == [0.1, 0.2]
+    assert rows.loc[0, "variable"] == "reflectance"


### PR DESCRIPTION
## Summary
- Restructure optional dependencies into focused extras (`core`, `viz`, `cloud`, `qgis`, `ml`, `docs`) for lighter, more targeted installs
- Add new `ml` and `summary` modules with CLI integration, plus corresponding docs and tests
- Expand QGIS plugin with workflow builder dialog, additional processing provider algorithms, and improved provider detection
- Add ruff configuration with import sorting, update CI workflows for the new dependency structure

## Test plan
- [ ] Verify `pip install HyperCoast[viz]`, `HyperCoast[cloud]`, `HyperCoast[ml]` each install only the intended subset
- [ ] Run `hypercoast summary` and `hypercoast ml` CLI commands
- [ ] Run full test suite with `pytest tests/`
- [ ] Verify QGIS plugin loads and workflow builder dialog opens
- [ ] Confirm `pre-commit run --all-files` passes cleanly