### PR TITLE
Make QGIS plugin registry-driven to support all HyperCoast formats

### DIFF
--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -1612,7 +1612,10 @@ class HyperspectralDataset:
                 # sensor (DESIS, NEON, Tanager, AVIRIS, PRISMA, EnMAP, Wyvern,
                 # and any future addition to the hypercoast registry).
                 image = hypercoast.sensor_to_image(
-                    self.data_type, self.dataset, wavelengths=wavelengths
+                    self.data_type,
+                    self.dataset,
+                    wavelengths=wavelengths,
+                    method="nearest",
                 )
 
             else:

--- a/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
+++ b/qgis_plugin/hypercoast_qgis/hyperspectral_provider.py
@@ -156,6 +156,24 @@ def _registry_data_types():
 DATA_TYPES = _registry_data_types()
 
 
+def _reader_data_types():
+    """Return reader-backed data types (every type except ``Generic``).
+
+    These are the sensors dispatched to the hypercoast library readers. The
+    list is derived from :data:`DATA_TYPES`, which is itself sourced from the
+    hypercoast registry when available, so new sensors added to the library are
+    picked up automatically.
+
+    Returns:
+        list[str]: Sensor data-type keys backed by a hypercoast reader.
+    """
+    return [name for name in DATA_TYPES if name != "Generic"]
+
+
+# Sensor data types backed by a hypercoast reader (excludes ``Generic``).
+READER_DATA_TYPES = _reader_data_types()
+
+
 PACE_BGC_VARIABLES = [
     "chlor_a",
     "carbon_phyto",
@@ -191,7 +209,7 @@ class HyperspectralDataset:
 
     def _detect_type(self):
         """Auto-detect the data type based on file extension and content."""
-        return detect_data_type(self.filepath, self._is_tanager_hdf5_file)
+        return detect_data_type(self.filepath, self._is_tanager_hdf5_file, DATA_TYPES)
 
     def _is_tanager_hdf5_file(self):
         """Return whether an HDF5 file looks like a Tanager product.
@@ -293,47 +311,15 @@ class HyperspectralDataset:
                 f"Trying hypercoast loader: type={self.data_type}, file={self.filepath}",
                 LOG_INFO,
             )
-            if self.data_type == "EMIT":
-                self.dataset = hypercoast.read_emit(self.filepath)
-                self._extract_emit_metadata()
-
-            elif self.data_type == "PACE":
-                self.dataset = hypercoast.read_pace(self.filepath)
-                self._is_swath = True
-                if not self._extract_pace_metadata():
-                    return False
-
-            elif self.data_type == "DESIS":
-                self.dataset = hypercoast.read_desis(self.filepath)
-                self._extract_desis_metadata()
-
-            elif self.data_type == "NEON":
-                self.dataset = hypercoast.read_neon(self.filepath)
-                self._extract_neon_metadata()
-
-            elif self.data_type == "AVIRIS":
-                self.dataset = hypercoast.read_aviris(self.filepath)
-                self._extract_generic_metadata()
-
-            elif self.data_type == "PRISMA":
-                self.dataset = hypercoast.read_prisma(self.filepath)
-                self._extract_generic_metadata()
-
-            elif self.data_type == "EnMAP":
-                self.dataset = hypercoast.read_enmap(self.filepath)
-                self._extract_generic_metadata()
-
-            elif self.data_type == "Tanager":
-                self.dataset = hypercoast.read_tanager(self.filepath)
-                if not self._extract_tanager_metadata():
-                    return False
-
-            elif self.data_type == "Wyvern":
-                self.dataset = hypercoast.read_wyvern(self.filepath)
-                self._extract_generic_metadata()
-
-            else:
+            if self.data_type == "Generic":
                 return self._load_generic()
+
+            # Registry-driven dispatch: every sensor registered in the
+            # hypercoast library (current or future) is read through the
+            # shared ``read_sensor`` entry point, so the plugin automatically
+            # supports every hyperspectral format the library supports without
+            # a per-sensor branch here.
+            self.dataset = hypercoast.read_sensor(self.data_type, self.filepath)
 
             # Guard against readers that return None instead of raising
             if self.dataset is None:
@@ -342,6 +328,9 @@ class HyperspectralDataset:
                     LOG_WARNING,
                 )
                 return self._load_generic()
+
+            if not self._extract_metadata():
+                return False
 
             _log(
                 f"Hypercoast loader succeeded: type={self.data_type}",
@@ -384,19 +373,7 @@ class HyperspectralDataset:
         """
         from .core.venv_manager import run_in_venv
 
-        reader_map = {
-            "EMIT": "read_emit",
-            "PACE": "read_pace",
-            "DESIS": "read_desis",
-            "NEON": "read_neon",
-            "AVIRIS": "read_aviris",
-            "PRISMA": "read_prisma",
-            "EnMAP": "read_enmap",
-            "Tanager": "read_tanager",
-            "Wyvern": "read_wyvern",
-        }
-        reader_fn = reader_map.get(self.data_type)
-        if reader_fn is None:
+        if not self._is_reader_data_type():
             return False
 
         import tempfile
@@ -413,7 +390,7 @@ class HyperspectralDataset:
 
         script = (
             "import hypercoast, sys\n"
-            f"ds = hypercoast.{reader_fn}(r'{fp}')\n"
+            f"ds = hypercoast.read_sensor({self.data_type!r}, r'{fp}')\n"
             "if ds is None:\n"
             "    sys.exit(1)\n"
             "ds.load()\n"
@@ -421,7 +398,7 @@ class HyperspectralDataset:
         )
 
         _log(
-            f"Running hypercoast.{reader_fn} in venv subprocess",
+            f"Running hypercoast reader for {self.data_type} in venv subprocess",
             LOG_INFO,
         )
         rc, stdout, stderr = run_in_venv(script, timeout=120)
@@ -438,17 +415,8 @@ class HyperspectralDataset:
             # Load into memory so the file handle is released before cleanup
             with xr.open_dataset(tmp_nc) as ds:
                 self.dataset = ds.load()
-            # Extract metadata using the same helpers as _load_with_hypercoast
-            extractor = {
-                "EMIT": self._extract_emit_metadata,
-                "PACE": self._extract_pace_metadata,
-                "DESIS": self._extract_desis_metadata,
-                "NEON": self._extract_neon_metadata,
-                "Tanager": self._extract_tanager_metadata,
-            }.get(self.data_type, self._extract_generic_metadata)
-            if self.data_type == "PACE":
-                self._is_swath = True
-            extractor()
+            # Extract metadata using the same helper as _load_with_hypercoast
+            self._extract_metadata()
             _log(
                 f"Subprocess load succeeded: type={self.data_type}",
                 LOG_INFO,
@@ -471,26 +439,7 @@ class HyperspectralDataset:
         """
         from .core.venv_manager import run_in_venv
 
-        fn_map = {
-            "EMIT": "emit_to_image",
-            "PACE": "pace_to_image",
-            "DESIS": "desis_to_image",
-            "NEON": "neon_to_image",
-            "Tanager": "tanager_to_image",
-        }
-        to_image_fn = fn_map.get(self.data_type)
-        if to_image_fn is None:
-            return None
-
-        reader_map = {
-            "EMIT": "read_emit",
-            "PACE": "read_pace",
-            "DESIS": "read_desis",
-            "NEON": "read_neon",
-            "Tanager": "read_tanager",
-        }
-        reader_fn = reader_map.get(self.data_type)
-        if reader_fn is None:
+        if not self._is_reader_data_type():
             return None
 
         if wavelengths is None:
@@ -499,21 +448,19 @@ class HyperspectralDataset:
         fp = self.filepath.replace("\\", "\\\\")
         op = output_path.replace("\\", "\\\\")
 
-        extra_args = ""
-        if self.data_type == "PACE":
-            extra_args = ", method='nearest'"
-
+        # Registry-driven read + image conversion so every reader-backed sensor
+        # can be exported in the subprocess, not just a hardcoded subset.
         script = (
             "import hypercoast, sys\n"
             "from leafmap import image_to_geotiff\n"
-            f"ds = hypercoast.{reader_fn}(r'{fp}')\n"
+            f"ds = hypercoast.read_sensor({self.data_type!r}, r'{fp}')\n"
             "if ds is None:\n"
             "    sys.exit(1)\n"
             "if 'wavelength' not in ds.dims and 'wavelength' not in ds.coords:\n"
             "    print('NO_WAVELENGTH_DIM', file=sys.stderr)\n"
             "    sys.exit(2)\n"
-            f"image = hypercoast.{to_image_fn}(ds, wavelengths={wavelengths!r}"
-            f"{extra_args})\n"
+            f"image = hypercoast.sensor_to_image({self.data_type!r}, ds, "
+            f"wavelengths={wavelengths!r}, method='nearest')\n"
             f"image_to_geotiff(image, r'{op}', dtype='float32')\n"
         )
 
@@ -562,29 +509,8 @@ class HyperspectralDataset:
         """
         from .core.venv_manager import run_in_venv
 
-        reader_map = {
-            "EMIT": "read_emit",
-            "PACE": "read_pace",
-            "DESIS": "read_desis",
-            "NEON": "read_neon",
-            "AVIRIS": "read_aviris",
-            "PRISMA": "read_prisma",
-            "EnMAP": "read_enmap",
-            "Tanager": "read_tanager",
-            "Wyvern": "read_wyvern",
-        }
-        reader_fn = reader_map.get(self.data_type)
-        if reader_fn is None:
+        if not self._is_reader_data_type():
             return None
-
-        fn_map = {
-            "EMIT": "emit_to_image",
-            "PACE": "pace_to_image",
-            "DESIS": "desis_to_image",
-            "NEON": "neon_to_image",
-            "Tanager": "tanager_to_image",
-        }
-        to_image_fn = fn_map.get(self.data_type)
 
         if wavelengths is None:
             wavelengths = [650, 550, 450]
@@ -598,24 +524,19 @@ class HyperspectralDataset:
         op = output_path.replace("\\", "\\\\")
         nc = tmp_nc.replace("\\", "\\\\")
 
-        extra_args = ""
-        if self.data_type == "PACE":
-            extra_args = ", method='nearest'"
-
-        # Build optional export block
-        export_block = ""
-        if to_image_fn:
-            export_block = (
-                "if 'wavelength' in ds.dims or 'wavelength' in ds.coords:\n"
-                f"    image = hypercoast.{to_image_fn}(ds, wavelengths={wavelengths!r}"
-                f"{extra_args})\n"
-                f"    image_to_geotiff(image, r'{op}', dtype='float32')\n"
-            )
+        # Export only when the dataset has a spectral dimension; registry-driven
+        # conversion handles every reader-backed sensor uniformly.
+        export_block = (
+            "if 'wavelength' in ds.dims or 'wavelength' in ds.coords:\n"
+            f"    image = hypercoast.sensor_to_image({self.data_type!r}, ds, "
+            f"wavelengths={wavelengths!r}, method='nearest')\n"
+            f"    image_to_geotiff(image, r'{op}', dtype='float32')\n"
+        )
 
         script = (
             "import hypercoast, sys\n"
             "from leafmap import image_to_geotiff\n"
-            f"ds = hypercoast.{reader_fn}(r'{fp}')\n"
+            f"ds = hypercoast.read_sensor({self.data_type!r}, r'{fp}')\n"
             "if ds is None:\n"
             "    sys.exit(1)\n" + export_block + "ds.load()\n"
             f"ds.to_netcdf(r'{nc}')\n"
@@ -640,16 +561,7 @@ class HyperspectralDataset:
             with xr.open_dataset(tmp_nc) as ds:
                 self.dataset = ds.load()
 
-            extractor = {
-                "EMIT": self._extract_emit_metadata,
-                "PACE": self._extract_pace_metadata,
-                "DESIS": self._extract_desis_metadata,
-                "NEON": self._extract_neon_metadata,
-                "Tanager": self._extract_tanager_metadata,
-            }.get(self.data_type, self._extract_generic_metadata)
-            if self.data_type == "PACE":
-                self._is_swath = True
-            extractor()
+            self._extract_metadata()
 
             if os.path.isfile(output_path):
                 _log(f"Combined load+export succeeded: {output_path}", LOG_INFO)
@@ -718,6 +630,39 @@ class HyperspectralDataset:
             if not self.load():
                 return None
         return self.export_to_geotiff(output_path, wavelengths, bands)
+
+    def _is_reader_data_type(self):
+        """Return whether the data type is backed by a hypercoast reader.
+
+        Returns:
+            True when ``self.data_type`` is a registry sensor (not ``Generic``).
+        """
+        return self.data_type != "Generic" and self.data_type in DATA_TYPES
+
+    def _extract_metadata(self):
+        """Populate metadata from ``self.dataset`` using a per-sensor extractor.
+
+        Sensors with bespoke geolocation handling keep their tuned extractors;
+        any other (including newly registered) sensor falls back to the generic
+        extractor. This keeps the loader registry-driven while preserving the
+        well-tested behavior of the established sensors.
+
+        Returns:
+            bool: ``True`` on success. Extractors that can detect an empty or
+            invalid dataset return ``False``, which is propagated here.
+        """
+        extractor = {
+            "EMIT": self._extract_emit_metadata,
+            "PACE": self._extract_pace_metadata,
+            "DESIS": self._extract_desis_metadata,
+            "NEON": self._extract_neon_metadata,
+            "Tanager": self._extract_tanager_metadata,
+        }.get(self.data_type, self._extract_generic_metadata)
+
+        if self.data_type == "PACE":
+            self._is_swath = True
+
+        return extractor() is not False
 
     def _extract_emit_metadata(self):
         """Extract metadata from EMIT dataset."""
@@ -1475,33 +1420,22 @@ class HyperspectralDataset:
                 )
                 return self._filter_good_wavelengths(self.wavelengths, values)
 
-            elif self.data_type == "PACE":
-                da = hypercoast.extract_pace(self.dataset, lat, lon)
+            # Registry-driven extraction for any reader-backed sensor with a
+            # registered extractor (PACE, DESIS, NEON, and future additions).
+            if self._is_reader_data_type():
+                da = hypercoast.extract_sensor(self.data_type, self.dataset, lat, lon)
                 return self._filter_good_wavelengths(
                     da.coords["wavelength"].values, da.values
                 )
 
-            elif self.data_type == "DESIS":
-                da = hypercoast.extract_desis(self.dataset, lat, lon)
-                return self._filter_good_wavelengths(
-                    da.coords["wavelength"].values, da.values
-                )
-
-            elif self.data_type == "NEON":
-                da = hypercoast.extract_neon(self.dataset, lat, lon)
-                return self._filter_good_wavelengths(
-                    da.coords["wavelength"].values, da.values
-                )
-
+            data_var = self.get_data_variable()
+            if "y" in data_var.dims and "x" in data_var.dims:
+                values = data_var.sel(y=lat, x=lon, method="nearest").values
             else:
-                data_var = self.get_data_variable()
-                if "y" in data_var.dims and "x" in data_var.dims:
-                    values = data_var.sel(y=lat, x=lon, method="nearest").values
-                else:
-                    values = data_var.sel(
-                        latitude=lat, longitude=lon, method="nearest"
-                    ).values
-                return self._filter_good_wavelengths(self.wavelengths, values)
+                values = data_var.sel(
+                    latitude=lat, longitude=lon, method="nearest"
+                ).values
+            return self._filter_good_wavelengths(self.wavelengths, values)
 
         except Exception as e:
             _log(f"Error in hypercoast extraction: {e}", LOG_WARNING)
@@ -1673,15 +1607,12 @@ class HyperspectralDataset:
                     self.dataset, wavelengths=wavelengths, method="nearest"
                 )
 
-            elif self.data_type == "DESIS":
-                image = hypercoast.desis_to_image(self.dataset, wavelengths=wavelengths)
-
-            elif self.data_type == "NEON":
-                image = hypercoast.neon_to_image(self.dataset, wavelengths=wavelengths)
-
-            elif self.data_type == "Tanager":
-                image = hypercoast.tanager_to_image(
-                    self.dataset, wavelengths=wavelengths
+            elif self._is_reader_data_type():
+                # Registry-driven conversion for every other reader-backed
+                # sensor (DESIS, NEON, Tanager, AVIRIS, PRISMA, EnMAP, Wyvern,
+                # and any future addition to the hypercoast registry).
+                image = hypercoast.sensor_to_image(
+                    self.data_type, self.dataset, wavelengths=wavelengths
                 )
 
             else:

--- a/qgis_plugin/hypercoast_qgis/provider/detection.py
+++ b/qgis_plugin/hypercoast_qgis/provider/detection.py
@@ -8,13 +8,82 @@ SPDX-License-Identifier: MIT
 
 import os
 
+# Filename tokens that map to a data type but are not simply the sensor's own
+# name. The sensor name itself is always matched automatically, so only the
+# non-obvious aliases need to be listed here.
+EXTRA_NAME_TOKENS = {
+    "PACE": ("OCI",),
+    "PRISMA": ("PRS",),
+    "Tanager": (
+        "ORTHO_RADIANCE_HDF5",
+        "BASIC_RADIANCE_HDF5",
+        "ORTHO_SR_HDF5",
+        "BASIC_SR_HDF5",
+    ),
+}
 
-def detect_data_type(filepath, tanager_hdf5_checker=None):
+# Preferred detection order for the built-in sensors so that more specific
+# tokens are matched first. Any additional sensor supplied through ``data_types``
+# (for example a newly registered hypercoast sensor) is appended after these.
+DEFAULT_DETECTION_ORDER = (
+    "EMIT",
+    "PACE",
+    "DESIS",
+    "NEON",
+    "AVIRIS",
+    "PRISMA",
+    "EnMAP",
+    "Tanager",
+    "Wyvern",
+)
+
+
+def _detection_order(data_types):
+    """Return the data types to test, in detection order.
+
+    Args:
+        data_types: Optional iterable of available data-type keys (for example
+            the keys of the provider ``DATA_TYPES`` table, which is sourced from
+            the hypercoast registry). When ``None``, the built-in order is used.
+
+    Returns:
+        list[str]: Data-type names to check, excluding ``Generic``.
+    """
+    if not data_types:
+        return list(DEFAULT_DETECTION_ORDER)
+
+    available = [name for name in data_types if name != "Generic"]
+    ordered = [name for name in DEFAULT_DETECTION_ORDER if name in available]
+    extra = sorted(name for name in available if name not in DEFAULT_DETECTION_ORDER)
+    return ordered + extra
+
+
+def _tokens_for(data_type):
+    """Return the uppercase filename tokens that identify a data type.
+
+    Args:
+        data_type: Sensor data-type key (for example ``"EnMAP"``).
+
+    Returns:
+        list[str]: Uppercase substrings that indicate the data type.
+    """
+    tokens = [data_type.upper()]
+    tokens.extend(EXTRA_NAME_TOKENS.get(data_type, ()))
+    return tokens
+
+
+def detect_data_type(filepath, tanager_hdf5_checker=None, data_types=None):
     """Detect a supported HyperCoast data type from a file path.
+
+    Detection is registry-driven: any sensor present in ``data_types`` (which the
+    provider sources from the hypercoast registry) is matched by its name, so new
+    sensors added to the library are detected without changing this function.
 
     Args:
         filepath: Input file path.
         tanager_hdf5_checker: Optional callable used to inspect HDF5 content.
+        data_types: Optional iterable of available data-type keys. When ``None``,
+            the built-in sensor set is used.
 
     Returns:
         Detected data type name.
@@ -22,31 +91,13 @@ def detect_data_type(filepath, tanager_hdf5_checker=None):
     _, ext = os.path.splitext(str(filepath).lower())
     filename = os.path.basename(str(filepath)).upper()
 
-    if "EMIT" in filename:
-        return "EMIT"
-    if "PACE" in filename or "OCI" in filename:
-        return "PACE"
-    if "DESIS" in filename:
-        return "DESIS"
-    if "NEON" in filename:
-        return "NEON"
-    if "AVIRIS" in filename:
-        return "AVIRIS"
-    if "PRISMA" in filename or "PRS" in filename:
-        return "PRISMA"
-    if "ENMAP" in filename:
-        return "EnMAP"
-    if (
-        "TANAGER" in filename
-        or "ORTHO_RADIANCE_HDF5" in filename
-        or "BASIC_RADIANCE_HDF5" in filename
-        or "ORTHO_SR_HDF5" in filename
-        or "BASIC_SR_HDF5" in filename
-    ):
-        return "Tanager"
-    if "WYVERN" in filename:
-        return "Wyvern"
+    for data_type in _detection_order(data_types):
+        tokens = _tokens_for(data_type)
+        if any(token in filename for token in tokens):
+            return data_type
+
     if ext in [".h5", ".hdf5"] and callable(tanager_hdf5_checker):
         if tanager_hdf5_checker():
             return "Tanager"
+
     return "Generic"

--- a/qgis_plugin/qt6_tests/test_hyperspectral_provider.py
+++ b/qgis_plugin/qt6_tests/test_hyperspectral_provider.py
@@ -5,13 +5,119 @@ import pytest
 
 xr = pytest.importorskip("xarray")
 
-from hypercoast_qgis.hyperspectral_provider import DATA_TYPES, HyperspectralDataset
+from hypercoast_qgis.hyperspectral_provider import (
+    DATA_TYPES,
+    READER_DATA_TYPES,
+    HyperspectralDataset,
+)
+from hypercoast_qgis.provider.detection import detect_data_type
+
+
+def _spectral_dataset(variable="reflectance"):
+    """Return a minimal spectral xarray dataset for loader/export tests."""
+    return xr.Dataset(
+        {
+            variable: (
+                ("wavelength", "y", "x"),
+                np.ones((2, 2, 2), dtype="float32"),
+            )
+        },
+        coords={"wavelength": np.array([500.0, 600.0])},
+    )
 
 
 def test_data_types_include_registry_metadata():
     """QGIS data types should expose registry defaults when available."""
     assert DATA_TYPES["PACE"]["variable"] == "Rrs"
     assert DATA_TYPES["Wyvern"]["default_rgb"] == [799, 679, 570]
+
+
+def test_reader_data_types_exclude_generic():
+    """Reader-backed data types should cover sensors but not the fallback."""
+    assert "Generic" not in READER_DATA_TYPES
+    assert "EMIT" in READER_DATA_TYPES
+    assert "Wyvern" in READER_DATA_TYPES
+
+
+def test_detect_data_type_matches_registry_sensor_by_name():
+    """A newly registered sensor should auto-detect from its name alone."""
+    data_types = {"EMIT": {}, "PACE": {}, "HYPERION": {}, "Generic": {}}
+
+    assert detect_data_type("scene_HYPERION_001.tif", data_types=data_types) == (
+        "HYPERION"
+    )
+    # Established alias tokens still resolve to their sensor.
+    assert detect_data_type("PACE_OCI_2024.nc", data_types=data_types) == "PACE"
+    assert detect_data_type("random_scene.tif", data_types=data_types) == "Generic"
+
+
+def test_load_with_hypercoast_dispatches_through_read_sensor(monkeypatch):
+    """Loading should route every sensor through the registry read_sensor."""
+    import hypercoast_qgis.hyperspectral_provider as provider_module
+
+    calls = {}
+
+    class _HyperCoast:
+        """Fake HyperCoast module recording the requested sensor."""
+
+        def read_sensor(self, sensor, source, **kwargs):
+            """Record the sensor name and return a spectral dataset."""
+            calls["sensor"] = sensor
+            calls["source"] = source
+            return _spectral_dataset()
+
+    monkeypatch.setattr(provider_module, "HAS_HYPERCOAST", True)
+    monkeypatch.setattr(provider_module, "hypercoast", _HyperCoast(), raising=False)
+
+    provider = HyperspectralDataset("AVIRIS_scene.nc", "AVIRIS")
+
+    assert provider.load() is True
+    assert calls["sensor"] == "AVIRIS"
+    assert provider.dataset is not None
+
+
+def test_export_with_hypercoast_dispatches_through_sensor_to_image(
+    tmp_path, monkeypatch
+):
+    """Export should route reader-backed sensors through sensor_to_image."""
+    import hypercoast_qgis.hyperspectral_provider as provider_module
+    import leafmap
+
+    calls = {}
+
+    class _HyperCoast:
+        """Fake HyperCoast module recording the converted sensor."""
+
+        def sensor_to_image(self, sensor, data, **kwargs):
+            """Record the sensor name and return a placeholder image."""
+            calls["sensor"] = sensor
+            return "IMAGE"
+
+    def _fake_write(image, output, dtype=None):
+        """Write a placeholder GeoTIFF so the export path can succeed."""
+        with open(output, "wb") as handle:
+            handle.write(b"fake geotiff")
+
+    monkeypatch.setattr(provider_module, "HAS_HYPERCOAST", True)
+    monkeypatch.setattr(provider_module, "hypercoast", _HyperCoast(), raising=False)
+    monkeypatch.setattr(leafmap, "image_to_geotiff", _fake_write)
+
+    provider = HyperspectralDataset("WYVERN_scene.tif", "Wyvern")
+    provider.dataset = _spectral_dataset()
+    output_path = tmp_path / "wyvern.tif"
+
+    result = provider._export_with_hypercoast(str(output_path), [650, 550, 450])
+
+    assert result == str(output_path)
+    assert calls["sensor"] == "Wyvern"
+
+
+def test_extract_metadata_returns_false_for_empty_pace():
+    """Empty PACE datasets should fail metadata extraction."""
+    provider = HyperspectralDataset("PACE_OCI_test.nc", "PACE")
+    provider.dataset = xr.Dataset()
+
+    assert provider._extract_metadata() is False
 
 
 def test_tanager_hdf5_asset_filename_auto_detects_tanager():


### PR DESCRIPTION
## Summary

The QGIS plugin previously hardcoded its hyperspectral-format support in several parallel `if/elif` chains (load, export, spectral extraction, and the Windows venv subprocess), plus a hardcoded filename-detection table. Adding a new sensor to the `hypercoast` library did **not** make it loadable in the plugin — every dispatch site had to be edited by hand.

This PR makes the plugin **registry-driven** so it automatically supports every hyperspectral format the library exposes to QGIS (and any sensor added in the future), using the library's shared registry entry points.

## Changes

- **Load dispatch** (`_load_with_hypercoast`, `_load_via_subprocess`, `_load_and_export_via_subprocess`): use `hypercoast.read_sensor(data_type, path)` instead of per-sensor `read_*` branches.
- **Export dispatch** (`_export_with_hypercoast`, `_export_via_subprocess`): use `hypercoast.sensor_to_image(data_type, ds, ...)`. The subprocess export now covers every reader-backed sensor instead of a hardcoded subset.
- **Spectral extraction** (`_extract_with_hypercoast`): use `hypercoast.extract_sensor(...)` for sensors with a registered extractor; EMIT keeps its bespoke path.
- **Metadata extraction**: consolidated into a single `_extract_metadata` helper (previously duplicated in three places), preserving the tuned EMIT/PACE/DESIS/NEON/Tanager behavior and swath flags, with a generic fallback for everything else.
- **Detection** (`provider/detection.py`): now derives match tokens from the `DATA_TYPES` table (sourced from the registry), so new sensors are detected by name automatically. Established alias tokens (OCI→PACE, PRS→PRISMA, Tanager HDF5 asset names) and HDF5-content detection are preserved.
- Added `READER_DATA_TYPES` and an `_is_reader_data_type` helper as the single source of truth for reader-backed sensors.

## Testing

- `pre-commit run --all-files` (black, ruff, codespell, reuse, bandit) — passing.
- `pytest qt6_tests/` — 98 passed (5 new tests for registry-driven detection, load, export, and metadata handling).

Net result: the same 9 reader-backed sensors work as before, the dispatch logic is ~200 lines smaller, and future library sensors are supported with zero plugin changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved automatic sensor type detection using token-based matching and a configurable detection order.
  * Streamlined hyperspectral loading, metadata extraction, spectral extraction, and export through unified reader-backed workflows (with safer fallback to generic handling).
  * Windows processing paths were updated to use the same unified reader/image conversion approach.

* **Bug Fixes**
  * Better handling of empty PACE datasets during metadata extraction.

* **Tests**
  * Expanded unit tests covering reader-backed routing, detection aliases, exports, and metadata behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->