### PR TITLE
Bump version to 0.27.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.26.0 - Current
+## v0.27.0 - Current
 
 **What's Changed**
 

--- a/hypercoast/__init__.py
+++ b/hypercoast/__init__.py
@@ -6,7 +6,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.26.0"
+__version__ = "0.27.0"
 
 
 from . import ml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "HyperCoast"
-version = "0.26.0"
+version = "0.27.0"
 dynamic = [
     "dependencies",
 ]
@@ -100,7 +100,7 @@ exclude = ["docs*"]
 dependencies = {file = ["requirements.txt"]}
 
 [tool.bumpversion]
-current_version = "0.26.0"
+current_version = "0.27.0"
 commit = true
 tag = true
 

--- a/qgis_plugin/hypercoast_qgis/metadata.txt
+++ b/qgis_plugin/hypercoast_qgis/metadata.txt
@@ -5,7 +5,7 @@ name=HyperCoast
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Visualize, search, and analyze hyperspectral data including EMIT, PACE, DESIS, NEON, AVIRIS, PRISMA, EnMAP, Tanager, and Wyvern datasets
-version=0.26.0
+version=0.27.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -32,6 +32,8 @@ deprecated=False
 hasProcessingProvider=yes
 
 changelog=
+    0.27.0
+        - Bump package and QGIS plugin minor version
     0.26.0
         - Bump package and QGIS plugin minor version
     0.25.0


### PR DESCRIPTION
## Summary

- bump Python package version to 0.27.0
- bump QGIS plugin metadata version to 0.27.0
- update the current changelog heading and plugin changelog

## Testing

- python -c "import hypercoast; print(hypercoast.__version__)"
- pytest qgis_plugin/qt6_tests/test_metadata_docs.py qgis_plugin/qt6_tests/test_install_plugin_packaging.py
- pre-commit run --all-files
